### PR TITLE
Remove ConsistencyLevel header from simple Graph API queries

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -208,7 +208,10 @@ public class GraphApiService
             }
 
             _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", graphToken);
-            _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("ConsistencyLevel", "eventual");
+            // NOTE: Do NOT add "ConsistencyLevel: eventual" header here.
+            // This header is only required for advanced Graph query capabilities ($count, $search, certain $filter operations).
+            // For simple service principal lookups using basic $filter, this header is not needed and causes HTTP 400 errors.
+            // See: https://learn.microsoft.com/en-us/graph/aad-advanced-queries
 
             // Step 1: Derive federated identity subject using FMI ID logic
             _logger.LogInformation("[STEP 1] Deriving federated identity subject (FMI ID)...");
@@ -739,8 +742,10 @@ public class GraphApiService
         if (string.IsNullOrWhiteSpace(token)) return false;
 
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        _httpClient.DefaultRequestHeaders.Remove("ConsistencyLevel");
-        _httpClient.DefaultRequestHeaders.TryAddWithoutValidation("ConsistencyLevel", "eventual");
+        // NOTE: Do NOT add "ConsistencyLevel: eventual" header here.
+        // This header is only required for advanced Graph query capabilities ($count, $search, certain $filter operations).
+        // For simple queries like service principal lookups, this header is not needed and causes HTTP 400 errors.
+        // See: https://learn.microsoft.com/en-us/graph/aad-advanced-queries
 
         return true;
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
@@ -376,6 +377,91 @@ public class GraphApiServiceTests
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
     }
+
+    [Fact]
+    public async Task LookupServicePrincipalAsync_DoesNotIncludeConsistencyLevelHeader()
+    {
+        // This test verifies that the ConsistencyLevel header is NOT sent during service principal lookup.
+        // The ConsistencyLevel: eventual header is only required for advanced Graph queries and causes
+        // HTTP 400 "One or more headers are invalid" errors for simple $filter queries.
+        // Regression test for issue discovered on 2025-12-19.
+        //
+        // NOTE: This test covers BOTH bug locations:
+        // 1. ExecutePublishGraphStepsAsync (line 211) - where header was incorrectly set after token acquisition
+        // 2. EnsureGraphHeadersAsync (lines 745-746) - where header was incorrectly set before all Graph API calls
+        //
+        // The bug in ExecutePublishGraphStepsAsync was "defensive" - it set the header on the HttpClient, but
+        // EnsureGraphHeadersAsync would have overwritten it anyway. By testing EnsureGraphHeadersAsync (which is
+        // called by ALL Graph API operations), we ensure the header is never sent regardless of whether
+        // ExecutePublishGraphStepsAsync tries to set it.
+
+        // Arrange
+        HttpRequestMessage? capturedRequest = null;
+        var handler = new CapturingHttpMessageHandler((req) => capturedRequest = req);
+        var logger = Substitute.For<ILogger<GraphApiService>>();
+        var executor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
+
+        // Mock az CLI token acquisition to return a valid token
+        executor.ExecuteAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var cmd = callInfo.ArgAt<string>(0);
+                var args = callInfo.ArgAt<string>(1);
+                
+                // Simulate az account show - logged in
+                if (cmd == "az" && args != null && args.StartsWith("account show", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(new CommandResult 
+                    { 
+                        ExitCode = 0, 
+                        StandardOutput = JsonSerializer.Serialize(new { tenantId = "tenant-123" }), 
+                        StandardError = string.Empty 
+                    });
+                }
+                
+                // Simulate az account get-access-token -> return token
+                if (cmd == "az" && args != null && args.Contains("get-access-token", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult(new CommandResult 
+                    { 
+                        ExitCode = 0, 
+                        StandardOutput = "fake-graph-token-12345", 
+                        StandardError = string.Empty 
+                    });
+                }
+                
+                // Default: success
+                return Task.FromResult(new CommandResult { ExitCode = 0, StandardOutput = string.Empty, StandardError = string.Empty });
+            });
+
+        // Create GraphApiService with our capturing handler
+        var service = new GraphApiService(logger, executor, handler);
+
+        // Queue response for service principal lookup
+        var spResponse = new { value = new[] { new { id = "sp-object-id-123", appId = "blueprint-456" } } };
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(spResponse))
+        });
+
+        // Act - Call a public method that internally uses LookupServicePrincipalAsync
+        var result = await service.LookupServicePrincipalByAppIdAsync("tenant-123", "blueprint-456");
+
+        // Assert
+        result.Should().NotBeNull("service principal lookup should succeed");
+        capturedRequest.Should().NotBeNull("should have captured the HTTP request");
+        
+        // Verify this is indeed a service principal lookup request
+        capturedRequest!.Method.Should().Be(HttpMethod.Get);
+        capturedRequest.RequestUri.Should().NotBeNull();
+        capturedRequest.RequestUri!.AbsolutePath.Should().Contain("servicePrincipals");
+        capturedRequest.RequestUri.Query.Should().Contain("$filter");
+        
+        // Verify the ConsistencyLevel header is NOT present on the service principal lookup request
+        capturedRequest.Headers.Contains("ConsistencyLevel").Should().BeFalse(
+            "ConsistencyLevel header should NOT be present for simple service principal lookup queries. " +
+            "This header is only needed for advanced Graph query capabilities and causes HTTP 400 errors otherwise.");
+    }
 }
 
 // Simple fake handler that returns queued responses sequentially
@@ -387,6 +473,33 @@ internal class FakeHttpMessageHandler : HttpMessageHandler
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        if (_responses.Count == 0)
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") });
+
+        var resp = _responses.Dequeue();
+        return Task.FromResult(resp);
+    }
+}
+
+// Capturing handler that captures requests AFTER headers are applied
+internal class CapturingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses = new();
+    private readonly Action<HttpRequestMessage> _captureAction;
+
+    public CapturingHttpMessageHandler(Action<HttpRequestMessage> captureAction)
+    {
+        _captureAction = captureAction;
+    }
+
+    public void QueueResponse(HttpResponseMessage resp) => _responses.Enqueue(resp);
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Important: Capture AFTER HttpClient has applied DefaultRequestHeaders
+        // At this point, request.Headers contains both request-specific and default headers
+        _captureAction(request);
+
         if (_responses.Count == 0)
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") });
 


### PR DESCRIPTION
The ConsistencyLevel: eventual header is now only set for advanced Microsoft Graph queries, as its presence on simple service principal lookups caused HTTP 400 errors. Added comments referencing Microsoft documentation to clarify correct usage. Introduced a regression test and a CapturingHttpMessageHandler to ensure the header is not sent for basic queries. This fixes a bug where the header was incorrectly applied to all Graph API requests.