### PR TITLE
Add idempotency and reuse tracking to agent setup flow

### DIFF
--- a/.claude/agents/pr-code-reviewer.md
+++ b/.claude/agents/pr-code-reviewer.md
@@ -654,6 +654,38 @@ When a catch block, comment, or doc string covers multiple distinct error condit
   // After:  "Device code flow may succeed depending on your tenant's CAP configuration."
   ```
 
+### 26. Bare `catch (Exception)` Not Excluding `OperationCanceledException`
+
+A catch block that uses `catch (Exception)` or `catch (Exception ex)` without a `when (ex is not OperationCanceledException)` filter, where the method has a `CancellationToken` in scope. This swallows cancellation silently — setup continues, config may be cleared or re-registration triggered, and Ctrl+C appears to hang.
+
+- **Pattern to catch**:
+  - `catch (Exception)` or `catch (Exception ex)` in a method whose signature includes `CancellationToken ct` or `CancellationToken cancellationToken`
+  - The catch body returns a default/null/false value rather than re-throwing
+  - No explicit `catch (OperationCanceledException)` block preceding the broad catch
+- **Severity**: `high` — cancellation is silently swallowed; operations that should terminate on Ctrl+C continue running and may corrupt or clear persisted state
+- **Check**: For every `catch (Exception)` or `catch (Exception ex)` in the diff, check if the enclosing method signature has a `CancellationToken` parameter. If yes and there is no `when (ex is not OperationCanceledException)` filter and no dedicated `catch (OperationCanceledException)` block above it, flag it.
+- **Fix**:
+  ```csharp
+  catch (Exception ex) when (ex is not OperationCanceledException)
+  {
+      _logger.LogDebug(ex, "...");
+      return false; // or null, or default
+  }
+  ```
+  Alternatively, place a dedicated re-throw block first:
+  ```csharp
+  catch (OperationCanceledException)
+  {
+      throw; // propagate immediately — do not swallow
+  }
+  catch (Exception ex)
+  {
+      _logger.LogDebug(ex, "...");
+      return false;
+  }
+  ```
+- **Real examples** (from PR #384): `AgentRegistrationExistsAsync` in `GraphApiService.cs` and `FindExistingAgentIdentityAsync` in `AgentBlueprintService.cs` both had bare `catch (Exception ex)` blocks that swallowed `OperationCanceledException`, causing setup to continue (and potentially clear valid stored state) after cancellation.
+
 **MANDATORY REPORTING RULE**: Whenever the diff contains any test file (`.Tests.cs`), you MUST emit a named finding for this check — even if no violation is found. The finding must appear in the review output with one of three statuses:
   - **`high` severity** if a violation is found (missing warmup, dead executor mock, etc.)
   - **`info` — FIXED** if the PR is fixing a prior violation (warmup added to previously-cold classes) — list each class fixed and its measured or estimated speedup

--- a/.claude/skills/review-staged/SKILL.md
+++ b/.claude/skills/review-staged/SKILL.md
@@ -109,7 +109,13 @@ The skill uses **Claude Code directly** for semantic code analysis (same as revi
 2. Claude Code reads `.github/copilot-instructions.md` for coding standards
 3. Claude Code gets staged files: `git diff --staged --name-only`
 4. Claude Code gets staged changes: `git diff --staged`
-5. **Claude Code reads the complete current content of every staged file** (not just diff lines) to enable full-file semantic analysis. This is critical for catching issues that exist in unchanged sections of modified files, such as:
+5. **Claude Code reads the complete current content of every staged file** (not just diff lines) to enable full-file semantic analysis.
+5a. **If any staged file is a test file** (path contains `.Tests.` or filename ends in `Tests.cs`), Claude Code MUST also invoke the `pr-test-analyzer` agent as a subagent to review test coverage quality. Pass the staged diff and list of staged test files as context. The `pr-test-analyzer` agent focuses on:
+   - NSubstitute predicate precision (predicates on mutable reference types evaluated at assertion time vs. call time)
+   - Missing test scenarios for new orchestration code paths (e.g., 409 idempotent path, tri-state verification results)
+   - Assertions that track implementation rather than requirements
+   - Test method names that accurately describe the contract being verified
+   Include the `pr-test-analyzer` findings in the review document under a dedicated **Test Coverage** section. This is critical for catching issues that exist in unchanged sections of modified files, such as:
    - Duplicate hardcoded constants or magic values that already exist elsewhere
    - Parallel code structures that should be consolidated (e.g., a method building the same spec list as a shared helper)
    - Unused or dead code that was already there but not touched by the diff

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
@@ -384,7 +384,7 @@ internal static class NonDwBlueprintSetupOrchestrator
                 ctx.Config.AgentRegistrationId!,
                 ctx.CancellationToken);
 
-            if (exists)
+            if (exists == true)
             {
                 registrationId = ctx.Config.AgentRegistrationId;
                 registrationAlreadyExisted = true;
@@ -392,9 +392,9 @@ internal static class NonDwBlueprintSetupOrchestrator
                     ctx.Logger.LogInformation("Agent already registered (ID: {RegistrationId}). Skipping.", registrationId);
                 ctx.Logger.LogInformation("");
             }
-            else
+            else if (exists == false)
             {
-                // Stored ID no longer exists in the registry — clear it and create a new registration.
+                // 404 confirmed — stored ID no longer exists in the registry.
                 using (ctx.Logger.Indent())
                     ctx.Logger.LogInformation("Stored registration ID {RegistrationId} no longer exists; creating a new registration.", ctx.Config.AgentRegistrationId);
                 ctx.Config.AgentRegistrationId = null;
@@ -402,11 +402,20 @@ internal static class NonDwBlueprintSetupOrchestrator
                 // stale value on disk that would cause the same stale-ID check to repeat.
                 await ctx.ConfigService.SaveStateAsync(ctx.Config);
             }
+            else
+            {
+                // Verification inconclusive (auth or transient error) — preserve the stored ID
+                // to avoid unintended re-registration. The user can clear the config manually if needed.
+                using (ctx.Logger.Indent())
+                    ctx.Logger.LogWarning("Could not verify agent registration {RegistrationId} (auth or transient error); retaining stored value.", ctx.Config.AgentRegistrationId);
+                registrationId = ctx.Config.AgentRegistrationId;
+                registrationAlreadyExisted = true;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(registrationId))
         {
-            registrationId = await ctx.GraphApiService.RegisterAgentInstanceAsyncV2(
+            var (newId, fromConflict) = await ctx.GraphApiService.RegisterAgentInstanceAsyncV2(
                 ctx.Config.TenantId!,
                 agentDisplayName,
                 ctx.Config.AgentDescription,
@@ -414,6 +423,8 @@ internal static class NonDwBlueprintSetupOrchestrator
                 ctx.Config.AgenticAppId,
                 ctx.Config.ClientAppId,
                 ctx.CancellationToken);
+            registrationId = newId;
+            if (fromConflict) registrationAlreadyExisted = true;
         }
 
         if (registrationId is not null)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
@@ -296,6 +296,7 @@ internal static class NonDwBlueprintSetupOrchestrator
         {
             ctx.Logger.LogInformation("Agent identity already created (ID: {AgentId}). Skipping.", ctx.Config.AgenticAppId);
             ctx.Results.AgentIdentityCreated = true;
+            ctx.Results.AgentIdentityAlreadyExisted = true;
             ctx.Results.AgentIdentityId = ctx.Config.AgenticAppId;
             ctx.Results.AgentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName;
         }
@@ -304,31 +305,52 @@ internal static class NonDwBlueprintSetupOrchestrator
             var agentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName
                 ?? "Agent";
 
-            // Agent identity creation via delegated flow (AgentIdentity.Create.All).
-            // Agent ID Developer role is sufficient — client credentials are not required.
-            ctx.Logger.LogInformation("Creating agent identity...");
-            var agentId = await ctx.GraphApiService.CreateAgentIdentityDelegatedAsync(
+            // API-level idempotency: check if an identity with this display name already exists
+            // for the blueprint. Handles re-runs where the generated config was cleared.
+            var existingIdentityId = await ctx.BlueprintService.FindExistingAgentIdentityAsync(
                 ctx.Config.TenantId!,
                 ctx.Config.AgentBlueprintId!,
                 agentIdentityDisplayName,
                 ctx.CancellationToken);
 
-            if (agentId is not null)
+            if (!string.IsNullOrWhiteSpace(existingIdentityId))
             {
-                ctx.Config.AgenticAppId = agentId;
+                ctx.Logger.LogInformation("Found existing agent identity (ID: {AgentId}). Skipping creation.", existingIdentityId);
+                ctx.Config.AgenticAppId = existingIdentityId;
                 await ctx.ConfigService.SaveStateAsync(ctx.Config);
                 ctx.Results.AgentIdentityCreated = true;
-                ctx.Results.AgentIdentityId = agentId;
+                ctx.Results.AgentIdentityAlreadyExisted = true;
+                ctx.Results.AgentIdentityId = existingIdentityId;
                 ctx.Results.AgentIdentityDisplayName = agentIdentityDisplayName;
-                using (ctx.Logger.Indent())
-                    ctx.Logger.LogInformation("Agent identity created (ID: {AgentId})", agentId);
-                ctx.Logger.LogInformation("");
             }
-            else if (!ctx.Results.AgentIdentityFailed)
+            else
             {
-                ctx.Results.AgentIdentityFailed = true;
-                ctx.Results.Warnings.Add("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
-                ctx.Logger.LogWarning("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                // Agent identity creation via delegated flow (AgentIdentity.Create.All).
+                // Agent ID Developer role is sufficient — client credentials are not required.
+                ctx.Logger.LogInformation("Creating agent identity...");
+                var agentId = await ctx.GraphApiService.CreateAgentIdentityDelegatedAsync(
+                    ctx.Config.TenantId!,
+                    ctx.Config.AgentBlueprintId!,
+                    agentIdentityDisplayName,
+                    ctx.CancellationToken);
+
+                if (agentId is not null)
+                {
+                    ctx.Config.AgenticAppId = agentId;
+                    await ctx.ConfigService.SaveStateAsync(ctx.Config);
+                    ctx.Results.AgentIdentityCreated = true;
+                    ctx.Results.AgentIdentityId = agentId;
+                    ctx.Results.AgentIdentityDisplayName = agentIdentityDisplayName;
+                    using (ctx.Logger.Indent())
+                        ctx.Logger.LogInformation("Agent identity created (ID: {AgentId})", agentId);
+                    ctx.Logger.LogInformation("");
+                }
+                else if (!ctx.Results.AgentIdentityFailed)
+                {
+                    ctx.Results.AgentIdentityFailed = true;
+                    ctx.Results.Warnings.Add("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                    ctx.Logger.LogWarning("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                }
             }
         }
 
@@ -349,21 +371,42 @@ internal static class NonDwBlueprintSetupOrchestrator
             agentDisplayName = agentDisplayName[..^" Identity".Length].TrimEnd() + " Agent";
 
         ctx.Logger.LogInformation("");
+        ctx.Logger.LogInformation("Registering agent...");
+
+        // If a registration ID is already stored, verify it still exists before skipping creation.
+        string? registrationId = null;
+        bool registrationAlreadyExisted = false;
+
         if (!string.IsNullOrWhiteSpace(ctx.Config.AgentRegistrationId))
         {
-            ctx.Logger.LogInformation("Registering agent...");
-            using (ctx.Logger.Indent())
-                ctx.Logger.LogInformation("Agent already registered (ID: {RegistrationId}). Skipping.", ctx.Config.AgentRegistrationId);
-            ctx.Logger.LogInformation("");
-            ctx.Results.AgentInstanceRegistered = true;
-            ctx.Results.AgentInstanceId = ctx.Config.AgentRegistrationId;
-            ctx.Results.AgentRegistrationDisplayName = agentDisplayName;
-        }
-        else
-        {
-            ctx.Logger.LogInformation("Registering agent...");
+            var exists = await ctx.GraphApiService.AgentRegistrationExistsAsync(
+                ctx.Config.TenantId!,
+                ctx.Config.AgentRegistrationId!,
+                ctx.CancellationToken);
 
-            var registrationId = await ctx.GraphApiService.RegisterAgentInstanceAsyncV2(
+            if (exists)
+            {
+                registrationId = ctx.Config.AgentRegistrationId;
+                registrationAlreadyExisted = true;
+                using (ctx.Logger.Indent())
+                    ctx.Logger.LogInformation("Agent already registered (ID: {RegistrationId}). Skipping.", registrationId);
+                ctx.Logger.LogInformation("");
+            }
+            else
+            {
+                // Stored ID no longer exists in the registry — clear it and create a new registration.
+                using (ctx.Logger.Indent())
+                    ctx.Logger.LogInformation("Stored registration ID {RegistrationId} no longer exists; creating a new registration.", ctx.Config.AgentRegistrationId);
+                ctx.Config.AgentRegistrationId = null;
+                // Persist the cleared ID immediately so a subsequent failure does not leave a
+                // stale value on disk that would cause the same stale-ID check to repeat.
+                await ctx.ConfigService.SaveStateAsync(ctx.Config);
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(registrationId))
+        {
+            registrationId = await ctx.GraphApiService.RegisterAgentInstanceAsyncV2(
                 ctx.Config.TenantId!,
                 agentDisplayName,
                 ctx.Config.AgentDescription,
@@ -371,24 +414,28 @@ internal static class NonDwBlueprintSetupOrchestrator
                 ctx.Config.AgenticAppId,
                 ctx.Config.ClientAppId,
                 ctx.CancellationToken);
+        }
 
-            if (registrationId is not null)
+        if (registrationId is not null)
+        {
+            ctx.Config.AgentRegistrationId = registrationId;
+            await ctx.ConfigService.SaveStateAsync(ctx.Config);
+            ctx.Results.AgentInstanceRegistered = true;
+            ctx.Results.AgentRegistrationAlreadyExisted = registrationAlreadyExisted;
+            ctx.Results.AgentInstanceId = registrationId;
+            ctx.Results.AgentRegistrationDisplayName = agentDisplayName;
+            if (!registrationAlreadyExisted)
             {
-                ctx.Config.AgentRegistrationId = registrationId;
-                await ctx.ConfigService.SaveStateAsync(ctx.Config);
-                ctx.Results.AgentInstanceRegistered = true;
-                ctx.Results.AgentInstanceId = registrationId;
-                ctx.Results.AgentRegistrationDisplayName = agentDisplayName;
                 using (ctx.Logger.Indent())
                     ctx.Logger.LogInformation("Agent registered (ID: {RegistrationId})", registrationId);
                 ctx.Logger.LogInformation("");
             }
-            else
-            {
-                ctx.Results.AgentRegistrationFailed = true;
-                ctx.Results.Warnings.Add("Agent registration failed via Graph copilot/agentRegistrations API.");
-                ctx.Logger.LogWarning("Agent registration failed via Graph copilot/agentRegistrations API.");
-            }
+        }
+        else
+        {
+            ctx.Results.AgentRegistrationFailed = true;
+            ctx.Results.Warnings.Add("Agent registration failed via Graph copilot/agentRegistrations API.");
+            ctx.Logger.LogWarning("Agent registration failed via Graph copilot/agentRegistrations API.");
         }
 
         // Sync all settings (ServiceConnection, TokenValidation, Agent365Observability) to the app config file.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -455,14 +455,20 @@ internal static class SetupHelpers
             else
             {
                 if (results.AgentIdentityCreated)
-                    logger.LogInformation(DryRunRow(5, "Agent identity") + "created   '{Name}' (ID: {Id})",
+                {
+                    var identityVerb = (results.AgentIdentityAlreadyExisted ? "reused" : "created").PadRight(9);
+                    logger.LogInformation(DryRunRow(5, "Agent identity") + identityVerb + " '{Name}' (ID: {Id})",
                         results.AgentIdentityDisplayName ?? "unknown", results.AgentIdentityId ?? "unknown");
+                }
                 else if (results.AgentIdentityFailed)
                     logger.LogWarning(DryRunRow(5, "Agent identity") + "failed — see warnings");
 
                 if (results.AgentInstanceRegistered)
-                    logger.LogInformation(DryRunRow(6, "Agent Registration") + "registered   '{Name}' (ID: {Id})",
+                {
+                    var registrationVerb = (results.AgentRegistrationAlreadyExisted ? "reused" : "registered").PadRight(12);
+                    logger.LogInformation(DryRunRow(6, "Agent Registration") + registrationVerb + " '{Name}' (ID: {Id})",
                         results.AgentRegistrationDisplayName ?? "unknown", results.AgentInstanceId ?? "unknown");
+                }
                 else if (results.AgentRegistrationFailed)
                     logger.LogWarning(DryRunRow(6, "Agent Registration") + "failed — see warnings");
             }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
@@ -121,6 +121,13 @@ public class SetupResults
     public bool AgentIdentityCreated { get; set; }
 
     /// <summary>
+    /// True when <see cref="AgentIdentityCreated"/> is set because an existing identity was
+    /// found (via config or API lookup) rather than freshly created. Drives "reused" vs "created"
+    /// in the setup summary.
+    /// </summary>
+    public bool AgentIdentityAlreadyExisted { get; set; }
+
+    /// <summary>
     /// The Agent Identity ID returned after agent identity creation.
     /// Non-null when <see cref="AgentIdentityCreated"/> is true.
     /// </summary>
@@ -136,6 +143,13 @@ public class SetupResults
     /// Populated by the non-DW blueprint setup flow only.
     /// </summary>
     public bool AgentInstanceRegistered { get; set; }
+
+    /// <summary>
+    /// True when <see cref="AgentInstanceRegistered"/> is set because an existing registration was
+    /// found (via config or API lookup) rather than freshly registered. Drives "reused" vs "registered"
+    /// in the setup summary.
+    /// </summary>
+    public bool AgentRegistrationAlreadyExisted { get; set; }
 
     /// <summary>
     /// The Agent Instance ID returned by the Agent Instance Graph API after registration.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
@@ -228,6 +228,35 @@ public class AgentBlueprintService
     }
 
     /// <summary>
+    /// Returns the service principal ID of an existing agent identity for the given blueprint
+    /// whose display name matches <paramref name="displayName"/>, or null if none is found.
+    /// Wraps <see cref="GetAgentInstancesForBlueprintAsync"/>; exceptions are caught and logged
+    /// non-fatally so callers can fall through to creation.
+    /// </summary>
+    public virtual async Task<string?> FindExistingAgentIdentityAsync(
+        string tenantId,
+        string blueprintId,
+        string displayName,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var instances = await GetAgentInstancesForBlueprintAsync(tenantId, blueprintId, cancellationToken);
+            var match = instances.FirstOrDefault(i =>
+                string.Equals(i.DisplayName, displayName, StringComparison.OrdinalIgnoreCase));
+            // IdentitySpId is the Graph SP object ID — the same value CreateAgentIdentityDelegatedAsync
+            // returns and stores in AgenticAppId (both are /beta/servicePrincipals/{id} object IDs).
+            return match?.IdentitySpId;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not look up existing agent identities for blueprint {BlueprintId} (non-fatal): {Message}",
+                blueprintId, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Fetches all pages of a Graph API collection, following @odata.nextLink pagination.
     /// Returns the deserialized "value" array items from all pages.
     /// </summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
@@ -248,7 +248,7 @@ public class AgentBlueprintService
             // returns and stores in AgenticAppId (both are /beta/servicePrincipals/{id} object IDs).
             return match?.IdentitySpId;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Could not look up existing agent identities for blueprint {BlueprintId} (non-fatal): {Message}",
                 blueprintId, ex.Message);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -1225,7 +1225,7 @@ public class GraphApiService
     /// token includes AgentRegistration.ReadWrite.All, or falls back to the az CLI Graph token.
     /// Returns the new agent registration ID on success (200 OK), or null on failure.
     /// </summary>
-    public virtual async Task<string?> RegisterAgentInstanceAsyncV2(
+    public virtual async Task<(string? Id, bool AlreadyExisted)> RegisterAgentInstanceAsyncV2(
         string tenantId,
         string displayName,
         string? description,
@@ -1239,7 +1239,7 @@ public class GraphApiService
         if (string.IsNullOrWhiteSpace(currentUserId))
         {
             _logger.LogError("Failed to retrieve current user ID — required for agent registration.");
-            return null;
+            return (null, false);
         }
 
         // Use the custom app token provider with .default so the token is issued to the "Agent 365 CLI"
@@ -1308,7 +1308,7 @@ public class GraphApiService
             registrationId ??= payload["id"]?.ToString();
 
             response.Json?.Dispose();
-            return registrationId;
+            return (registrationId, false);
         }
 
         // 409 Conflict means an agent with the same sourceAgentId already exists.
@@ -1327,14 +1327,14 @@ public class GraphApiService
             if (!string.IsNullOrWhiteSpace(existingId))
             {
                 _logger.LogInformation("Agent already registered (existing ID: {RegistrationId}). Skipping.", existingId);
-                return existingId;
+                return (existingId, true);
             }
 
             // 409 but no ID in the body — server did not return the existing resource.
             _logger.LogWarning(
                 "Agent registration returned 409 Conflict but the response body did not include an 'id'. " +
                 "Record the registration ID manually and add it to the generated config as 'agentRegistrationId'.");
-            return null;
+            return (null, false);
         }
 
         if (response.StatusCode == 403)
@@ -1345,7 +1345,7 @@ public class GraphApiService
         else
             _logger.LogError("Agent registration failed with HTTP {StatusCode}. Body: {Body}", response.StatusCode, response.Body);
         response.Json?.Dispose();
-        return null;
+        return (null, false);
     }
 
     /// <summary>
@@ -1377,9 +1377,11 @@ public class GraphApiService
     /// <summary>
     /// Checks whether an existing agent registration is still present by fetching
     /// GET <see cref="AgentRegistrationsPath"/>/{registrationId}.
-    /// Returns true if the registration exists (200 OK), false if it is gone (404) or the call fails.
+    /// Returns true (200 OK), false (404 Not Found), or null (auth/transient error — result unknown).
+    /// Callers must not treat null as "not found"; they should preserve any stored registration ID
+    /// rather than triggering re-registration on an inconclusive result.
     /// </summary>
-    public virtual async Task<bool> AgentRegistrationExistsAsync(
+    public virtual async Task<bool?> AgentRegistrationExistsAsync(
         string tenantId,
         string registrationId,
         CancellationToken ct = default)
@@ -1393,14 +1395,19 @@ public class GraphApiService
 
         try
         {
-            using var doc = await GraphGetAsync(tenantId, path, ct, scopes);
-            return doc != null;
+            var response = await GraphGetWithResponseAsync(tenantId, path, scopes: scopes, ct: ct);
+            response.Json?.Dispose();
+            if (response.IsSuccess) return true;
+            if (response.StatusCode == 404) return false;
+            _logger.LogDebug("Could not verify agent registration {RegistrationId} (HTTP {StatusCode}); treating as unknown.",
+                registrationId, response.StatusCode);
+            return null;
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogDebug(ex, "Could not verify agent registration {RegistrationId} (non-fatal): {Message}",
                 registrationId, ex.Message);
-            return false;
+            return null;
         }
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -1311,6 +1311,32 @@ public class GraphApiService
             return registrationId;
         }
 
+        // 409 Conflict means an agent with the same sourceAgentId already exists.
+        // The contract guarantees sourceAgentId uniqueness, so this is an idempotent re-run.
+        // Extract the existing registration ID from the response body and return it.
+        if (response.StatusCode == 409)
+        {
+            _logger.LogDebug("Agent registration returned 409 Conflict (sourceAgentId already exists). Body: {Body}", response.Body);
+
+            string? existingId = null;
+            if (response.Json != null && response.Json.RootElement.TryGetProperty("id", out var existingIdProp))
+                existingId = existingIdProp.GetString();
+
+            response.Json?.Dispose();
+
+            if (!string.IsNullOrWhiteSpace(existingId))
+            {
+                _logger.LogInformation("Agent already registered (existing ID: {RegistrationId}). Skipping.", existingId);
+                return existingId;
+            }
+
+            // 409 but no ID in the body — server did not return the existing resource.
+            _logger.LogWarning(
+                "Agent registration returned 409 Conflict but the response body did not include an 'id'. " +
+                "Record the registration ID manually and add it to the generated config as 'agentRegistrationId'.");
+            return null;
+        }
+
         if (response.StatusCode == 403)
             _logger.LogError(
                 "Agent registration failed (403 Forbidden). " +
@@ -1346,6 +1372,36 @@ public class GraphApiService
             ct,
             treatNotFoundAsSuccess: true,
             scopes: scopes);
+    }
+
+    /// <summary>
+    /// Checks whether an existing agent registration is still present by fetching
+    /// GET <see cref="AgentRegistrationsPath"/>/{registrationId}.
+    /// Returns true if the registration exists (200 OK), false if it is gone (404) or the call fails.
+    /// </summary>
+    public virtual async Task<bool> AgentRegistrationExistsAsync(
+        string tenantId,
+        string registrationId,
+        CancellationToken ct = default)
+    {
+        IEnumerable<string>? scopes = _tokenProvider != null
+            ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
+            : null;
+
+        var path = $"{AgentRegistrationsPath}/{Uri.EscapeDataString(registrationId)}";
+        _logger.LogDebug("GET https://graph.microsoft.com{Path}", path);
+
+        try
+        {
+            using var doc = await GraphGetAsync(tenantId, path, ct, scopes);
+            return doc != null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not verify agent registration {RegistrationId} (non-fatal): {Message}",
+                registrationId, ex.Message);
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
@@ -449,7 +449,18 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
+
+        // Capture field values at each SaveStateAsync call so we can assert the Step 5 save
+        // happened before Step 6 mutated AgentRegistrationId on the same config object.
+        var savedStates = new List<(string? AgenticAppId, string? AgentRegistrationId)>();
+        ctx.ConfigService
+            .When(s => s.SaveStateAsync(Arg.Any<Agent365Config>(), Arg.Any<string>()))
+            .Do(callInfo =>
+            {
+                var c = callInfo.Arg<Agent365Config>();
+                savedStates.Add((c.AgenticAppId, c.AgentRegistrationId));
+            });
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -457,9 +468,9 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
             because: "the existing agent identity must be reused");
         await graph.DidNotReceive().CreateAgentIdentityDelegatedAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
-        await ctx.ConfigService.Received().SaveStateAsync(
-            Arg.Is<Agent365Config>(c => c.AgenticAppId == "existing-sp-id"),
-            Arg.Any<string>());
+        savedStates.Should().Contain(
+            s => s.AgenticAppId == "existing-sp-id" && s.AgentRegistrationId == null,
+            because: "Step 5 must persist the reused identity ID before Step 6 sets AgentRegistrationId on the same config instance");
     }
 
     /// <summary>
@@ -481,7 +492,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -511,7 +522,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -540,7 +551,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -569,7 +580,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -595,7 +606,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -663,7 +674,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -697,7 +708,7 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
         graph.RegisterAgentInstanceAsyncV2(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
             Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns("new-reg-id");
+            .Returns(("new-reg-id", false));
 
         await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
@@ -705,5 +716,73 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
             because: "the registration was freshly created, not reused");
         await graph.DidNotReceive().AgentRegistrationExistsAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Step 6: When RegisterAgentInstanceAsyncV2 returns an existing ID via 409 Conflict,
+    /// AgentRegistrationAlreadyExisted must be true so the summary shows "reused" not "registered".
+    /// </summary>
+    [Fact]
+    public async Task Step6_SetsAlreadyExistedFlag_When409ConflictReturnedByRegisterApi()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+            // No AgentRegistrationId — simulates a first-time run that hits a 409
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(("conflict-reg-id", true));
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentRegistrationAlreadyExisted.Should().BeTrue(
+            because: "a 409 Conflict means the agent was already registered; the flag must be true so the summary shows 'reused' rather than 'registered'");
+        ctx.Results.AgentInstanceId.Should().Be("conflict-reg-id",
+            because: "the existing registration ID returned via 409 must be recorded");
+        ctx.Results.AgentInstanceRegistered.Should().BeTrue(
+            because: "registration is considered successful even when retrieved via 409");
+    }
+
+    /// <summary>
+    /// Step 6: When AgentRegistrationExistsAsync returns null (auth or transient error),
+    /// the stored registration ID must be preserved and re-registration must not be attempted.
+    /// </summary>
+    [Fact]
+    public async Task Step6_PreservesStoredRegistrationId_WhenVerificationIsInconclusive()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+            AgentRegistrationId = "stored-reg-id",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        graph.AgentRegistrationExistsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((bool?)null);
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentInstanceId.Should().Be("stored-reg-id",
+            because: "when verification is inconclusive the stored ID must be preserved to avoid unintended re-registration");
+        ctx.Results.AgentRegistrationAlreadyExisted.Should().BeTrue(
+            because: "an inconclusive verification is treated as 'assume still exists' to prevent data loss");
+        await graph.DidNotReceive().RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
@@ -363,4 +363,347 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
             Arg.Any<string>(), Arg.Any<string>(),
             Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>());
     }
+
+    // -------------------------------------------------------------------------
+    // Idempotency tests — Steps 5 & 6
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Builds a SetupContext suited for testing the agent identity + registration steps
+    /// (Steps 5–6) via the AgentInstanceOnly path.
+    /// Returns the context, graph service mock, and blueprint service mock so tests can
+    /// configure stub return values.
+    /// </summary>
+    private static (SetupContext ctx, GraphApiService graph, AgentBlueprintService blueprintService)
+        BuildIdempotencyTestContext(Agent365Config? config = null)
+    {
+        var graph = Substitute.ForPartsOf<GraphApiService>();
+
+        // Prevent real HTTP for consent lookup and oauth2 grant lookups.
+        graph.GraphGetAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            .Returns((System.Text.Json.JsonDocument?)null);
+
+        var cfg = config ?? new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+        };
+
+        var mockExecutor = BuildMockExecutor();
+        var configService = Substitute.For<IConfigService>();
+        configService.SaveStateAsync(Arg.Any<Agent365Config>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        var blueprintService = Substitute.ForPartsOf<AgentBlueprintService>(
+            Substitute.For<ILogger<AgentBlueprintService>>(), graph);
+
+        var ctx = new SetupContext(
+            config: cfg,
+            results: new SetupResults(),
+            logger: Substitute.For<ILogger>(),
+            configFile: new FileInfo("a365.config.json"),
+            generatedConfigPath: "a365.generated.config.json",
+            correlationId: "test-correlation-id",
+            skipInfrastructure: true,
+            skipRequirements: true,
+            cancellationToken: CancellationToken.None,
+            configService: configService,
+            executor: mockExecutor,
+            botConfigurator: Substitute.For<IBotConfigurator>(),
+            authValidator: Substitute.For<AzureAuthValidator>(
+                NullLogger<AzureAuthValidator>.Instance, mockExecutor),
+            platformDetector: Substitute.ForPartsOf<PlatformDetector>(
+                Substitute.For<ILogger<PlatformDetector>>()),
+            graphApiService: graph,
+            blueprintService: blueprintService,
+            blueprintLookupService: Substitute.ForPartsOf<BlueprintLookupService>(
+                Substitute.For<ILogger<BlueprintLookupService>>(), graph),
+            federatedCredentialService: Substitute.ForPartsOf<FederatedCredentialService>(
+                Substitute.For<ILogger<FederatedCredentialService>>(), graph),
+            clientAppValidator: Substitute.For<IClientAppValidator>(),
+            agentInstanceOnly: true,
+            loginHintResolver: () => Task.FromResult<string?>(null));
+
+        return (ctx, graph, blueprintService);
+    }
+
+    /// <summary>
+    /// Step 5: When the API lookup finds an existing identity by display name,
+    /// the existing ID must be reused and CreateAgentIdentityDelegatedAsync must NOT be called.
+    /// </summary>
+    [Fact]
+    public async Task Step5_ReuseExistingIdentity_WhenFoundByApiLookup()
+    {
+        var (ctx, graph, blueprintService) = BuildIdempotencyTestContext();
+
+        blueprintService.FindExistingAgentIdentityAsync(
+            "tenant-id", "blueprint-id", "sellakapri211 Identity", Arg.Any<CancellationToken>())
+            .Returns("existing-sp-id");
+
+        // Step 6 must also complete cleanly; stub RegisterAgentInstanceAsyncV2
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentIdentityId.Should().Be("existing-sp-id",
+            because: "the existing agent identity must be reused");
+        await graph.DidNotReceive().CreateAgentIdentityDelegatedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await ctx.ConfigService.Received().SaveStateAsync(
+            Arg.Is<Agent365Config>(c => c.AgenticAppId == "existing-sp-id"),
+            Arg.Any<string>());
+    }
+
+    /// <summary>
+    /// Step 5: When the lookup returns null, CreateAgentIdentityDelegatedAsync must be called.
+    /// </summary>
+    [Fact]
+    public async Task Step5_CreatesNewIdentity_WhenNotFoundByApiLookup()
+    {
+        var (ctx, graph, blueprintService) = BuildIdempotencyTestContext();
+
+        blueprintService.FindExistingAgentIdentityAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+
+        graph.CreateAgentIdentityDelegatedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("new-sp-id");
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentIdentityId.Should().Be("new-sp-id",
+            because: "a new agent identity must be created when no existing one is found");
+        await graph.Received(1).CreateAgentIdentityDelegatedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Step 6: When AgentRegistrationId is not in config, RegisterAgentInstanceAsyncV2 must be called.
+    /// </summary>
+    [Fact]
+    public async Task Step6_RegistersNewAgent_WhenNotInConfig()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentInstanceId.Should().Be("new-reg-id",
+            because: "RegisterAgentInstanceAsyncV2 must be called when no registration ID is in config");
+        await graph.Received(1).RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await graph.DidNotReceive().AgentRegistrationExistsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Step 5: When an existing identity is found by API lookup, AgentIdentityAlreadyExisted
+    /// must be true so the summary shows "reused" rather than "created".
+    /// </summary>
+    [Fact]
+    public async Task Step5_SetsAlreadyExistedFlag_WhenFoundByApiLookup()
+    {
+        var (ctx, graph, blueprintService) = BuildIdempotencyTestContext();
+
+        blueprintService.FindExistingAgentIdentityAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("existing-sp-id");
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentIdentityAlreadyExisted.Should().BeTrue(
+            because: "the identity was found by API lookup, not freshly created");
+    }
+
+    /// <summary>
+    /// Step 5: When AgenticAppId is already in config, AgentIdentityAlreadyExisted must be true
+    /// so the summary shows "reused" rather than "created".
+    /// </summary>
+    [Fact]
+    public async Task Step5_SetsAlreadyExistedFlag_WhenFoundInConfig()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id-from-config",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentIdentityAlreadyExisted.Should().BeTrue(
+            because: "the identity was already recorded in config, not freshly created");
+    }
+
+    /// <summary>
+    /// Step 5: When a new identity is created (lookup returns null), AgentIdentityAlreadyExisted
+    /// must remain false so the summary shows "created".
+    /// </summary>
+    [Fact]
+    public async Task Step5_AlreadyExistedFlag_IsFalse_WhenNewlyCreated()
+    {
+        var (ctx, graph, blueprintService) = BuildIdempotencyTestContext();
+
+        blueprintService.FindExistingAgentIdentityAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((string?)null);
+        graph.CreateAgentIdentityDelegatedAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("new-sp-id");
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentIdentityAlreadyExisted.Should().BeFalse(
+            because: "the identity was freshly created, not reused");
+    }
+
+    /// <summary>
+    /// Step 6: When AgentRegistrationId is in config and the GET confirms it still exists,
+    /// AgentRegistrationAlreadyExisted must be true and RegisterAgentInstanceAsyncV2 must NOT be called.
+    /// </summary>
+    [Fact]
+    public async Task Step6_SetsAlreadyExistedFlag_WhenFoundInConfigAndVerified()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+            AgentRegistrationId = "reg-id-from-config",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        // Verification GET returns true — registration still exists
+        graph.AgentRegistrationExistsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentRegistrationAlreadyExisted.Should().BeTrue(
+            because: "the registration was verified in the registry, not freshly registered");
+        await graph.DidNotReceive().RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Step 6: When AgentRegistrationId is in config but the GET returns false (stale ID),
+    /// a new registration must be created and AgentRegistrationAlreadyExisted must be false.
+    /// </summary>
+    [Fact]
+    public async Task Step6_CreatesNewRegistration_WhenStoredIdIsStale()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+            AgentRegistrationId = "stale-reg-id",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        // Verification GET returns false — stored registration no longer exists
+        graph.AgentRegistrationExistsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentInstanceId.Should().Be("new-reg-id",
+            because: "stale registration must be replaced by a new one");
+        ctx.Results.AgentRegistrationAlreadyExisted.Should().BeFalse(
+            because: "the registration was freshly created after the stored ID was found stale");
+        await graph.Received(1).RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Step 6: When a new registration is created (no ID in config),
+    /// AgentRegistrationAlreadyExisted must remain false so the summary shows "registered".
+    /// </summary>
+    [Fact]
+    public async Task Step6_AlreadyExistedFlag_IsFalse_WhenNewlyRegistered()
+    {
+        var config = new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentBlueprintId = "blueprint-id",
+            AgentIdentityDisplayName = "sellakapri211 Identity",
+            ClientAppId = "client-app-id",
+            AgenticAppId = "agentic-app-id",
+        };
+        var (ctx, graph, _) = BuildIdempotencyTestContext(config);
+
+        graph.RegisterAgentInstanceAsyncV2(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns("new-reg-id");
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        ctx.Results.AgentRegistrationAlreadyExisted.Should().BeFalse(
+            because: "the registration was freshly created, not reused");
+        await graph.DidNotReceive().AgentRegistrationExistsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
@@ -768,6 +768,91 @@ public class AgentBlueprintServiceTests
             result.Should().BeTrue();
         }
     }
+
+    // ── FindExistingAgentIdentityAsync tests ──────────────────────────────────
+
+    /// <summary>
+    /// Returns a partial mock of AgentBlueprintService with GetAgentInstancesForBlueprintAsync
+    /// available for stubbing. The GraphApiService dependency is inert (no HTTP calls expected).
+    /// </summary>
+    private AgentBlueprintService BuildPartialBlueprintService() =>
+        Substitute.ForPartsOf<AgentBlueprintService>(
+            _mockLogger,
+            new GraphApiService(_mockGraphLogger, _mockExecutor,
+                Substitute.For<IAuthenticationService>(),
+                new FakeHttpMessageHandler(),
+                tokenProvider: null));
+
+    [Fact]
+    public async Task FindExistingAgentIdentityAsync_ReturnsSpId_WhenDisplayNameMatches()
+    {
+        var service = BuildPartialBlueprintService();
+        service.GetAgentInstancesForBlueprintAsync("tenant-id", "blueprint-id", Arg.Any<CancellationToken>())
+            .Returns(new List<AgentInstanceInfo>
+            {
+                new() { IdentitySpId = "sp-id-123", DisplayName = "sellakapri211 Identity" }
+            });
+
+        var result = await service.FindExistingAgentIdentityAsync("tenant-id", "blueprint-id", "sellakapri211 Identity");
+
+        result.Should().Be("sp-id-123",
+            because: "the service must return the SP ID of the matching agent identity");
+    }
+
+    [Fact]
+    public async Task FindExistingAgentIdentityAsync_IsCaseInsensitive()
+    {
+        var service = BuildPartialBlueprintService();
+        service.GetAgentInstancesForBlueprintAsync("tenant-id", "blueprint-id", Arg.Any<CancellationToken>())
+            .Returns(new List<AgentInstanceInfo>
+            {
+                new() { IdentitySpId = "sp-id-456", DisplayName = "MY AGENT IDENTITY" }
+            });
+
+        var result = await service.FindExistingAgentIdentityAsync("tenant-id", "blueprint-id", "my agent identity");
+
+        result.Should().Be("sp-id-456",
+            because: "display name matching must be case-insensitive");
+    }
+
+    [Fact]
+    public async Task FindExistingAgentIdentityAsync_ReturnsNull_WhenNoMatch()
+    {
+        var service = BuildPartialBlueprintService();
+        service.GetAgentInstancesForBlueprintAsync("tenant-id", "blueprint-id", Arg.Any<CancellationToken>())
+            .Returns(new List<AgentInstanceInfo>
+            {
+                new() { IdentitySpId = "sp-id-999", DisplayName = "Some Other Agent Identity" }
+            });
+
+        var result = await service.FindExistingAgentIdentityAsync("tenant-id", "blueprint-id", "sellakapri211 Identity");
+
+        result.Should().BeNull(because: "no entry matches the requested display name");
+    }
+
+    [Fact]
+    public async Task FindExistingAgentIdentityAsync_ReturnsNull_WhenListIsEmpty()
+    {
+        var service = BuildPartialBlueprintService();
+        service.GetAgentInstancesForBlueprintAsync("tenant-id", "blueprint-id", Arg.Any<CancellationToken>())
+            .Returns(new List<AgentInstanceInfo>());
+
+        var result = await service.FindExistingAgentIdentityAsync("tenant-id", "blueprint-id", "sellakapri211 Identity");
+
+        result.Should().BeNull(because: "an empty list means no agent identities exist for the blueprint");
+    }
+
+    [Fact]
+    public async Task FindExistingAgentIdentityAsync_ReturnsNull_WhenLookupThrows()
+    {
+        var service = BuildPartialBlueprintService();
+        service.GetAgentInstancesForBlueprintAsync("tenant-id", "blueprint-id", Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<AgentInstanceInfo>>(_ => throw new InvalidOperationException("Network error"));
+
+        var result = await service.FindExistingAgentIdentityAsync("tenant-id", "blueprint-id", "sellakapri211 Identity");
+
+        result.Should().BeNull(because: "exceptions from the underlying query must be swallowed non-fatally");
+    }
 }
 
 // Simple fake handler that returns queued responses sequentially

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceRegisterAgentInstanceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceRegisterAgentInstanceTests.cs
@@ -285,8 +285,10 @@ public class GraphApiServiceRegisterAgentInstanceTests
             agentIdentityId: "agent-identity-id",
             clientAppId: null);
 
-        result.Should().Be("existing-reg-id-409",
+        result.Id.Should().Be("existing-reg-id-409",
             because: "409 Conflict means the agent is already registered; the existing ID in the body must be returned");
+        result.AlreadyExisted.Should().BeTrue(
+            because: "a 409 Conflict signals the registration pre-existed; the orchestrator uses this to show 'reused' in the summary");
     }
 
     /// <summary>
@@ -318,8 +320,10 @@ public class GraphApiServiceRegisterAgentInstanceTests
             agentIdentityId: "agent-identity-id",
             clientAppId: null);
 
-        result.Should().BeNull(
+        result.Id.Should().BeNull(
             because: "when 409 body contains no id, the existing registration ID cannot be determined");
+        result.AlreadyExisted.Should().BeFalse(
+            because: "without an ID in the 409 response body the registration cannot be confirmed as pre-existing");
     }
 
     [Fact]
@@ -355,7 +359,7 @@ public class GraphApiServiceRegisterAgentInstanceTests
     }
 
     [Fact]
-    public async Task AgentRegistrationExistsAsync_ReturnsFalse_WhenGetFails()
+    public async Task AgentRegistrationExistsAsync_ReturnsNull_WhenGetFailsWithNon404()
     {
         using var handler = new TestHttpMessageHandler();
 
@@ -367,7 +371,8 @@ public class GraphApiServiceRegisterAgentInstanceTests
         var service = BuildService(handler);
         var result = await service.AgentRegistrationExistsAsync("tenant-id", "reg-id-abc");
 
-        result.Should().BeFalse(because: "a failed GET should return false without throwing");
+        result.Should().BeNull(
+            because: "a non-404 HTTP failure (e.g. 403) means the check is inconclusive — the registration may still exist");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceRegisterAgentInstanceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceRegisterAgentInstanceTests.cs
@@ -254,4 +254,144 @@ public class GraphApiServiceRegisterAgentInstanceTests
         capturedRequest!.RequestUri!.ToString()
             .Should().Contain("/beta/agentRegistry/agentInstances");
     }
+
+    /// <summary>
+    /// 409 Conflict means sourceAgentId already exists. When the body contains an "id",
+    /// RegisterAgentInstanceAsyncV2 must return that ID (idempotent re-run).
+    /// </summary>
+    [Fact]
+    public async Task RegisterAgentInstanceAsyncV2_ReturnsExistingId_On409Conflict()
+    {
+        using var handler = new TestHttpMessageHandler();
+
+        // GET /v1.0/me — needed to resolve current user ID
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new System.Net.Http.StringContent(JsonSerializer.Serialize(new { id = "user-id" }))
+        });
+
+        // POST returns 409 with the existing registration ID in the body
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new System.Net.Http.StringContent(JsonSerializer.Serialize(new { id = "existing-reg-id-409" }))
+        });
+
+        var service = BuildService(handler);
+        var result = await service.RegisterAgentInstanceAsyncV2(
+            tenantId: "tenant-id",
+            displayName: "My Agent",
+            description: null,
+            blueprintId: "blueprint-id",
+            agentIdentityId: "agent-identity-id",
+            clientAppId: null);
+
+        result.Should().Be("existing-reg-id-409",
+            because: "409 Conflict means the agent is already registered; the existing ID in the body must be returned");
+    }
+
+    /// <summary>
+    /// When 409 response body has no "id", RegisterAgentInstanceAsyncV2 returns null
+    /// (caller cannot infer the existing registration ID).
+    /// </summary>
+    [Fact]
+    public async Task RegisterAgentInstanceAsyncV2_ReturnsNull_On409WithoutId()
+    {
+        using var handler = new TestHttpMessageHandler();
+
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new System.Net.Http.StringContent(JsonSerializer.Serialize(new { id = "user-id" }))
+        });
+
+        // 409 but no "id" in body
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.Conflict)
+        {
+            Content = new System.Net.Http.StringContent("{\"error\":{\"message\":\"Agent with same sourceAgentId already exists\"}}")
+        });
+
+        var service = BuildService(handler);
+        var result = await service.RegisterAgentInstanceAsyncV2(
+            tenantId: "tenant-id",
+            displayName: "My Agent",
+            description: null,
+            blueprintId: "blueprint-id",
+            agentIdentityId: "agent-identity-id",
+            clientAppId: null);
+
+        result.Should().BeNull(
+            because: "when 409 body contains no id, the existing registration ID cannot be determined");
+    }
+
+    [Fact]
+    public async Task AgentRegistrationExistsAsync_ReturnsTrue_WhenGetSucceeds()
+    {
+        using var handler = new TestHttpMessageHandler();
+
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new System.Net.Http.StringContent(JsonSerializer.Serialize(new { id = "reg-id-123", displayName = "My Agent" }))
+        });
+
+        var service = BuildService(handler);
+        var result = await service.AgentRegistrationExistsAsync("tenant-id", "reg-id-123");
+
+        result.Should().BeTrue(because: "a 200 OK response means the registration exists");
+    }
+
+    [Fact]
+    public async Task AgentRegistrationExistsAsync_ReturnsFalse_WhenRegistrationNotFound()
+    {
+        using var handler = new TestHttpMessageHandler();
+
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.NotFound)
+        {
+            Content = new System.Net.Http.StringContent("{\"error\":{\"message\":\"Not found\"}}")
+        });
+
+        var service = BuildService(handler);
+        var result = await service.AgentRegistrationExistsAsync("tenant-id", "reg-id-deleted");
+
+        result.Should().BeFalse(because: "a 404 means the registration no longer exists");
+    }
+
+    [Fact]
+    public async Task AgentRegistrationExistsAsync_ReturnsFalse_WhenGetFails()
+    {
+        using var handler = new TestHttpMessageHandler();
+
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new System.Net.Http.StringContent("{\"error\":{\"message\":\"Forbidden\"}}")
+        });
+
+        var service = BuildService(handler);
+        var result = await service.AgentRegistrationExistsAsync("tenant-id", "reg-id-abc");
+
+        result.Should().BeFalse(because: "a failed GET should return false without throwing");
+    }
+
+    [Fact]
+    public async Task AgentRegistrationExistsAsync_RequestsCorrectPath()
+    {
+        System.Net.Http.HttpRequestMessage? capturedRequest = null;
+
+        using var handler = new CapturingHttpMessageHandler(req =>
+        {
+            if (req.Method == System.Net.Http.HttpMethod.Get)
+                capturedRequest = req;
+        });
+
+        handler.QueueResponse(new System.Net.Http.HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new System.Net.Http.StringContent(JsonSerializer.Serialize(new { id = "my-reg-id" }))
+        });
+
+        var service = BuildService(handler);
+        await service.AgentRegistrationExistsAsync("tenant-id", "my-reg-id");
+
+        capturedRequest.Should().NotBeNull();
+        capturedRequest!.RequestUri!.ToString()
+            .Should().Contain("/copilot/agentRegistrations/my-reg-id",
+                because: "the request must target the registration by ID, not as a collection query");
+    }
 }


### PR DESCRIPTION
Enhance non-DW blueprint setup to be idempotent for agent identity and registration steps.
- Check for existing agent identity and registration before creating new ones, reusing if found.
- Add flags to results to indicate whether resources were reused or created.
- Handle 409 Conflict in agent registration API to support idempotent re-runs.
- Update setup summary to show "reused" vs "created/registered".
- Add comprehensive unit tests for all idempotency scenarios.
- Refactor orchestrator logic for clarity and robustness.