### PR TITLE
Add Agent365ToolsServicePrincipalProdPublic script

### DIFF
--- a/scripts/cli/Auth/New-Agent365ToolsServicePrincipalProdPublic.ps1
+++ b/scripts/cli/Auth/New-Agent365ToolsServicePrincipalProdPublic.ps1
@@ -132,7 +132,7 @@ catch {
         Write-Host "  - AppRoleAssignment.ReadWrite.All" -ForegroundColor White
         Write-Host "  - Or Global Administrator / Application Administrator role" -ForegroundColor White
         Write-Host ""
-        Write-Host "Please contact your Azure AD administrator to run this script." -ForegroundColor Yellow
+        Write-Host "Please contact your Microsoft Entra ID administrator to run this script." -ForegroundColor Yellow
     }
     
     Disconnect-MgGraph | Out-Null


### PR DESCRIPTION
DESCRIPTION
This script creates the Service Principal for Agent 365 Tools in your Azure AD tenant. This is a ONE-TIME operation per tenant that requires admin permissions.
    
After the Service Principal is created, regular users can create their own app registrations without needing admin rights.

This script needs to be accessible 
& needs to be referenced before developing an agent in a tenant in Learn doc

Source: https://github.com/bap-microsoft/MCP-Platform/pull/530/files