### PR TITLE
Add gateway endpoint to mock tooling server for local agent testing

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.MockToolingServer/Server.cs
+++ b/src/Microsoft.Agents.A365.DevTools.MockToolingServer/Server.cs
@@ -223,9 +223,7 @@ public static class Server
                 {
                     mcpServerName = serverName,
                     mcpServerUniqueName = serverName,
-                    url = $"{serverUrl}/agents/servers/{serverName}",
-                    scope = "offline_access",
-                    audience = serverUrl
+                    url = $"{serverUrl}/agents/servers/{serverName}"
                 }).ToArray();
 
                 log.LogInformation("Returning {Count} MCP servers: {Servers}",


### PR DESCRIPTION
## Add gateway endpoint to mock tooling server for local agent testing

### Problem

- .NET agents expect a platform gateway endpoint at `/agents/{agentInstanceId}/mcpServers` to discover available MCP servers
- The mock server only provided direct MCP endpoints (`/mcp/sse`, `/agents/servers/{name}`)
- This caused MCP tool loading failures during local testing, resulting in 404 errors when agents tried to discover MCP servers

### Solution

- Added `/agents/{agentInstanceId}/mcpServers` gateway endpoint to `Server.cs`
- The endpoint returns an MCP server discovery list matching the `ToolingManifest.json` structure expected by the platform
- Added startup logging to indicate the gateway endpoint is available
- Response includes `mcpServerName`, `mcpServerUniqueName`, `url`, `scope`, and `audience` for each configured MCP server

### Changes

| File | Change |
|------|--------|
| `src/Microsoft.Agents.A365.DevTools.MockToolingServer/Server.cs` | Added gateway endpoint implementation (+36 lines) |

### Testing

- Verified with local agent + Agent Playground
- Successfully loaded 32 MCP tools (12 Calendar + 20 Mail)
- Agent correctly executes operations using mock calendar/mail tools
- No regressions to existing endpoints (`/mcp/sse`, `/mcp/schema.json`, `/health`)

### Related

Enables Phase 6 local testing workflow for agent development