### PR TITLE
build: produce separate portable PDB files

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -45,7 +45,7 @@
     <!-- Source Link Support -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <DebugType>embedded</DebugType>
+    <DebugType>portable</DebugType>
     
     <!-- Suppress common NuGet warnings -->
     <NoWarn>$(NoWarn);NU1608;NU5128</NoWarn>


### PR DESCRIPTION
Change DebugType from embedded to portable in Directory.Build.props so that separate .pdb files are generated alongside assemblies during build.