### PR TITLE
fix(config): incorrect init command recommendation

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -243,7 +243,7 @@ public class ConfigService : IConfigService
             _logger?.LogError("Static configuration file not found: {ConfigPath}", resolvedConfigPath);
             throw new FileNotFoundException(
                 $"Static configuration file not found: {resolvedConfigPath}. " +
-                $"Run 'a365 init' to create a new configuration or specify a different path.");
+                $"Run 'a365 config init' to create a new configuration or specify a different path.");
         }
 
         // Load static configuration (required)


### PR DESCRIPTION
When the client is not configured the command of `a365 config init` must be ran, but the suggestion is for `a365 init` which does not exist. 

Searched the rest of the repo and this command is correct in other instances.