### PR TITLE
fix: Handle Python projects without pyproject.toml in a365 deploy

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
@@ -566,6 +566,15 @@ public class PythonBuilder : IPlatformBuilder
 
         if (hasPyProject || hasSetupPy)
         {
+            // Check if requirements.txt also exists and log a warning
+            if (File.Exists(sourceRequirements))
+            {
+                _logger.LogWarning(
+                    "Both pyproject.toml/setup.py and requirements.txt exist. " +
+                    "Using editable install approach (pyproject.toml takes precedence). " +
+                    "Dependencies from requirements.txt will be ignored - ensure they're declared in pyproject.toml instead.");
+            }
+
             // Use editable install approach for projects with pyproject.toml/setup.py
             // This allows pip to install the project as a package
             _logger.LogInformation("Detected pyproject.toml or setup.py - using editable install approach");
@@ -578,8 +587,27 @@ public class PythonBuilder : IPlatformBuilder
             // Copy existing requirements.txt for projects without pyproject.toml/setup.py
             // This preserves the original dependency list
             _logger.LogInformation("No pyproject.toml or setup.py found - copying existing requirements.txt");
-            File.Copy(sourceRequirements, requirementsTxt, overwrite: true);
-            _logger.LogInformation("Copied existing requirements.txt to publish folder");
+
+            try
+            {
+                File.Copy(sourceRequirements, requirementsTxt, overwrite: true);
+                _logger.LogInformation("Copied existing requirements.txt to publish folder");
+            }
+            catch (FileNotFoundException ex)
+            {
+                _logger.LogError(ex, "Source requirements.txt not found: {Path}", sourceRequirements);
+                throw new DeployAppException($"Cannot find requirements.txt at {sourceRequirements}. The file may have been deleted.", ex);
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                _logger.LogError(ex, "Access denied when copying requirements.txt");
+                throw new DeployAppException($"Permission denied: Cannot copy requirements.txt to {requirementsTxt}. Check file permissions.", ex);
+            }
+            catch (IOException ex)
+            {
+                _logger.LogError(ex, "Failed to copy requirements.txt");
+                throw new DeployAppException($"Failed to copy requirements.txt to publish folder. The file may be in use or disk may be full.", ex);
+            }
         }
         else
         {

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
+
+public class PythonBuilderTests : IDisposable
+{
+    private readonly ILogger<PythonBuilder> _logger;
+    private readonly CommandExecutor _mockExecutor;
+    private readonly PythonBuilder _builder;
+    private readonly List<string> _tempDirectories;
+
+    public PythonBuilderTests()
+    {
+        _logger = Substitute.For<ILogger<PythonBuilder>>();
+        var executorLogger = Substitute.For<ILogger<CommandExecutor>>();
+        _mockExecutor = Substitute.ForPartsOf<CommandExecutor>(executorLogger);
+        _builder = new PythonBuilder(_logger, _mockExecutor);
+        _tempDirectories = new List<string>();
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithPyprojectToml_CreatesEditableRequirementsTxt()
+    {
+        // Arrange
+        var projectDir = CreateTempDirectory();
+        var publishDir = "publish";
+        var publishPath = Path.Combine(projectDir, publishDir);
+
+        // Create source files
+        File.WriteAllText(Path.Combine(projectDir, "pyproject.toml"), "[project]\nname = \"test-project\"");
+        File.WriteAllText(Path.Combine(projectDir, "requirements.txt"), "flask==2.0.0\nrequests==2.31.0");
+        File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
+
+        // Mock Python and pip executables
+        MockPythonEnvironment();
+
+        // Act
+        await _builder.BuildAsync(projectDir, publishDir, verbose: false);
+
+        // Assert
+        var requirementsTxt = Path.Combine(publishPath, "requirements.txt");
+        File.Exists(requirementsTxt).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("--find-links dist");
+        content.Should().Contain("--pre");
+        content.Should().Contain("-e .");
+        content.Should().NotContain("flask==2.0.0", "editable install should replace original requirements.txt");
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithSetupPy_CreatesEditableRequirementsTxt()
+    {
+        // Arrange
+        var projectDir = CreateTempDirectory();
+        var publishDir = "publish";
+        var publishPath = Path.Combine(projectDir, publishDir);
+
+        // Create source files
+        File.WriteAllText(Path.Combine(projectDir, "setup.py"), "from setuptools import setup\nsetup(name='test')");
+        File.WriteAllText(Path.Combine(projectDir, "requirements.txt"), "django==3.2.0\ncelery==5.2.0");
+        File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
+
+        // Mock Python and pip executables
+        MockPythonEnvironment();
+
+        // Act
+        await _builder.BuildAsync(projectDir, publishDir, verbose: false);
+
+        // Assert
+        var requirementsTxt = Path.Combine(publishPath, "requirements.txt");
+        File.Exists(requirementsTxt).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("--find-links dist");
+        content.Should().Contain("--pre");
+        content.Should().Contain("-e .");
+        content.Should().NotContain("django==3.2.0", "editable install should replace original requirements.txt");
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithOnlyRequirementsTxt_PreservesOriginalRequirements()
+    {
+        // Arrange
+        var projectDir = CreateTempDirectory();
+        var publishDir = "publish";
+        var publishPath = Path.Combine(projectDir, publishDir);
+
+        // Create source files - NO pyproject.toml or setup.py
+        var originalRequirements = "flask==2.0.0\nrequests==2.31.0\ngunicorn==20.1.0";
+        File.WriteAllText(Path.Combine(projectDir, "requirements.txt"), originalRequirements);
+        File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
+
+        // Mock Python and pip executables
+        MockPythonEnvironment();
+
+        // Act
+        await _builder.BuildAsync(projectDir, publishDir, verbose: false);
+
+        // Assert
+        var requirementsTxt = Path.Combine(publishPath, "requirements.txt");
+        File.Exists(requirementsTxt).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Be(originalRequirements, "should preserve original dependencies exactly");
+        content.Should().NotContain("-e .", "should not use editable install when no package metadata");
+        content.Should().Contain("flask==2.0.0");
+        content.Should().Contain("requests==2.31.0");
+        content.Should().Contain("gunicorn==20.1.0");
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithBothPyprojectTomlAndRequirements_PrefersPyprojectToml()
+    {
+        // Arrange
+        var projectDir = CreateTempDirectory();
+        var publishDir = "publish";
+        var publishPath = Path.Combine(projectDir, publishDir);
+
+        // Create source files with both pyproject.toml and requirements.txt
+        File.WriteAllText(Path.Combine(projectDir, "pyproject.toml"), "[project]\nname = \"test-project\"");
+        File.WriteAllText(Path.Combine(projectDir, "requirements.txt"), "fastapi==0.95.0");
+        File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
+
+        // Mock Python and pip executables
+        MockPythonEnvironment();
+
+        // Act
+        await _builder.BuildAsync(projectDir, publishDir, verbose: false);
+
+        // Assert
+        var requirementsTxt = Path.Combine(publishPath, "requirements.txt");
+        File.Exists(requirementsTxt).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("-e .", "should use editable install when pyproject.toml exists");
+        content.Should().NotContain("fastapi==0.95.0", "should not copy requirements.txt when pyproject.toml exists");
+    }
+
+    [Fact]
+    public async Task BuildAsync_WithoutRequirementsTxtAndNoPyprojectToml_CreatesMinimalRequirementsTxt()
+    {
+        // Arrange
+        var projectDir = CreateTempDirectory();
+        var publishDir = "publish";
+        var publishPath = Path.Combine(projectDir, publishDir);
+
+        // Create source files - NO requirements.txt, NO pyproject.toml, NO setup.py
+        File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
+
+        // Mock Python and pip executables
+        MockPythonEnvironment();
+
+        // Act
+        await _builder.BuildAsync(projectDir, publishDir, verbose: false);
+
+        // Assert
+        var requirementsTxt = Path.Combine(publishPath, "requirements.txt");
+        File.Exists(requirementsTxt).Should().BeTrue();
+
+        var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("# Auto-generated", "should create minimal file with comment");
+    }
+
+    private void MockPythonEnvironment()
+    {
+        // Mock python --version command
+        _mockExecutor.ExecuteAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(s => s.Contains("--version")),
+            Arg.Any<string>(),
+            Arg.Any<bool>())
+            .Returns(Task.FromResult(new CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = "Python 3.11.0",
+                StandardError = string.Empty
+            }));
+
+        // Mock pip --version command
+        _mockExecutor.ExecuteAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(s => s.Contains("pip --version")),
+            Arg.Any<string>(),
+            Arg.Any<bool>())
+            .Returns(Task.FromResult(new CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = "pip 23.0.1",
+                StandardError = string.Empty
+            }));
+
+        // Mock python -m py_compile command (syntax checking)
+        _mockExecutor.ExecuteAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(s => s.Contains("py_compile")),
+            Arg.Any<string>(),
+            Arg.Any<bool>())
+            .Returns(Task.FromResult(new CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = string.Empty,
+                StandardError = string.Empty
+            }));
+
+        // Mock uv build command (may not exist)
+        _mockExecutor.ExecuteAsync(
+            Arg.Is<string>(s => s == "uv"),
+            Arg.Is<string>(s => s.Contains("build")),
+            Arg.Any<string>(),
+            Arg.Any<bool>())
+            .Returns(Task.FromResult(new CommandResult
+            {
+                ExitCode = 1,
+                StandardOutput = string.Empty,
+                StandardError = "uv not found"
+            }));
+    }
+
+    private string CreateTempDirectory()
+    {
+        var tempPath = Path.Combine(Path.GetTempPath(), $"a365test_{Guid.NewGuid()}");
+        Directory.CreateDirectory(tempPath);
+        _tempDirectories.Add(tempPath);
+        return tempPath;
+    }
+
+    public void Dispose()
+    {
+        foreach (var tempDir in _tempDirectories)
+        {
+            try
+            {
+                if (Directory.Exists(tempDir))
+                {
+                    Directory.Delete(tempDir, recursive: true);
+                }
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #252 - `a365 deploy` overwrites `requirements.txt` for Python projects without `pyproject.toml`

## Problem

When deploying Python projects that have only `requirements.txt` (no `pyproject.toml` or `setup.py`), the CLI overwrites the requirements file with `-e .`, which fails because pip cannot find a package to install.

Error from Azure Oryx:
```
ERROR: file:///tmp/8de6a0cc7ececaa (from -r requirements.txt (line 3)) does not appear to be a Python project: neither 'setup.py' nor 'pyproject.toml' found.
```

## Solution

Modified `CreateAzureRequirementsTxt()` in `PythonBuilder.cs` to detect the project structure:

1. **If `pyproject.toml` or `setup.py` exists**: Use the existing `-e .` (editable install) approach
2. **If only `requirements.txt` exists**: Copy the existing file as-is to preserve dependencies
3. **If neither exists**: Create a minimal placeholder with a warning log

## Changes

- `PythonBuilder.cs`: Updated `CreateAzureRequirementsTxt()` method with project structure detection
- Added `projectDir` parameter to access source requirements.txt
- Improved logging to indicate which approach is being used

## Testing

- [x] Build passes (`dotnet build -c Release`)
- [x] All tests pass (945 passed, 0 failed)
- [x] Manual test with Python project without pyproject.toml (was failing, now works)

## Compatibility

This is a backward-compatible fix:
- Projects with `pyproject.toml` or `setup.py` continue to work as before
- Projects with only `requirements.txt` now work correctly
