### PR TITLE
Bump WebApp Node.js Version 

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365SetupRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365SetupRunner.cs
@@ -1746,7 +1746,7 @@ public sealed class A365SetupRunner
         return platform switch
         {
             Models.ProjectPlatform.Python => "PYTHON:3.11",
-            Models.ProjectPlatform.NodeJs => "NODE:18-lts", 
+            Models.ProjectPlatform.NodeJs => "NODE:20-lts", 
             Models.ProjectPlatform.DotNet => "DOTNETCORE:8.0",
             _ => "DOTNETCORE:8.0" // Default fallback
         };
@@ -1760,7 +1760,7 @@ public sealed class A365SetupRunner
         return platform switch
         {
             Models.ProjectPlatform.Python => "PYTHON|3.11",
-            Models.ProjectPlatform.NodeJs => "NODE|18-lts",
+            Models.ProjectPlatform.NodeJs => "NODE|20-lts",
             Models.ProjectPlatform.DotNet => "DOTNETCORE|8.0",
             _ => "DOTNETCORE|8.0" // Default fallback
         };


### PR DESCRIPTION
- Bump the Node.js version for the web app:
```pwsh
fail: Microsoft.Agents.A365.DevTools.Cli.Services.A365SetupRunner[0]
      ERROR: Web app creation failed: WARNING: vnet_route_all_enabled is not a known attribute of class <class 'azure.mgmt.web.v2024_11_01.models._models_py3.Site'> and will be ignored
      ERROR: Linux Runtime 'NODE|18-lts' is not supported.Run 'az webapp list-runtimes --os-type linux' to cross check
```