### PR TITLE
Revert workflow permissions after Copilot assignment testing

### DIFF
--- a/.github/workflows/auto-triage-issues.yml
+++ b/.github/workflows/auto-triage-issues.yml
@@ -5,17 +5,8 @@ on:
     types: [opened, edited]
 
 permissions:
-  issues: write       # Required to add labels and comments during triage
-  # TESTING: Temporarily using contents:write instead of contents:read.
-  # Hypothesis: The addAssigneesToAssignable GraphQL mutation with agentAssignment
-  # might require write access to create branches/commits for Copilot coding agent.
-  # Expected: This likely won't help because GITHUB_TOKEN lacks Copilot entitlement
-  # regardless of permissions. Copilot assignment requires user-level authentication.
-  # Revert to contents:read after confirming this doesn't resolve Copilot assignment.
-  contents: write
-  # The following permissions are required for Copilot coding agent assignment:
-  # - pull-requests:write - Copilot coding agent creates PRs when fixing issues
-  # - actions:read - Required for the addAssigneesToAssignable GraphQL mutation
+  issues: write
+  contents: read
   pull-requests: write
   actions: read
 

--- a/autoTriage/tests/workflows/test_workflows.py
+++ b/autoTriage/tests/workflows/test_workflows.py
@@ -48,9 +48,7 @@ class TestAutoTriageWorkflow:
     def test_workflow_has_required_permissions(self, workflow):
         """Test workflow has correct permissions."""
         assert workflow["permissions"]["issues"] == "write"
-        # Note: contents is temporarily set to 'write' for testing Copilot assignment.
-        # Should be 'read' in production. See workflow comments for details.
-        assert workflow["permissions"]["contents"] in ("read", "write")
+        assert workflow["permissions"]["contents"] == "read"
 
     def test_workflow_uses_python_311(self, workflow):
         """Test workflow uses Python 3.11."""


### PR DESCRIPTION
Reverts contents:write permission - testing confirmed GITHUB_TOKEN cannot assign Copilot regardless of workflow permissions.