### PR TITLE
Added Mapping for mcp_meserver.

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/McpConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/McpConstants.cs
@@ -109,6 +109,8 @@ public static class McpConstants
 
                 // User/Me servers
                 ["MCP_MeTools"] = ("McpServers.Me.All", "api://mcp-metools"),
+                ["MCP_MeServer"] = ("McpServers.Me.All", "api://mcp-meserver"),
+                ["mcp_meserver"] = ("McpServers.Me.All", "api://mcp-meserver"),
                 ["MeMCPServer"] = ("McpServers.Me.All", "api://mcp-meserver"),
 
                 // Admin servers


### PR DESCRIPTION
Added two additional mappings for mcp_meserver.

 ["MCP_MeServer"] = ("McpServers.Me.All", "api://mcp-meserver"),
 ["mcp_meserver"] = ("McpServers.Me.All", "api://mcp-meserver"),

This is to be consistent with the naming, and also align with the C# Examples when 'a365 setup permissions mcp' is run. 

As an example, the SemanticKernel based dotnet example makes a call to the URL defined by the map and since no map is currently available to call "mcp_meserver" (which should be in the main URL), the call fails. 