### PR TITLE
Fix Node deploy include dist folder and correct Oryx manifest

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ErrorCodes.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ErrorCodes.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Constants
         public const string DeploymentScopesFailed = "DEPLOYMENT_SCOPES_FAILED";
         public const string DeploymentMcpFailed = "DEPLOYMENT_MCP_FAILED";
         public const string HighPrivilegeScopeDetected = "HIGH_PRIVILEGE_SCOPE_DETECTED";
-        public const string SetupValidationFailed = "SETUP_VALIDATION_FAILED";
+        public const string NodeBuildFailed = "NODE_BUILD_FAILED";
+        public const string NodeDependencyInstallFailed = "NODE_DEPENDENCY_INSTALL_FAILED";
+        public const string NodeProjectNotFound = "NODE_PROJECT_NOT_FOUND";
         public const string RetryExhausted = "RETRY_EXHAUSTED";
+        public const string SetupValidationFailed = "SETUP_VALIDATION_FAILED";
     }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeBuildFailedException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeBuildFailedException.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Exceptions;
+
+/// <summary>
+/// Thrown when the build process of a Node.js project fails.
+/// </summary>
+public sealed class NodeBuildFailedException : Agent365Exception
+{
+    public override int ExitCode => 1;
+    public override bool IsUserError => true;
+
+    public NodeBuildFailedException(string projectDirectory, string? npmErrorOutput)
+        : base(
+            errorCode: ErrorCodes.NodeBuildFailed,
+            issueDescription: "Failed to build the Node.js project using 'npm run build'.",
+            errorDetails: BuildDetails(projectDirectory, npmErrorOutput),
+            mitigationSteps: new List<string>
+            {
+                "Run 'npm run build' locally in the project directory and fix any TypeScript/webpack/build errors.",
+                "Verify that the 'build' script is defined correctly in package.json.",
+                "If the build depends on environment variables or private packages, ensure those are configured on the machine running 'a365 deploy'.",
+                "After resolving the build issues, rerun 'a365 deploy'."
+            },
+            context: new Dictionary<string, string>
+            {
+                ["ProjectDirectory"] = projectDirectory
+            })
+    {
+    }
+
+    private static List<string> BuildDetails(string projectDirectory, string? npmErrorOutput)
+    {
+        var details = new List<string>
+        {
+            $"Project directory: {projectDirectory}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(npmErrorOutput))
+        {
+            details.Add("npm build error output (truncated):");
+            details.Add($"  {TrimError(npmErrorOutput)}");
+        }
+
+        return details;
+    }
+
+    private static string TrimError(string error)
+    {
+        const int maxLen = 400;
+        error = error.Trim();
+        return error.Length <= maxLen ? error : error[..maxLen] + " ...";
+    }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeDependencyInstallException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeDependencyInstallException.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Exceptions;
+
+/// <summary>
+/// Thrown when installation of Node.js dependencies fails.
+/// </summary>
+public class NodeDependencyInstallException : Agent365Exception
+{
+    public override int ExitCode => 1;
+    public override bool IsUserError => true;
+
+    public NodeDependencyInstallException(string projectDirectory, string? npmErrorOutput)
+        : base(
+            errorCode: ErrorCodes.NodeDependencyInstallFailed,
+            issueDescription: "Failed to install Node.js dependencies for the project.",
+            errorDetails: BuildDetails(projectDirectory, npmErrorOutput),
+            mitigationSteps: new List<string>
+            {
+                "Run 'npm install' (or 'npm ci') locally in the project directory and fix any errors.",
+                "Check that your internet connection and npm registry access are working.",
+                "If you use a private registry or npm auth, ensure those settings are configured on the machine running 'a365 deploy'.",
+                "After fixing the issue, rerun 'a365 deploy'."
+            },
+            context: new Dictionary<string, string>
+            {
+                ["ProjectDirectory"] = projectDirectory
+            })
+    {
+    }
+
+    private static List<string> BuildDetails(string projectDirectory, string? npmErrorOutput)
+    {
+        var details = new List<string>
+        {
+            $"Project directory: {projectDirectory}",
+        };
+
+        if (!string.IsNullOrWhiteSpace(npmErrorOutput))
+        {
+            details.Add("npm error output (truncated):");
+            details.Add($"  {TrimError(npmErrorOutput)}");
+        }
+
+        return details;
+    }
+
+    private static string TrimError(string error)
+    {
+        const int maxLen = 400;
+        error = error.Trim();
+        return error.Length <= maxLen ? error : error[..maxLen] + " ...";
+    }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeProjectNotFoundException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/NodeProjectNotFoundException.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Exceptions;
+
+/// <summary>
+/// Thrown when a Node.js deployment is requested from a directory that does not contain a package.json.
+/// </summary>
+public class NodeProjectNotFoundException : Agent365Exception
+{
+    public override int ExitCode => 1;
+    public override bool IsUserError => true;
+
+    public NodeProjectNotFoundException(string projectDirectory)
+        : base(
+            errorCode: ErrorCodes.NodeProjectNotFound,
+            issueDescription: "No Node.js project was found in the specified directory.",
+            errorDetails: new List<string>
+            {
+                "The deployment expects a package.json file to identify the Node.js project.",
+                $"Checked directory: {projectDirectory}"
+            },
+            mitigationSteps: new List<string>
+            {
+                "Run this command from the root of your Node.js project (where package.json is located), or",
+                "Update the --project-path in your a365 config to point to the folder containing package.json.",
+                "Verify that package.json is checked into source control and not ignored or deleted."
+            },
+            context: new Dictionary<string, string>
+            {
+                ["ProjectDirectory"] = projectDirectory
+            })
+    {
+    }
+}


### PR DESCRIPTION
This PR fixes two issues in the Node.js deployment path of the A365 CLI:

1. **Built assets in `dist/` were not being deployed**  
   Node projects that use `start: "node dist/index.js"` failed on Azure with:
Error: Cannot find module '/home/site/wwwroot/dist/index.js'

because the `dist` folder was never copied into the publish output.

2. **Node Oryx manifest sometimes contained Python build commands**  
Generated `oryx-manifest.toml` files for Node projects could contain a
`build-command` like:
```toml
[build]
platform = "nodejs"
version = "18"
build-command = "pip install -r requirements.txt"
```
which is incorrect for Node and causes confusing / broken builds.