### PR TITLE
fix: pass -NoProfile when invoking pwsh in requirement checks

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/PowerShellModulesRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/PowerShellModulesRequirementCheck.cs
@@ -277,7 +277,7 @@ public class PowerShellModulesRequirementCheck : RequirementCheck
             var processStartInfo = new ProcessStartInfo
             {
                 FileName = executable,
-                Arguments = $"-Command \"{wrappedCommand}\"",
+                Arguments = $"-NoProfile -NonInteractive -Command \"{wrappedCommand}\"",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,


### PR DESCRIPTION
## Summary
- `PowerShellModulesRequirementCheck.ExecutePowerShellCommandAsync` invoked `pwsh` with only `-Command`, so any output written by the user's PowerShell profile (PSReadLine install prompt, posh-git warnings, custom `Write-Host`, etc.) was prepended to stdout.
- The availability probe parses stdout as an int via `int.TryParse("$PSVersionTable.PSVersion.Major")`; profile pollution makes this fail and the CLI reports `PowerShell is not available on this system` even when pwsh 7+ is installed. `Get-Module` / `Install-Module` calls on the same code path silently misbehave for the same reason.
- Adds `-NoProfile -NonInteractive` to the pwsh arguments. This matches the existing convention in `MicrosoftGraphTokenProvider.BuildPowerShellArguments`.

## Repro (before fix)
Any PowerShell profile that writes to stdout — for example one that imports `posh-git` or prompts for PSReadLine. Running `a365 setup all` (or `a365 setup requirements`) produces:
```
ERROR: Fail: PowerShell Modules
  PowerShell is not available on this system
  Install PowerShell 7+ from https://learn.microsoft.com/...
```

After the fix, the probe returns a clean `7` regardless of profile contents and the check proceeds to module detection.

## Test plan
- [x] `dotnet test --filter FullyQualifiedName~PowerShellModulesRequirementCheckTests` — 5/5 pass
- [x] Rebuilt and installed CLI via `scripts/cli/install-cli.ps1`; `a365 setup requirements` progresses past the PowerShell check on a machine with a profile that prints to stdout (previously blocked at this step)
- [x] Manual: `pwsh -NoProfile -Command "$PSVersionTable.PSVersion.Major"` returns `7` cleanly with the same profile that polluted the unflagged call