### PR TITLE
feat: add redirect URIs and remove unused config option

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -850,9 +850,6 @@ public static class DevelopMcpCommand
         var serviceTreeIdOption = new Option<string?>("--service-tree-id", description: "ServiceTree ID for Entra app registration (required in Microsoft corporate tenants)");
         command.AddOption(serviceTreeIdOption);
 
-        var configOption = new Option<string>(["-c", "--config"], getDefaultValue: () => "a365.config.json", description: "Configuration file path");
-        command.AddOption(configOption);
-
         var publisherOption = new Option<string?>("--publisher", description: "Publisher name (required, used in MOS package metadata)");
         command.AddOption(publisherOption);
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -143,7 +143,7 @@ internal class RegisterCommandExecutor
         {
             _logger.LogError("Failed to register MCP server '{ServerName}': {Error}", input.ServerName, ex.Message);
             _logger.LogDebug("Exception details: {Exception}", ex.ToString());
-            _logger.LogWarning("Entra app registrations were NOT rolled back. Use 'cleanup-external-mcp-server-resources' to remove them if needed.");
+            _logger.LogWarning("Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
             return;
         }
 
@@ -166,7 +166,7 @@ internal class RegisterCommandExecutor
                 _logger.LogError("Failed to add MCP server {ServerName}: {Error}", input.ServerName, errorMsg);
             }
 
-            Console.WriteLine($"Entra app registrations were NOT rolled back. Use 'cleanup-external-mcp-server-resources' to remove them if needed.");
+            Console.WriteLine($"Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
             return;
         }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -155,7 +155,10 @@ internal class RegisterCommandExecutor
                 || errorMsg.Contains("delete the existing record", StringComparison.OrdinalIgnoreCase))
             {
                 Console.WriteLine();
+                var prevColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine($"ERROR: A server named '{input.ServerName}' already exists. Please choose a different name.");
+                Console.ForegroundColor = prevColor;
                 _logger.LogDebug("Raw server error: {Error}", errorMsg);
             }
             else

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -143,15 +143,27 @@ internal class RegisterCommandExecutor
         {
             _logger.LogError("Failed to register MCP server '{ServerName}': {Error}", input.ServerName, ex.Message);
             _logger.LogDebug("Exception details: {Exception}", ex.ToString());
-            _logger.LogWarning("Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
+            _logger.LogWarning("Entra app registrations were NOT rolled back. Use 'cleanup-external-mcp-server-resources' to remove them if needed.");
             return;
         }
 
         if (addResponse is null || !addResponse.IsSuccess)
         {
             var errorMsg = addResponse?.Message ?? "No response received";
-            _logger.LogError("Failed to add MCP server {ServerName}: {Error}", input.ServerName, errorMsg);
-            _logger.LogWarning("Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
+
+            if (errorMsg.Contains("violates a database constraint", StringComparison.OrdinalIgnoreCase)
+                || errorMsg.Contains("delete the existing record", StringComparison.OrdinalIgnoreCase))
+            {
+                Console.WriteLine();
+                Console.WriteLine($"ERROR: A server named '{input.ServerName}' already exists. Please choose a different name.");
+                _logger.LogDebug("Raw server error: {Error}", errorMsg);
+            }
+            else
+            {
+                _logger.LogError("Failed to add MCP server {ServerName}: {Error}", input.ServerName, errorMsg);
+            }
+
+            Console.WriteLine($"Entra app registrations were NOT rolled back. Use 'cleanup-external-mcp-server-resources' to remove them if needed.");
             return;
         }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -159,6 +159,7 @@ internal class RegisterCommandExecutor
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.WriteLine($"ERROR: A server named '{input.ServerName}' already exists. Please choose a different name.");
                 Console.ForegroundColor = prevColor;
+                _logger.LogError("A server named '{ServerName}' already exists. Please choose a different name.", input.ServerName);
                 _logger.LogDebug("Raw server error: {Error}", errorMsg);
             }
             else

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -617,7 +617,7 @@ internal class RegisterCommandExecutor
             var copilotRedirectUri = $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{publicClientsClientId}";
             try
             {
-                await _graphApiService.UpdateAppPublicClientRedirectUrisAsync(tenantId, publicClientsObjectId, new[] { copilotRedirectUri, "http://localhost:8080/callback" });
+                await _graphApiService.UpdateAppPublicClientRedirectUrisAsync(tenantId, publicClientsObjectId, new[] { copilotRedirectUri, "http://localhost:8080/callback", "https://vscode.dev/redirect", "http://localhost" });
                 _logger.LogDebug("Set redirect URI on '{AppName}' ({ObjectId}): {Uri}", publicClientsAppName, publicClientsObjectId, copilotRedirectUri);
             }
             catch (Exception ex)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -167,6 +167,7 @@ internal class RegisterCommandExecutor
                 _logger.LogError("Failed to add MCP server {ServerName}: {Error}", input.ServerName, errorMsg);
             }
 
+            _logger.LogWarning("Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
             Console.WriteLine($"Entra app registrations were NOT rolled back. Delete them manually in the Azure portal if needed.");
             return;
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -100,7 +100,7 @@ public class Agent365ToolingService : IAgent365ToolingService
                     _logger.LogDebug("{Operation} failed: {Message}", operationName, errorMessage);
                     if (!string.IsNullOrWhiteSpace(serverCorrelationId))
                     {
-                        _logger.LogDebug("Server correlation ID (x-ms-correlation-id): {CorrelationId}", serverCorrelationId);
+                        _logger.LogWarning("Server correlation ID (x-ms-correlation-id): {CorrelationId}", serverCorrelationId);
                     }
                     return (false, responseContent);
                 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -97,10 +97,10 @@ public class Agent365ToolingService : IAgent365ToolingService
                         errorMessage += $" - {statusResponse.Error}";
                     }
                     
-                    _logger.LogError("{Operation} failed: {Message}", operationName, errorMessage);
+                    _logger.LogDebug("{Operation} failed: {Message}", operationName, errorMessage);
                     if (!string.IsNullOrWhiteSpace(serverCorrelationId))
                     {
-                        _logger.LogError("Server correlation ID (x-ms-correlation-id): {CorrelationId}", serverCorrelationId);
+                        _logger.LogDebug("Server correlation ID (x-ms-correlation-id): {CorrelationId}", serverCorrelationId);
                     }
                     return (false, responseContent);
                 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
@@ -249,20 +249,6 @@ public class DevelopMcpCommandTests
         }
     }
 
-    [Theory]
-    [InlineData("register-external-mcp-server")]
-    public void ConfigDependentSubcommands_SupportConfigOption(string subcommandName)
-    {
-        // Act
-        var command = DevelopMcpCommand.CreateCommand(_mockLogger, _mockToolingService);
-        var subcommand = command.Subcommands.First(sc => sc.Name == subcommandName);
-
-        // Assert
-        var configOption = subcommand.Options.FirstOrDefault(o => o.Name == "config");
-        configOption.Should().NotBeNull($"Subcommand '{subcommandName}' should have --config option");
-        configOption!.Aliases.Should().Contain("-c", $"Config option should have -c alias in '{subcommandName}'");
-    }
-
     [Fact]
     public void RegisterExternalMcpServerSubcommand_HasAllExpectedOptions()
     {
@@ -291,7 +277,6 @@ public class DevelopMcpCommandTests
         optionNames.Should().Contain("remote-scopes");
         optionNames.Should().Contain("tenant-id");
         optionNames.Should().Contain("service-tree-id");
-        optionNames.Should().Contain("config");
         optionNames.Should().Contain("publisher");
         optionNames.Should().Contain("description");
         optionNames.Should().Contain("dry-run");
@@ -313,9 +298,6 @@ public class DevelopMcpCommandTests
 
         var tenantIdOption = options.First(o => o.Name == "tenant-id");
         tenantIdOption.Aliases.Should().Contain("-t");
-
-        var configOption = options.First(o => o.Name == "config");
-        configOption.Aliases.Should().Contain("-c");
 
         var verboseOption = options.First(o => o.Name == "verbose");
         verboseOption.Aliases.Should().Contain("-v");

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
@@ -281,6 +281,7 @@ public class DevelopMcpCommandTests
         optionNames.Should().Contain("description");
         optionNames.Should().Contain("dry-run");
         optionNames.Should().Contain("verbose");
+        optionNames.Should().NotContain("config");
 
         // Verify critical aliases
         var serverNameOption = options.First(o => o.Name == "server-name");


### PR DESCRIPTION
## Summary
- Add `https://vscode.dev/redirect` and `http://localhost` redirect URIs to the PublicClients Entra app during `register-external-mcp-server`
- Remove unused `--config` / `-c` option from `register-external-mcp-server` command (was never wired to anything, cluttered `--help` output)

## Test plan
- [x] Build passes with 0 warnings
- [x] All 1344 tests pass
- [ ] Run `a365 develop-mcp register-external-mcp-server --help` and verify `--config` no longer appears
- [ ] Register a new server and verify the PublicClients app has all 4 redirect URIs in Azure Portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)