### PR TITLE
fix(docs): correct Developer Portal configuration in setup instructions

### DIFF
--- a/docs/agent365-guided-setup/a365-setup-instructions.md
+++ b/docs/agent365-guided-setup/a365-setup-instructions.md
@@ -599,9 +599,8 @@ Provide the user with the following instructions:
 
 1. **Get your blueprint ID** by running:
    ```bash
-   a365 config display -g
+   a365 config display -g --field agentBlueprintId
    ```
-   Copy the `agentBlueprintId` value from the output.
 
 2. **Navigate to Developer Portal** by opening your browser and going to:
    ```

--- a/docs/agent365-guided-setup/a365-setup-instructions.md
+++ b/docs/agent365-guided-setup/a365-setup-instructions.md
@@ -597,21 +597,24 @@ For complete details, see [Create agent instances](https://learn.microsoft.com/e
 
 Provide the user with the following instructions:
 
-1. **Get your blueprint app ID** by running:
+1. **Get your blueprint ID** by running:
    ```bash
    a365 config display -g
    ```
-   Copy the `agentBlueprintAppId` value from the output.
+   Copy the `agentBlueprintId` value from the output.
 
 2. **Navigate to Developer Portal** by opening your browser and going to:
    ```
-   https://dev.teams.microsoft.com/tools/agent-blueprint/<your-blueprint-app-id>/configuration
+   https://dev.teams.microsoft.com/tools/agent-blueprint/<your-blueprint-id>/configuration
    ```
-   Replace `<your-blueprint-app-id>` with the value you copied.
+   Replace `<your-blueprint-id>` with the value you copied.
 
 3. **Configure the agent** in the Developer Portal:
-   - Set **Agent Type** to `Bot Based`
-   - Set **Bot ID** to your `agentBlueprintAppId` value
+   - Set **Agent Type** to `API Based`
+   - Set **Notification URL** to your agent's messaging endpoint. Get the value by running:
+     ```bash
+     a365 config display -g --field messagingEndpoint
+     ```
    - Select **Save**
 
 > **Note:** If the user doesn't have access to the Developer Portal, they should contact their tenant administrator to grant access or complete this configuration on their behalf.


### PR DESCRIPTION
## Summary

Fixes documentation errors in 'docs/agent365-guided-setup/a365-setup-instructions.md' where the Developer Portal configuration instructions diverge from the [official create-instance docs](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/create-instance).

## Changes

- **Agent Type**: \Bot Based\ → \API Based\
- **Notification URL**: replaced \Bot ID\ field with \Notification URL\ using \365 config display -g --field messagingEndpoint\
- **Field name**: \gentBlueprintAppId\ → \gentBlueprintId\

Closes #363