### PR TITLE
Fix Copilot coding agent assignment using GraphQL API & Update copilot agent permissions

### DIFF
--- a/.github/workflows/auto-triage-issues.yml
+++ b/.github/workflows/auto-triage-issues.yml
@@ -5,8 +5,13 @@ on:
     types: [opened, edited]
 
 permissions:
-  issues: write
-  contents: read
+  issues: write       # Required to add labels and comments during triage
+  contents: read      # Required to read repository files for analysis
+  # The following permissions are required for Copilot coding agent assignment:
+  # - pull-requests:write - Copilot coding agent creates PRs when fixing issues
+  # - actions:read - Required for the addAssigneesToAssignable GraphQL mutation
+  pull-requests: write
+  actions: read
 
 jobs:
   triage:

--- a/autoTriage/services/copilot_service.py
+++ b/autoTriage/services/copilot_service.py
@@ -77,6 +77,115 @@ class CopilotService:
             logger.error(f"Error checking Copilot status: {e}")
             return False
 
+    def _get_assignment_prerequisites(
+        self, owner: str, repo: str, issue_number: int
+    ) -> tuple[str | None, str | None, str | None, str | None]:
+        """Get all prerequisites for Copilot assignment in a single GraphQL call.
+        
+        Combines bot ID lookup and issue/repo ID lookup to reduce API calls
+        and rate-limit pressure.
+        
+        Returns:
+            Tuple of (bot_id, repo_id, issue_id, error). 
+            If error is not None, it indicates the specific failure reason.
+            Individual IDs may be None with error=None if that specific item wasn't found.
+        """
+        try:
+            query = '''
+            query($owner: String!, $name: String!, $issueNumber: Int!) {
+              repository(owner: $owner, name: $name) {
+                id
+                issue(number: $issueNumber) {
+                  id
+                }
+                suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+                  nodes {
+                    login
+                    __typename
+                    ... on Bot {
+                      id
+                    }
+                    ... on User {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+            '''
+            
+            result = subprocess.run(
+                [
+                    'gh', 'api', 'graphql',
+                    '-f', f'query={query}',
+                    '-f', f'owner={owner}',
+                    '-f', f'name={repo}',
+                    '-F', f'issueNumber={issue_number}'
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            
+            if result.returncode != 0:
+                error_msg = f"Failed to query prerequisites: {result.stderr.strip() or 'Unknown error'}"
+                logger.warning(error_msg)
+                return None, None, None, error_msg
+            
+            data = json.loads(result.stdout)
+            
+            # Normalize nullable 'data' field to avoid AttributeError on None.get()
+            data_field = data.get('data')
+            if not isinstance(data_field, dict):
+                error_msg = f"GraphQL returned null data for {owner}/{repo}"
+                logger.warning(error_msg)
+                return None, None, None, error_msg
+            
+            # Validate repository data
+            repo_data = data_field.get('repository')
+            if not isinstance(repo_data, dict):
+                logger.warning(f"Repository {owner}/{repo} not found or not accessible")
+                return None, None, None, None  # Not an API error, just repo not found
+            
+            repo_id = repo_data.get('id')
+            
+            # Extract issue ID (may be null if issue doesn't exist)
+            issue_data = repo_data.get('issue')
+            issue_id = None
+            if isinstance(issue_data, dict):
+                issue_id = issue_data.get('id')
+            else:
+                logger.warning(f"Issue #{issue_number} not found in {owner}/{repo}")
+            
+            # Extract Copilot bot ID from suggested actors
+            bot_id = None
+            suggested_actors = repo_data.get('suggestedActors')
+            if isinstance(suggested_actors, dict):
+                nodes = suggested_actors.get('nodes')
+                if isinstance(nodes, list):
+                    for actor in nodes:
+                        if not isinstance(actor, dict):
+                            continue
+                        login = actor.get('login', '')
+                        if login in (COPILOT_ACTOR_LOGIN, COPILOT_ACTOR_BOT):
+                            bot_id = actor.get('id')
+                            break
+            
+            return bot_id, repo_id, issue_id, None
+            
+        except subprocess.TimeoutExpired:
+            error_msg = f"Timeout querying prerequisites for {owner}/{repo}"
+            logger.error(error_msg)
+            return None, None, None, error_msg
+        except json.JSONDecodeError as e:
+            error_msg = f"Invalid JSON response: {e}"
+            logger.error(error_msg)
+            return None, None, None, error_msg
+        except Exception as e:
+            error_msg = f"Error getting assignment prerequisites: {e}"
+            logger.error(error_msg)
+            return None, None, None, error_msg
+
     def assign_to_copilot(
         self,
         owner: str,
@@ -85,7 +194,7 @@ class CopilotService:
         custom_instructions: str = "",
         base_branch: str = "main"
     ) -> Dict[str, Any]:
-        """Assign an issue to GitHub Copilot coding agent.
+        """Assign an issue to GitHub Copilot coding agent using GraphQL API.
         
         Args:
             owner: Repository owner
@@ -98,31 +207,85 @@ class CopilotService:
             Dict with success status and details
         """
         try:
-            # Build the API request payload
-            payload = {
-                "assignees": [COPILOT_ASSIGNEE],
-                "agent_assignment": {
-                    "target_repo": f"{owner}/{repo}",
-                    "base_branch": base_branch,
-                    "custom_instructions": custom_instructions,
-                    "custom_agent": "",
-                    "model": ""
+            # Step 1: Get all prerequisites in a single GraphQL call
+            bot_id, repo_id, issue_id, prereq_error = self._get_assignment_prerequisites(
+                owner, repo, issue_number
+            )
+            
+            # If there was an API/query error, return it directly
+            if prereq_error:
+                return {
+                    "success": False,
+                    "error": prereq_error,
+                    "issue_number": issue_number
                 }
-            }
             
-            payload_json = json.dumps(payload)
+            if not bot_id:
+                logger.error(f"Copilot coding agent not available for {owner}/{repo}")
+                return {
+                    "success": False,
+                    "error": "Copilot coding agent not available for this repository",
+                    "issue_number": issue_number
+                }
             
-            # Use gh CLI to make the API call
+            if not repo_id:
+                logger.error(f"Failed to get repository ID for {owner}/{repo}")
+                return {
+                    "success": False,
+                    "error": "Failed to get repository ID",
+                    "issue_number": issue_number
+                }
+            
+            if not issue_id:
+                logger.error(f"Failed to get issue ID for {owner}/{repo}#{issue_number}")
+                return {
+                    "success": False,
+                    "error": "Failed to get issue ID",
+                    "issue_number": issue_number
+                }
+            
+            # Step 2: Assign issue to Copilot using GraphQL mutation
+            # Use json.dumps for proper escaping of all special characters
+            escaped_issue_id = json.dumps(issue_id)
+            escaped_bot_id = json.dumps(bot_id)
+            escaped_repo_id = json.dumps(repo_id)
+            escaped_base_branch = json.dumps(base_branch)
+            escaped_instructions = json.dumps(custom_instructions)
+            
+            mutation = f'''
+            mutation {{
+              addAssigneesToAssignable(input: {{
+                assignableId: {escaped_issue_id},
+                assigneeIds: [{escaped_bot_id}],
+                agentAssignment: {{
+                  targetRepositoryId: {escaped_repo_id},
+                  baseRef: {escaped_base_branch},
+                  customInstructions: {escaped_instructions},
+                  customAgent: "",
+                  model: ""
+                }}
+              }}) {{
+                assignable {{
+                  ... on Issue {{
+                    id
+                    title
+                    assignees(first: 10) {{
+                      nodes {{
+                        login
+                      }}
+                    }}
+                  }}
+                }}
+              }}
+            }}
+            '''
+            
             result = subprocess.run(
                 [
-                    'gh', 'api',
-                    '--method', 'POST',
-                    '-H', 'Accept: application/vnd.github+json',
-                    '-H', 'X-GitHub-Api-Version: 2022-11-28',
-                    f'/repos/{owner}/{repo}/issues/{issue_number}/assignees',
-                    '--input', '-'
+                    'gh', 'api', 'graphql',
+                    '-f', f'query={mutation}',
+                    '-H', 'GraphQL-Features: issues_copilot_assignment_api_support,coding_agent_model_selection'
                 ],
-                input=payload_json,
                 capture_output=True,
                 text=True,
                 timeout=60
@@ -137,6 +300,26 @@ class CopilotService:
                 }
             
             response = json.loads(result.stdout) if result.stdout else {}
+            
+            # Check for GraphQL errors - aggregate all messages for better diagnostics
+            errors = response.get('errors')
+            if errors:
+                error_messages = []
+                for err in errors:
+                    msg = err.get('message', 'Unknown GraphQL error')
+                    path = err.get('path')
+                    if path:
+                        path_str = '/'.join(str(p) for p in path)
+                        msg = f"{msg} (path: {path_str})"
+                    error_messages.append(msg)
+                
+                combined_error_msg = '; '.join(error_messages) if error_messages else 'Unknown GraphQL error'
+                logger.error(f"GraphQL error assigning issue #{issue_number}: {combined_error_msg}")
+                return {
+                    "success": False,
+                    "error": combined_error_msg,
+                    "issue_number": issue_number
+                }
             
             logger.info(f"Successfully assigned issue #{issue_number} to Copilot coding agent")
             return {

--- a/autoTriage/tests/services/test_copilot_service.py
+++ b/autoTriage/tests/services/test_copilot_service.py
@@ -169,11 +169,72 @@ class TestIsCopilotEnabled:
 
 
 # =============================================================================
+# Helper functions for GraphQL API mocking
+# =============================================================================
+
+def make_prerequisites_response(
+    bot_id: str = "BOT_123",
+    repo_id: str = "REPO_123",
+    issue_id: str = "ISSUE_456"
+) -> dict:
+    """Helper to create a valid combined prerequisites lookup response.
+    
+    This response combines bot ID, repo ID, and issue ID lookups into a single
+    GraphQL query response.
+    """
+    return {
+        "data": {
+            "repository": {
+                "id": repo_id,
+                "issue": {
+                    "id": issue_id
+                },
+                "suggestedActors": {
+                    "nodes": [
+                        {"login": "copilot-swe-agent", "id": bot_id, "__typename": "Bot"}
+                    ]
+                }
+            }
+        }
+    }
+
+
+def make_assignment_response() -> dict:
+    """Helper to create a valid assignment mutation response."""
+    return {
+        "data": {
+            "addAssigneesToAssignable": {
+                "assignable": {
+                    "id": "ISSUE_456",
+                    "title": "Test Issue",
+                    "assignees": {
+                        "nodes": [{"login": "copilot-swe-agent"}]
+                    }
+                }
+            }
+        }
+    }
+
+
+# =============================================================================
 # TestAssignToCopilot
 # =============================================================================
 
 class TestAssignToCopilot:
-    """Test assign_to_copilot method."""
+    """Test assign_to_copilot method with GraphQL API (2-call flow)."""
+
+    def _mock_subprocess_calls(self, prereq_response, assign_response):
+        """Helper to mock the sequence of subprocess calls for assign_to_copilot.
+        
+        The optimized flow uses 2 GraphQL calls:
+        1. Prerequisites lookup (bot ID + repo ID + issue ID)
+        2. Assignment mutation
+        """
+        responses = [
+            make_subprocess_result(0, json.dumps(prereq_response)),
+            make_subprocess_result(0, json.dumps(assign_response)),
+        ]
+        return responses
 
     # Test: Successful assignments with different parameters
     @pytest.mark.parametrize("issue_num,base_branch,instructions", [
@@ -184,13 +245,15 @@ class TestAssignToCopilot:
         (1, "main", "Multi\nline\ninstructions"),
     ], ids=["minimal", "standard", "with_branch", "with_instructions", "multiline_instructions"])
     def test_successful_assignment(self, issue_num, base_branch, instructions):
-        """Test successful issue assignment to Copilot."""
+        """Test successful issue assignment to Copilot via GraphQL."""
         from services.copilot_service import CopilotService
         
-        mock_response = {"id": 123, "number": issue_num}
-        mock_result = make_subprocess_result(0, json.dumps(mock_response))
+        responses = self._mock_subprocess_calls(
+            make_prerequisites_response(),
+            make_assignment_response()
+        )
         
-        with patch('subprocess.run', return_value=mock_result):
+        with patch('subprocess.run', side_effect=responses):
             service = CopilotService()
             result = service.assign_to_copilot(
                 "owner", "repo", issue_num,
@@ -200,17 +263,20 @@ class TestAssignToCopilot:
             
             assert result["success"] is True
             assert result["issue_number"] == issue_num
-            assert result["assigned_to"] == "copilot-swe-agent[bot]"  # Uses COPILOT_ASSIGNEE constant
+            assert result["assigned_to"] == "copilot-swe-agent[bot]"
             assert result["base_branch"] == base_branch
 
-    # Test: Payload verification
-    def test_payload_structure(self):
-        """Verify the payload sent to GitHub API is correct."""
-        from services.copilot_service import CopilotService, COPILOT_ASSIGNEE
+    # Test: GraphQL mutation is called with correct structure
+    def test_graphql_mutation_called(self):
+        """Verify that GraphQL mutation is called with proper structure."""
+        from services.copilot_service import CopilotService
         
-        mock_result = make_subprocess_result(0, "{}")
+        responses = self._mock_subprocess_calls(
+            make_prerequisites_response("BOT_XYZ", "REPO_ABC", "ISSUE_DEF"),
+            make_assignment_response()
+        )
         
-        with patch('subprocess.run', return_value=mock_result) as mock_run:
+        with patch('subprocess.run', side_effect=responses) as mock_run:
             service = CopilotService()
             service.assign_to_copilot(
                 "microsoft", "Agent365-devTools", 42,
@@ -218,49 +284,355 @@ class TestAssignToCopilot:
                 base_branch="develop"
             )
             
-            # Extract the input payload
-            call_kwargs = mock_run.call_args.kwargs
-            payload = json.loads(call_kwargs['input'])
+            # Second call should be the mutation (optimized 2-call flow)
+            mutation_call = mock_run.call_args_list[1]
+            call_args = mutation_call[0][0]
             
-            assert payload["assignees"] == [COPILOT_ASSIGNEE]
-            assert payload["agent_assignment"]["target_repo"] == "microsoft/Agent365-devTools"
-            assert payload["agent_assignment"]["base_branch"] == "develop"
-            assert payload["agent_assignment"]["custom_instructions"] == "Fix it"
+            # Verify GraphQL Features header is included
+            assert '-H' in call_args
+            header_index = call_args.index('-H')
+            header_value = call_args[header_index + 1]
+            assert 'issues_copilot_assignment_api_support' in header_value
 
-    # Test: Failure scenarios
-    @pytest.mark.parametrize("side_effect,return_code,stderr,expected_error", [
-        (None, 1, "Not authorized", "Not authorized"),
-        (None, 1, "Issue not found", "Issue not found"),
-        (None, 1, "Rate limit", "Rate limit"),
-        (subprocess.TimeoutExpired(cmd='gh', timeout=60), 0, "", "Timeout"),
-        (Exception("Connection failed"), 0, "", "Connection failed"),
-    ], ids=["unauthorized", "not_found", "rate_limit", "timeout", "exception"])
-    def test_assignment_failures(self, side_effect, return_code, stderr, expected_error):
-        """Test handling of various assignment failures."""
+    # Test: Copilot not available for repository
+    def test_copilot_not_available(self):
+        """Test handling when Copilot is not enabled for the repository."""
         from services.copilot_service import CopilotService
         
-        if side_effect:
-            with patch('subprocess.run', side_effect=side_effect):
-                service = CopilotService()
-                result = service.assign_to_copilot("owner", "repo", 42)
-                
-                assert result["success"] is False
-                assert expected_error in result["error"]
-                assert result["issue_number"] == 42
-        else:
-            mock_result = make_subprocess_result(return_code, "", stderr)
-            with patch('subprocess.run', return_value=mock_result):
-                service = CopilotService()
-                result = service.assign_to_copilot("owner", "repo", 42)
-                
-                assert result["success"] is False
-                assert result["error"] == stderr
-                assert result["issue_number"] == 42
+        # Return response with no copilot-swe-agent in actors (combined query)
+        no_copilot_response = {
+            "data": {
+                "repository": {
+                    "id": "REPO_123",
+                    "issue": {"id": "ISSUE_456"},
+                    "suggestedActors": {
+                        "nodes": [{"login": "some-user", "id": "USER_1"}]
+                    }
+                }
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(no_copilot_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert "not available" in result["error"]
+            assert result["issue_number"] == 42
 
+    # Test: Failed prerequisites lookup (API error)
+    def test_prerequisites_lookup_failure(self):
+        """Test handling when prerequisites lookup fails with API error."""
+        from services.copilot_service import CopilotService
+        
+        mock_result = make_subprocess_result(1, "", "API error")
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            # Should reflect the actual API failure, not generic "Copilot not available"
+            assert "Failed to query prerequisites" in result["error"] or "API error" in result["error"]
 
-# =============================================================================
-# TestGetFixInstructions
-# =============================================================================
+    # Test: Issue not found in prerequisites response
+    def test_issue_not_found_in_prerequisites(self):
+        """Test handling when issue is not found in combined prerequisites lookup."""
+        from services.copilot_service import CopilotService
+        
+        # Issue is null but bot and repo are valid
+        missing_issue_response = {
+            "data": {
+                "repository": {
+                    "id": "REPO_123",
+                    "issue": None,
+                    "suggestedActors": {
+                        "nodes": [{"login": "copilot-swe-agent", "id": "BOT_123", "__typename": "Bot"}]
+                    }
+                }
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(missing_issue_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            assert "issue ID" in result["error"]
+
+    # Test: Repository not found in prerequisites response
+    def test_repo_not_found_in_prerequisites(self):
+        """Test handling when repository is not found - specific error message."""
+        from services.copilot_service import CopilotService
+        
+        # Repository is null
+        null_repo_response = {
+            "data": {
+                "repository": None
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(null_repo_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            # When repo is null, bot_id won't be found, so error should be about Copilot not available
+            assert "error" in result
+            assert "not available" in result["error"] or "repository" in result["error"].lower()
+
+    # Test: GraphQL mutation failure
+    def test_mutation_failure(self):
+        """Test handling when GraphQL mutation fails."""
+        from services.copilot_service import CopilotService
+        
+        responses = [
+            make_subprocess_result(0, json.dumps(make_prerequisites_response())),
+            make_subprocess_result(1, "", "Forbidden"),
+        ]
+        
+        with patch('subprocess.run', side_effect=responses):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert "Forbidden" in result["error"]
+            assert result["issue_number"] == 42
+
+    # Test: GraphQL errors in response
+    def test_graphql_errors_in_response(self):
+        """Test handling of GraphQL errors in the response body."""
+        from services.copilot_service import CopilotService
+        
+        error_response = {
+            "errors": [{"message": "You don't have permission to assign issues"}]
+        }
+        
+        responses = [
+            make_subprocess_result(0, json.dumps(make_prerequisites_response())),
+            make_subprocess_result(0, json.dumps(error_response)),
+        ]
+        
+        with patch('subprocess.run', side_effect=responses):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert "permission" in result["error"]
+            assert result["issue_number"] == 42
+
+    # Test: Multiple GraphQL errors are aggregated
+    def test_multiple_graphql_errors_aggregated(self):
+        """Test that multiple GraphQL errors are aggregated into a single message."""
+        from services.copilot_service import CopilotService
+        
+        multi_error_response = {
+            "errors": [
+                {"message": "First error", "path": ["addAssigneesToAssignable", "assignable"]},
+                {"message": "Second error"},
+                {"message": "Third error", "path": ["mutation", "field"]}
+            ]
+        }
+        
+        responses = [
+            make_subprocess_result(0, json.dumps(make_prerequisites_response())),
+            make_subprocess_result(0, json.dumps(multi_error_response)),
+        ]
+        
+        with patch('subprocess.run', side_effect=responses):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            # All errors should be in the message
+            assert "First error" in result["error"]
+            assert "Second error" in result["error"]
+            assert "Third error" in result["error"]
+            # Path should be included for errors that have it
+            assert "path:" in result["error"]
+
+    # Test: Timeout during assignment
+    def test_timeout_handling(self):
+        """Test handling of timeout during assignment."""
+        from services.copilot_service import CopilotService
+        
+        with patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='gh', timeout=60)):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+
+    # Test: General exception handling  
+    def test_exception_handling(self):
+        """Test handling of unexpected exceptions."""
+        from services.copilot_service import CopilotService
+        
+        with patch('subprocess.run', side_effect=Exception("Unexpected error")):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+
+    # =========================================================================
+    # Regression tests for nullable GraphQL responses in prerequisites lookup
+    # These test cases ensure _get_assignment_prerequisites handles nulls gracefully.
+    # =========================================================================
+
+    @pytest.mark.parametrize("response,description", [
+        ({"data": {"repository": None}}, "null repository"),
+        ({"data": {"repository": {"id": "R1", "issue": {"id": "I1"}, "suggestedActors": None}}}, "null suggestedActors"),
+        ({"data": {"repository": {"id": "R1", "issue": {"id": "I1"}, "suggestedActors": {"nodes": None}}}}, "null nodes"),
+        ({"data": {"repository": {"id": "R1", "issue": {"id": "I1"}, "suggestedActors": {"nodes": [None]}}}}, "null actor in nodes"),
+        ({"data": None}, "null data"),
+        ({}, "empty response"),
+    ], ids=["null_repo", "null_actors", "null_nodes", "null_actor_item", "null_data", "empty"])
+    def test_prerequisites_nullable_response_variations(self, response, description):
+        """Parameterized test for nullable fields in combined prerequisites lookup.
+        
+        All these cases should fail gracefully without raising exceptions.
+        """
+        from services.copilot_service import CopilotService
+        
+        mock_result = make_subprocess_result(0, json.dumps(response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False, f"Should fail gracefully for prerequisites lookup: {description}"
+            assert result["issue_number"] == 42
+
+    # =========================================================================
+    # Regression tests for nullable issue/repository in prerequisites response
+    # These test cases ensure graceful failure when API returns null for
+    # repository or issue, without raising unexpected exceptions.
+    # =========================================================================
+
+    def test_null_repository_in_response(self):
+        """Test graceful handling when repository is null in GraphQL response.
+        
+        Regression test: When the API returns {"data": {"repository": null}},
+        the code should fail gracefully without raising AttributeError.
+        """
+        from services.copilot_service import CopilotService
+        
+        null_repo_response = {
+            "data": {
+                "repository": None  # Repository not found or no access
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(null_repo_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            # Should have a clear error, not an exception traceback
+            assert "error" in result
+
+    def test_null_issue_in_response(self):
+        """Test graceful handling when issue is null in GraphQL response.
+        
+        Regression test: When the API returns {"data": {"repository": {"id": "...", "issue": null}}},
+        the code should fail gracefully without raising AttributeError.
+        """
+        from services.copilot_service import CopilotService
+        
+        null_issue_response = {
+            "data": {
+                "repository": {
+                    "id": "REPO_123",
+                    "issue": None,  # Issue not found
+                    "suggestedActors": {
+                        "nodes": [{"login": "copilot-swe-agent", "id": "BOT_123", "__typename": "Bot"}]
+                    }
+                }
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(null_issue_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+            assert "error" in result
+
+    def test_null_data_in_response(self):
+        """Test graceful handling when data is null in GraphQL response."""
+        from services.copilot_service import CopilotService
+        
+        null_data_response = {
+            "data": None
+        }
+        mock_result = make_subprocess_result(0, json.dumps(null_data_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+
+    def test_missing_issue_id_in_response(self):
+        """Test graceful handling when issue object exists but has no id field."""
+        from services.copilot_service import CopilotService
+        
+        missing_id_response = {
+            "data": {
+                "repository": {
+                    "id": "REPO_123",
+                    "issue": {},  # Issue object exists but no id
+                    "suggestedActors": {
+                        "nodes": [{"login": "copilot-swe-agent", "id": "BOT_123", "__typename": "Bot"}]
+                    }
+                }
+            }
+        }
+        mock_result = make_subprocess_result(0, json.dumps(missing_id_response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False
+            assert result["issue_number"] == 42
+
+    @pytest.mark.parametrize("response,description", [
+        ({"data": {"repository": None}}, "null repository"),
+        ({"data": {"repository": {"id": "R1", "issue": None, "suggestedActors": {"nodes": [{"login": "copilot-swe-agent", "id": "B1"}]}}}}, "null issue"),
+        ({"data": None}, "null data"),
+        ({}, "empty response"),
+        ({"data": {}}, "empty data object"),
+        ({"data": {"repository": {}}}, "repository without id"),
+    ], ids=["null_repo", "null_issue", "null_data", "empty", "empty_data", "no_repo_id"])
+    def test_nullable_response_variations(self, response, description):
+        """Parameterized test for various nullable/missing field scenarios.
+        
+        All these cases should fail gracefully without raising exceptions.
+        """
+        from services.copilot_service import CopilotService
+        
+        mock_result = make_subprocess_result(0, json.dumps(response))
+        
+        with patch('subprocess.run', return_value=mock_result):
+            service = CopilotService()
+            result = service.assign_to_copilot("owner", "repo", 42)
+            
+            assert result["success"] is False, f"Should fail gracefully for: {description}"
+            assert result["issue_number"] == 42
 
 class TestGetFixInstructions:
     """Test get_fix_instructions method."""


### PR DESCRIPTION
- Update workflow permissions to include pull-requests:write and actions:read
- Rewrite assign_to_copilot() to use GraphQL API with required feature headers
- Add helper methods to get Copilot bot ID and issue/repo IDs
- Use addAssigneesToAssignable mutation with agentAssignment input
- Include GraphQL-Features header for Copilot assignment API support

Fixes HTTP 403 error when assigning issues to Copilot coding agent.