### PR TITLE
Change default Node runtime from 18 to 20

### DIFF
--- a/Readme-Usage.md
+++ b/Readme-Usage.md
@@ -398,7 +398,7 @@ a365 setup  # Creates agent blueprint and registers messaging endpoint
 Choose based on your application type:
 
 - **.NET Projects:** .NET 8.0 SDK or later
-- **Node.js Projects:** Node.js (18+ recommended) and npm
+- **Node.js Projects:** Node.js (20+ recommended) and npm
 - **Python Projects:** Python 3.11+ and pip
 
 The CLI will validate that required tools are installed before deployment.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/InfrastructureSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/InfrastructureSubcommand.cs
@@ -652,7 +652,7 @@ public static class InfrastructureSubcommand
         return platform switch
         {
             Models.ProjectPlatform.Python => "PYTHON:3.11",
-            Models.ProjectPlatform.NodeJs => "NODE:18-lts", 
+            Models.ProjectPlatform.NodeJs => "NODE:20-lts", 
             Models.ProjectPlatform.DotNet => "DOTNETCORE:8.0",
             _ => "DOTNETCORE:8.0" // Default fallback
         };


### PR DESCRIPTION
Newly provisioned web apps should default to Node.js 20.x (current maintenance LTS): use Node 20 LTS as default for app service as suggested: [Azure updates | Microsoft Azure](https://azure.microsoft.com/en-us/updates?id=action-required-upgrade-your-app-service-apps-to-node-20-lts-by-30-april-2025)

Fixes #65 