### PR TITLE
Fix python builds with a365 deploy

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -875,8 +875,7 @@ internal static class BlueprintSubcommand
             {
                 ["@odata.type"] = "Microsoft.Graph.AgentIdentityBlueprint", // CRITICAL: Required for Agent Blueprint type
                 ["displayName"] = displayName,
-                ["signInAudience"] = "AzureADMultipleOrgs", // Multi-tenant
-                ["managerApplications"] = "e8be65d6-d430-4289-a665-51bf2a194bda" // Managed-by app ID for A365
+                ["signInAudience"] = "AzureADMultipleOrgs" // Multi-tenant
             };
 
             // Add sponsors and owners fields if we have the current user

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -875,7 +875,8 @@ internal static class BlueprintSubcommand
             {
                 ["@odata.type"] = "Microsoft.Graph.AgentIdentityBlueprint", // CRITICAL: Required for Agent Blueprint type
                 ["displayName"] = displayName,
-                ["signInAudience"] = "AzureADMultipleOrgs" // Multi-tenant
+                ["signInAudience"] = "AzureADMultipleOrgs", // Multi-tenant
+                ["managerApplications"] = "e8be65d6-d430-4289-a665-51bf2a194bda" // Managed-by app ID for A365
             };
 
             // Add sponsors and owners fields if we have the current user

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
@@ -571,16 +571,19 @@ public class PythonBuilder : IPlatformBuilder
             {
                 _logger.LogWarning(
                     "Both pyproject.toml/setup.py and requirements.txt exist. " +
-                    "Using editable install approach (pyproject.toml takes precedence). " +
+                    "Using wheel install approach (pyproject.toml takes precedence). " +
                     "Dependencies from requirements.txt will be ignored - ensure they're declared in pyproject.toml instead.");
             }
 
-            // Use editable install approach for projects with pyproject.toml/setup.py
-            // This allows pip to install the project as a package
-            _logger.LogInformation("Detected pyproject.toml or setup.py - using editable install approach");
-            var content = "--find-links dist\n--pre\n-e .\n";
+            // Install from the pre-built wheel in dist/ rather than using editable install (-e .)
+            // Editable installs fail on Azure because Oryx builds in a different location than wwwroot
+            var publishDist = Path.Combine(publishPath, "dist");
+            var packageName = DetectPackageName(publishPath, publishDist);
+
+            _logger.LogInformation("Detected pyproject.toml or setup.py - using wheel install approach");
+            var content = $"--find-links dist\n--pre\n{packageName}\n";
             await File.WriteAllTextAsync(requirementsTxt, content);
-            _logger.LogInformation("Created requirements.txt for editable install");
+            _logger.LogInformation("Created requirements.txt to install {Package} from local wheel", packageName);
         }
         else if (File.Exists(sourceRequirements))
         {
@@ -616,6 +619,50 @@ public class PythonBuilder : IPlatformBuilder
             var content = "# Auto-generated - add your dependencies here\n";
             await File.WriteAllTextAsync(requirementsTxt, content);
         }
+    }
+
+    /// <summary>
+    /// Detects the package name from the pre-built wheel filename or pyproject.toml.
+    /// Wheel filenames follow the format: {name}-{version}-{tags}.whl
+    /// where the distribution name uses underscores (PEP 427), but pip accepts hyphens.
+    /// </summary>
+    private string DetectPackageName(string publishPath, string publishDist)
+    {
+        // Try to extract from wheel filename first
+        if (Directory.Exists(publishDist))
+        {
+            var wheels = Directory.GetFiles(publishDist, "*.whl");
+            if (wheels.Length > 0)
+            {
+                var wheelName = Path.GetFileNameWithoutExtension(wheels[0]);
+                // Wheel format: {name}-{version}-{python}-{abi}-{platform}
+                var parts = wheelName.Split('-');
+                if (parts.Length >= 2)
+                {
+                    var name = parts[0].Replace('_', '-');
+                    _logger.LogDebug("Detected package name from wheel: {Name}", name);
+                    return name;
+                }
+            }
+        }
+
+        // Fallback: try to read name from pyproject.toml
+        var pyprojectPath = Path.Combine(publishPath, "pyproject.toml");
+        if (File.Exists(pyprojectPath))
+        {
+            var content = File.ReadAllText(pyprojectPath);
+            var match = System.Text.RegularExpressions.Regex.Match(content, @"name\s*=\s*""([^""]+)""");
+            if (match.Success)
+            {
+                var name = match.Groups[1].Value;
+                _logger.LogDebug("Detected package name from pyproject.toml: {Name}", name);
+                return name;
+            }
+        }
+
+        // Last resort fallback
+        _logger.LogWarning("Could not detect package name, using '.' as fallback");
+        return ".";
     }
 
     private async Task CreateDeploymentFile(string publishPath)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
@@ -578,7 +578,7 @@ public class PythonBuilder : IPlatformBuilder
             // Install from the pre-built wheel in dist/ rather than using editable install (-e .)
             // Editable installs fail on Azure because Oryx builds in a different location than wwwroot
             var publishDist = Path.Combine(publishPath, "dist");
-            var packageName = DetectPackageName(publishPath, publishDist);
+            var packageName = await DetectPackageName(publishPath, publishDist);
 
             _logger.LogInformation("Detected pyproject.toml or setup.py - using wheel install approach");
             var content = $"--no-index\n--find-links dist\n--pre\n{packageName}\n";
@@ -626,15 +626,64 @@ public class PythonBuilder : IPlatformBuilder
     /// Wheel filenames follow the format: {name}-{version}-{tags}.whl
     /// where the distribution name uses underscores (PEP 427), but pip accepts hyphens.
     /// </summary>
-    private string DetectPackageName(string publishPath, string publishDist)
+    private async Task<string> DetectPackageName(string publishPath, string publishDist)
     {
-        // Try to extract from wheel filename first
+        // Read the expected project name from pyproject.toml first, so we can use it
+        // to narrow wheel selection when multiple wheels exist.
+        string? expectedName = null;
+        var pyprojectPath = Path.Combine(publishPath, "pyproject.toml");
+        if (File.Exists(pyprojectPath))
+        {
+            try
+            {
+                var tomlContent = await File.ReadAllTextAsync(pyprojectPath);
+
+                // Extract the [project] table body up to the next table header (or end of file),
+                // then match name = "..." only within that section.
+                var projectSectionMatch = System.Text.RegularExpressions.Regex.Match(
+                    tomlContent,
+                    @"^\[project\]\s*$\r?\n(.*?)(?=^\[|\z)",
+                    System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Singleline);
+                if (projectSectionMatch.Success)
+                {
+                    var projectSection = projectSectionMatch.Groups[1].Value;
+                    var nameMatch = System.Text.RegularExpressions.Regex.Match(
+                        projectSection,
+                        @"^name\s*=\s*[""']([^""']+)[""']\s*$",
+                        System.Text.RegularExpressions.RegexOptions.Multiline);
+                    if (nameMatch.Success)
+                    {
+                        expectedName = nameMatch.Groups[1].Value;
+                        _logger.LogDebug("Detected expected package name from pyproject.toml: {Name}", expectedName);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse pyproject.toml when detecting package name");
+            }
+        }
+
+        // Try to extract from wheel filename
         if (Directory.Exists(publishDist))
         {
             var wheels = Directory.GetFiles(publishDist, "*.whl");
             if (wheels.Length > 0)
             {
                 Array.Sort(wheels, StringComparer.Ordinal);
+
+                // If we know the expected project name, prefer the matching wheel
+                if (expectedName is not null && wheels.Length > 1)
+                {
+                    var normalizedExpected = expectedName.Replace('-', '_').ToLowerInvariant();
+                    var matched = wheels.FirstOrDefault(w =>
+                        Path.GetFileNameWithoutExtension(w).Split('-')[0].ToLowerInvariant() == normalizedExpected);
+                    if (matched is not null)
+                    {
+                        _logger.LogDebug("Selected wheel matching project name {Name}: {Wheel}", expectedName, Path.GetFileName(matched));
+                        wheels = new[] { matched };
+                    }
+                }
 
                 if (wheels.Length > 1)
                 {
@@ -656,31 +705,11 @@ public class PythonBuilder : IPlatformBuilder
             }
         }
 
-        // Fallback: try to read name from pyproject.toml [project] table (PEP 621)
-        var pyprojectPath = Path.Combine(publishPath, "pyproject.toml");
-        if (File.Exists(pyprojectPath))
+        // If we got a name from pyproject.toml but no wheels, use it
+        if (expectedName is not null)
         {
-            try
-            {
-                var content = File.ReadAllText(pyprojectPath);
-
-                // Match name = "..." only within the [project] table section.
-                // The pattern finds [project], then scans for name = before the next table header.
-                var match = System.Text.RegularExpressions.Regex.Match(
-                    content,
-                    @"^\[project\]\s*$.*?^name\s*=\s*[""']([^""']+)[""']",
-                    System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Singleline);
-                if (match.Success)
-                {
-                    var name = match.Groups[1].Value;
-                    _logger.LogDebug("Detected package name from pyproject.toml: {Name}", name);
-                    return name;
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to parse pyproject.toml when detecting package name");
-            }
+            _logger.LogDebug("No wheels found, using package name from pyproject.toml: {Name}", expectedName);
+            return expectedName;
         }
 
         // Fail fast rather than falling back to installing from the source tree

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/PythonBuilder.cs
@@ -548,7 +548,7 @@ public class PythonBuilder : IPlatformBuilder
 
     /// <summary>
     /// Creates requirements.txt for Azure deployment.
-    /// For projects with pyproject.toml or setup.py, uses editable install (-e .).
+    /// For projects with pyproject.toml or setup.py, installs from a pre-built wheel in dist/.
     /// For projects with only requirements.txt, copies the existing file to preserve dependencies.
     /// </summary>
     private async Task CreateAzureRequirementsTxt(string projectDir, string publishPath, bool verbose)
@@ -581,7 +581,7 @@ public class PythonBuilder : IPlatformBuilder
             var packageName = DetectPackageName(publishPath, publishDist);
 
             _logger.LogInformation("Detected pyproject.toml or setup.py - using wheel install approach");
-            var content = $"--find-links dist\n--pre\n{packageName}\n";
+            var content = $"--no-index\n--find-links dist\n--pre\n{packageName}\n";
             await File.WriteAllTextAsync(requirementsTxt, content);
             _logger.LogInformation("Created requirements.txt to install {Package} from local wheel", packageName);
         }
@@ -634,6 +634,16 @@ public class PythonBuilder : IPlatformBuilder
             var wheels = Directory.GetFiles(publishDist, "*.whl");
             if (wheels.Length > 0)
             {
+                Array.Sort(wheels, StringComparer.Ordinal);
+
+                if (wheels.Length > 1)
+                {
+                    _logger.LogWarning(
+                        "Multiple wheel files found in {PublishDist}; using the first wheel in deterministic filename order: {Wheel}",
+                        publishDist,
+                        Path.GetFileName(wheels[0]));
+                }
+
                 var wheelName = Path.GetFileNameWithoutExtension(wheels[0]);
                 // Wheel format: {name}-{version}-{python}-{abi}-{platform}
                 var parts = wheelName.Split('-');
@@ -646,23 +656,38 @@ public class PythonBuilder : IPlatformBuilder
             }
         }
 
-        // Fallback: try to read name from pyproject.toml
+        // Fallback: try to read name from pyproject.toml [project] table (PEP 621)
         var pyprojectPath = Path.Combine(publishPath, "pyproject.toml");
         if (File.Exists(pyprojectPath))
         {
-            var content = File.ReadAllText(pyprojectPath);
-            var match = System.Text.RegularExpressions.Regex.Match(content, @"name\s*=\s*""([^""]+)""");
-            if (match.Success)
+            try
             {
-                var name = match.Groups[1].Value;
-                _logger.LogDebug("Detected package name from pyproject.toml: {Name}", name);
-                return name;
+                var content = File.ReadAllText(pyprojectPath);
+
+                // Match name = "..." only within the [project] table section.
+                // The pattern finds [project], then scans for name = before the next table header.
+                var match = System.Text.RegularExpressions.Regex.Match(
+                    content,
+                    @"^\[project\]\s*$.*?^name\s*=\s*[""']([^""']+)[""']",
+                    System.Text.RegularExpressions.RegexOptions.Multiline | System.Text.RegularExpressions.RegexOptions.Singleline);
+                if (match.Success)
+                {
+                    var name = match.Groups[1].Value;
+                    _logger.LogDebug("Detected package name from pyproject.toml: {Name}", name);
+                    return name;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to parse pyproject.toml when detecting package name");
             }
         }
 
-        // Last resort fallback
-        _logger.LogWarning("Could not detect package name, using '.' as fallback");
-        return ".";
+        // Fail fast rather than falling back to installing from the source tree
+        _logger.LogError("Could not detect package name from wheel metadata or pyproject.toml");
+        throw new DeployAppException(
+            "Could not detect Python package name from the built wheel or pyproject.toml. " +
+            "Ensure a wheel is present in the publish dist directory or that pyproject.toml contains a valid [project] name.");
     }
 
     private async Task CreateDeploymentFile(string publishPath)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
@@ -48,8 +48,10 @@ public class PythonBuilderTests : IDisposable
         File.Exists(requirementsTxt).Should().BeTrue();
 
         var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("--no-index");
         content.Should().Contain("--find-links dist");
         content.Should().Contain("--pre");
+        content.Should().Contain("test-project", "should detect package name from pyproject.toml");
         content.Should().NotContain("-e .", "wheel install should not use editable install");
         content.Should().NotContain("flask==2.0.0", "wheel install should replace original requirements.txt");
     }
@@ -67,6 +69,11 @@ public class PythonBuilderTests : IDisposable
         File.WriteAllText(Path.Combine(projectDir, "requirements.txt"), "django==3.2.0\ncelery==5.2.0");
         File.WriteAllText(Path.Combine(projectDir, "app.py"), "print('hello')");
 
+        // Create a pre-built wheel in dist/ so DetectPackageName can find it
+        var distDir = Path.Combine(projectDir, "dist");
+        Directory.CreateDirectory(distDir);
+        File.WriteAllText(Path.Combine(distDir, "test-1.0.0-py3-none-any.whl"), "");
+
         // Mock Python and pip executables
         MockPythonEnvironment();
 
@@ -78,8 +85,10 @@ public class PythonBuilderTests : IDisposable
         File.Exists(requirementsTxt).Should().BeTrue();
 
         var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("--no-index");
         content.Should().Contain("--find-links dist");
         content.Should().Contain("--pre");
+        content.Should().Contain("test", "should detect package name from wheel filename");
         content.Should().NotContain("-e .", "wheel install should not use editable install");
         content.Should().NotContain("django==3.2.0", "wheel install should replace original requirements.txt");
     }
@@ -139,8 +148,10 @@ public class PythonBuilderTests : IDisposable
         File.Exists(requirementsTxt).Should().BeTrue();
 
         var content = await File.ReadAllTextAsync(requirementsTxt);
+        content.Should().Contain("--no-index");
         content.Should().Contain("--find-links dist");
         content.Should().Contain("--pre");
+        content.Should().Contain("test-project", "should detect package name from pyproject.toml");
         content.Should().NotContain("-e .", "wheel install should not use editable install");
         content.Should().NotContain("fastapi==0.95.0", "should not copy requirements.txt when pyproject.toml exists");
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/PythonBuilderTests.cs
@@ -50,8 +50,8 @@ public class PythonBuilderTests : IDisposable
         var content = await File.ReadAllTextAsync(requirementsTxt);
         content.Should().Contain("--find-links dist");
         content.Should().Contain("--pre");
-        content.Should().Contain("-e .");
-        content.Should().NotContain("flask==2.0.0", "editable install should replace original requirements.txt");
+        content.Should().NotContain("-e .", "wheel install should not use editable install");
+        content.Should().NotContain("flask==2.0.0", "wheel install should replace original requirements.txt");
     }
 
     [Fact]
@@ -80,8 +80,8 @@ public class PythonBuilderTests : IDisposable
         var content = await File.ReadAllTextAsync(requirementsTxt);
         content.Should().Contain("--find-links dist");
         content.Should().Contain("--pre");
-        content.Should().Contain("-e .");
-        content.Should().NotContain("django==3.2.0", "editable install should replace original requirements.txt");
+        content.Should().NotContain("-e .", "wheel install should not use editable install");
+        content.Should().NotContain("django==3.2.0", "wheel install should replace original requirements.txt");
     }
 
     [Fact]
@@ -139,7 +139,9 @@ public class PythonBuilderTests : IDisposable
         File.Exists(requirementsTxt).Should().BeTrue();
 
         var content = await File.ReadAllTextAsync(requirementsTxt);
-        content.Should().Contain("-e .", "should use editable install when pyproject.toml exists");
+        content.Should().Contain("--find-links dist");
+        content.Should().Contain("--pre");
+        content.Should().NotContain("-e .", "wheel install should not use editable install");
         content.Should().NotContain("fastapi==0.95.0", "should not copy requirements.txt when pyproject.toml exists");
     }
 


### PR DESCRIPTION
Editable installs were failing for Python builds on Azure. This PR resolves that issue, tested with Python Claude sample agent.

This pull request updates the Python packaging logic for Azure deployments to address issues with editable installs and to improve package name detection. Instead of using editable installs (which fail on Azure), the process now installs from a pre-built wheel, and a new helper method is introduced to reliably detect the package name from the wheel or `pyproject.toml`.

**Azure Python packaging improvements:**

* Switched from using editable installs (`-e .`) to installing from a pre-built wheel in the `dist/` directory, as editable installs fail on Azure due to build location mismatches. The generated `requirements.txt` now references the wheel and the detected package name instead of using `-e .`.
* Added a new private method `DetectPackageName` to extract the package name from the wheel filename or, as a fallback, from `pyproject.toml`. If neither is found, it defaults to `"."`. This ensures the correct package is installed during deployment.