### PR TITLE
Refactor SetupCommand to use GraphTokenScopeException

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ErrorCodes.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ErrorCodes.cs
@@ -10,5 +10,6 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Constants
         public const string DeploymentAppCompileFailed = "DEPLOYMENT_APP_COMPILE_FAILED";
         public const string DeploymentScopesFailed = "DEPLOYMENT_SCOPES_FAILED";
         public const string DeploymentMcpFailed = "DEPLOYMENT_MCP_FAILED";
+        public const string HighPrivilegeScopeDetected = "HIGH_PRIVILEGE_SCOPE_DETECTED";
     }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/GraphTokenScopeException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/GraphTokenScopeException.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Exceptions;
+
+/// <summary>
+/// Exception thrown when a Graph access token contains disallowed high-privilege scopes.
+/// </summary>
+public class GraphTokenScopeException : Agent365Exception
+{
+    private const string IssueDescriptionText = "Graph token contains high-privilege scopes";
+
+    public GraphTokenScopeException(string scope)
+        : base(
+            errorCode: ErrorCodes.HighPrivilegeScopeDetected,
+            issueDescription: IssueDescriptionText,
+            errorDetails: new List<string> { $"Disallowed scope detected in token: {scope}" },
+            mitigationSteps: new List<string>
+            {
+                "Check Microsoft Graph Command Line Tools app permissions: Azure portal ? App registrations ? 'Microsoft Graph Command Line Tools' (App ID: 14d82eec-204b-4c2f-b7e8-296a70dab67e) ? API permissions.",
+                "Look for 'Directory.AccessAsUser.All' and remove it or replace it with a least-privilege alternative (for example 'Directory.Read.All') if appropriate.",
+                "Re-run the CLI and, when the browser consent prompt appears, approve only the scopes requested by the CLI.",
+                "Note: Removing tenant-wide admin consent for this permission may impact other tools or automation that rely on it. Verify impact before removal."
+            })
+    {
+    }
+
+    public override int ExitCode => 2; // Configuration / permission error
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
@@ -88,7 +88,7 @@ class Program
             rootCommand.AddCommand(DevelopCommand.CreateCommand(developLogger, configService, executor, authService));
             rootCommand.AddCommand(DevelopMcpCommand.CreateCommand(developLogger, toolingService));
             rootCommand.AddCommand(SetupCommand.CreateCommand(setupLogger, configService, executor, 
-                deploymentService, botConfigurator, azureValidator, webAppCreator, platformDetector));
+                deploymentService, botConfigurator, azureValidator, webAppCreator, platformDetector, graphApiService));
             rootCommand.AddCommand(CreateInstanceCommand.CreateCommand(createInstanceLogger, configService, executor,
                 botConfigurator, graphApiService, azureValidator));
             rootCommand.AddCommand(DeployCommand.CreateCommand(deployLogger, configService, executor,

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
@@ -30,6 +30,7 @@ public class SetupCommandTests
     private readonly IAzureValidator _mockAzureValidator;
     private readonly AzureWebAppCreator _mockWebAppCreator;
     private readonly PlatformDetector _mockPlatformDetector;
+    private readonly GraphApiService _mockGraphApiService;
 
     public SetupCommandTests()
     {
@@ -53,6 +54,7 @@ public class SetupCommandTests
         _mockBotConfigurator = Substitute.For<IBotConfigurator>();
         _mockAzureValidator = Substitute.For<IAzureValidator>();
         _mockWebAppCreator = Substitute.ForPartsOf<AzureWebAppCreator>(Substitute.For<ILogger<AzureWebAppCreator>>());
+        _mockGraphApiService = Substitute.For<GraphApiService>();
 
         // Prevent the real setup runner from running during tests by short-circuiting it
         SetupCommand.SetupRunnerInvoker = (setupPath, generatedPath, exec, webApp) => Task.FromResult(true);
@@ -64,7 +66,7 @@ public class SetupCommandTests
         // Arrange
         var config = new Agent365Config { TenantId = "tenant", SubscriptionId = "sub", ResourceGroup = "rg", Location = "loc", AppServicePlanName = "plan", WebAppName = "web", AgentIdentityDisplayName = "agent", DeploymentProjectPath = "." };
         _mockConfigService.LoadAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(Task.FromResult(config));
-        var command = SetupCommand.CreateCommand(_mockLogger, _mockConfigService, _mockExecutor, _mockDeploymentService, _mockBotConfigurator, _mockAzureValidator, _mockWebAppCreator, _mockPlatformDetector);
+        var command = SetupCommand.CreateCommand(_mockLogger, _mockConfigService, _mockExecutor, _mockDeploymentService, _mockBotConfigurator, _mockAzureValidator, _mockWebAppCreator, _mockPlatformDetector, _mockGraphApiService);
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();
 
@@ -124,7 +126,8 @@ public class SetupCommandTests
             _mockBotConfigurator, 
             _mockAzureValidator, 
             _mockWebAppCreator, 
-            _mockPlatformDetector);
+            _mockPlatformDetector,
+            _mockGraphApiService);
         
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();
@@ -197,7 +200,8 @@ public class SetupCommandTests
             _mockBotConfigurator, 
             _mockAzureValidator, 
             _mockWebAppCreator, 
-            _mockPlatformDetector);
+            _mockPlatformDetector,
+            _mockGraphApiService);
 
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();
@@ -248,7 +252,8 @@ public class SetupCommandTests
             _mockBotConfigurator, 
             _mockAzureValidator, 
             _mockWebAppCreator, 
-            _mockPlatformDetector);
+            _mockPlatformDetector,
+            _mockGraphApiService);
 
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();
@@ -308,7 +313,8 @@ public class SetupCommandTests
             _mockBotConfigurator, 
             _mockAzureValidator, 
             _mockWebAppCreator, 
-            _mockPlatformDetector);
+            _mockPlatformDetector,
+            _mockGraphApiService);
 
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();
@@ -371,7 +377,8 @@ public class SetupCommandTests
             _mockBotConfigurator, 
             _mockAzureValidator, 
             _mockWebAppCreator, 
-            _mockPlatformDetector);
+            _mockPlatformDetector,
+            _mockGraphApiService);
 
         var parser = new CommandLineBuilder(command).Build();
         var testConsole = new TestConsole();


### PR DESCRIPTION
- Added `GraphApiService` as a dependency in `SetupCommand` and replaced inline instantiations with dependency injection.
- Introduced `GraphTokenScopeException` to handle disallowed high-privilege scopes in Graph tokens.
- Implemented `ValidateGraphToken` in `A365SetupRunner` to enforce least-privilege principles during token validation.
- Refactored `GetTokenFromGraphClient` to use `Azure.Identity` for token retrieval and validation.
- Added new error code `HighPrivilegeScopeDetected` to `ErrorCodes` for better error categorization.
- Updated `Program.cs` to inject `GraphApiService` at runtime.
- Enhanced unit tests to mock `GraphApiService` and ensure coverage of new functionality.
- Removed redundant code and improved exception handling to exclude `Agent365Exception` from generic catch blocks.


<img width="1719" height="199" alt="image" src="https://github.com/user-attachments/assets/c63bf914-2dc6-493b-b4c3-372eb736d7e4" />

