### PR TITLE
fix: Enable .NET runtime roll-forward for compatibility with newer ve…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Microsoft Agent 365 DevTools CLI (`a365`) - A .NET 8.0 CLI tool for deploying and managing Microsoft Agent 365 applications on Azure. Supports .NET, Node.js, and Python applications with auto-detection.
+Microsoft Agent 365 DevTools CLI (`a365`) - A .NET CLI tool built on .NET 8.0 with support for running on .NET 8.0 or higher (e.g., .NET 9, 10). Used for deploying and managing Microsoft Agent 365 applications on Azure. Supports .NET, Node.js, and Python applications with auto-detection.
 
 ## Build Commands
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Downloads](https://img.shields.io/nuget/dt/Microsoft.Agents.A365.DevTools.Cli?label=Downloads&color=green)](https://www.nuget.org/packages/Microsoft.Agents.A365.DevTools.Cli)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/microsoft/Agent365-devTools/.github/workflows/ci.yml?branch=main&label=Build&logo=github)](https://github.com/microsoft/Agent365-devTools/actions)
 [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE)
-[![.NET](https://img.shields.io/badge/.NET-8.0-512BD4)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-8.0+-512BD4)](https://dotnet.microsoft.com/)
 [![Contributors](https://img.shields.io/github/contributors/microsoft/Agent365-devTools?label=Contributors)](https://github.com/microsoft/Agent365-devTools/graphs/contributors)
 
 > **Note:**  
@@ -36,6 +36,11 @@ This project is currently in active development. The CLI is being actively devel
 ## Installation
 
 ### Prerequisites
+
+**System Requirements:**
+- **.NET 8.0 or higher**: The CLI requires .NET 8.0 runtime or any newer version (e.g., .NET 9, 10). [Download .NET](https://dotnet.microsoft.com/download)
+
+**Entra ID App Registration:**
 
 Before using the Agent365 CLI, you must create a custom Entra ID app registration with specific Microsoft Graph API permissions:
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Microsoft.Agents.A365.DevTools.Cli.csproj
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Microsoft.Agents.A365.DevTools.Cli.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Microsoft.Agents.A365.DevTools.Cli</RootNamespace>
 
+    <!-- Runtime Configuration: Allow running on newer .NET versions -->
+    <RollForward>Major</RollForward>
+
     <!-- Package as .NET Tool -->
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
**.NET Version Support and Documentation Updates**

* Updated the project and CLI documentation to clarify that the tool requires .NET 8.0 or higher (not just 8.0), including badge and prerequisites sections in `README.md` and the project overview in `CLAUDE.md`. 
* Modified the CLI project file (`Microsoft.Agents.A365.DevTools.Cli.csproj`) to set `<RollForward>Major</RollForward>`, allowing the CLI to run on newer major versions of .NET (e.g., .NET 9, 10).


Tested in ubuntu.

You can invoke the tool using the following command: a365
Tool 'microsoft.agents.a365.devtools.cli' (version '1.1.93-preview-ge5082cd521') was successfully installed.
1.1.93-preview+e5082cd521
sellak@CPC-sella-5TX53:~/Agent365-devTools/src/Microsoft.Agents.A365.DevTools.Cli$
sellak@CPC-sella-5TX53:~/Agent365-devTools/src/Microsoft.Agents.A365.DevTools.Cli$ a365 --version
1.1.93-preview+e5082cd521
sellak@CPC-sella-5TX53:~/Agent365-devTools/src/Microsoft.Agents.A365.DevTools.Cli$ dotnet --list-runtimes
Microsoft.AspNetCore.App 10.0.3 [/home/sellak/.dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.NETCore.App 10.0.3 [/home/sellak/.dotnet/shared/Microsoft.NETCore.App]
sellak@CPC-sella-5TX53:~/Agent365-devTools/src/Microsoft.Agents.A365.DevTools.Cli$
