### PR TITLE
Fix Graph authentication for non-interactive terminals

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -188,6 +188,7 @@ public class GraphApiService
 
         // When specific scopes are required, use custom client app if configured
         // CustomClientAppId should be set by callers who have access to config
+        // Use interactive browser flow (false) as device code has module bugs; -NonInteractive removed separately
         var token = (scopes != null && _tokenProvider != null)
             ? await _tokenProvider.GetMgGraphAccessTokenAsync(tenantId, scopes, false, CustomClientAppId, ct)
             : await GetGraphAccessTokenAsync(tenantId, ct);


### PR DESCRIPTION
- Remove -NonInteractive flag from PowerShell arguments to allow browser windows to open for WAM authentication
- Add ExtractJwtFromOutput() to filter WARNING/ERROR lines from PowerShell output that caused 'newline in header' errors
- Use interactive browser flow as device code has module bugs

Fixes authentication failures with errors:
'A window handle must be configured' and
'New-line characters are not allowed in header values'