### PR TITLE
Improve agent registration reliability and UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 ### Fixed
 - `setup all --agent-name` re-runs no longer create a duplicate agent registration: the CLI now reads `agentRegistrationId` from `a365.generated.config.json` (when present) and checks for an existing registration before posting a new one.
 - `setup all` now skips agent registration with a clear warning when the agent identity ID is not available, instead of silently sending an invalid request. Retry with `a365 setup all --agent-registration-only` once the identity is ready.
+- `setup all --agent-registration-only` reliability fixes: stored IDs are now correctly read in bootstrap (`--agent-name`) mode; falls back to a Graph API lookup when `agenticAppId` is missing; skips identity, permission, and project-settings steps that don't apply.
 
 ### Removed
 - `a365 config` command family (`config init`, `config display`, `config permissions`) — replaced by `a365 setup all --agent-name` and `a365 setup permissions custom`.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
@@ -258,25 +258,29 @@ internal static class AllSubcommand
                                 await WriteBootstrapConfigFileAsync(nonDwConfig, config.FullName, logger);
                         }
 
-                        // Merge AgentRegistrationId from the existing generated config (if present) so
-                        // re-running with --agent-name does not create a duplicate registration. Blueprint
-                        // and identity are found by display name, but registration has no lookup endpoint —
-                        // the stored ID is the only idempotency key available for the registration step.
+                        // Merge stored IDs from the existing generated config (if present) so re-running
+                        // with --agent-name reuses previously created resources. Registration has no
+                        // lookup endpoint so the stored ID is the only idempotency key; blueprint and
+                        // identity IDs are needed for the --agent-registration-only API fallback.
                         var bootstrapGenPath = Path.Combine(
                             config.DirectoryName ?? Environment.CurrentDirectory,
                             "a365.generated.config.json");
-                        if (File.Exists(bootstrapGenPath) && string.IsNullOrWhiteSpace(nonDwConfig.AgentRegistrationId))
+                        if (File.Exists(bootstrapGenPath))
                         {
                             try
                             {
                                 var genConfig = await configService.LoadAsync(config.FullName, bootstrapGenPath);
-                                if (!string.IsNullOrWhiteSpace(genConfig.AgentRegistrationId))
+                                if (!string.IsNullOrWhiteSpace(genConfig.AgentRegistrationId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentRegistrationId))
                                     nonDwConfig.AgentRegistrationId = genConfig.AgentRegistrationId;
+                                if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintId))
+                                    nonDwConfig.AgentBlueprintId = genConfig.AgentBlueprintId;
+                                if (!string.IsNullOrWhiteSpace(genConfig.AgenticAppId) && string.IsNullOrWhiteSpace(nonDwConfig.AgenticAppId))
+                                    nonDwConfig.AgenticAppId = genConfig.AgenticAppId;
                             }
                             catch (OperationCanceledException) { throw; }
                             catch (Exception ex)
                             {
-                                logger.LogDebug(ex, "Could not merge generated config in bootstrap mode; proceeding without stored registration ID.");
+                                logger.LogDebug(ex, "Could not merge generated config in bootstrap mode; proceeding without stored IDs.");
                             }
                         }
                     }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -1321,7 +1321,7 @@ internal static class BlueprintSubcommand
                 objectId,
                 userObjectId: null,
                 ct,
-                scopes: AuthenticationConstants.RequiredClientAppPermissions);
+                scopes: AuthenticationConstants.BlueprintOperationScopes);
 
             if (isOwner)
             {
@@ -1518,7 +1518,7 @@ internal static class BlueprintSubcommand
         {
             using var appDoc = await graphApiService.GraphGetAsync(
                 tenantId, $"/v1.0/applications/{objectId}?$select=api", ct,
-                scopes: AuthenticationConstants.RequiredClientAppPermissions);
+                scopes: AuthenticationConstants.BlueprintOperationScopes);
 
             var existingScopes = new JsonArray();
 
@@ -1562,7 +1562,7 @@ internal static class BlueprintSubcommand
 
             var patched = await graphApiService.GraphPatchAsync(
                 tenantId, $"/v1.0/applications/{objectId}", patch, ct,
-                scopes: AuthenticationConstants.RequiredClientAppPermissions);
+                scopes: AuthenticationConstants.BlueprintOperationScopes);
 
             if (patched)
                 logger.LogInformation("{Scope} scope added to blueprint", ConfigConstants.BlueprintOboScope);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
@@ -248,17 +248,49 @@ internal static class NonDwBlueprintSetupOrchestrator
             {
                 ctx.Logger.LogInformation("NOTE: --agent-registration-only flag set. Skipping requirements, blueprint, and permissions steps.");
                 ctx.Logger.LogInformation("");
-                // Populate results so the summary shows previous steps as already completed
-                ctx.Results.BlueprintCreated = true;
-                ctx.Results.BlueprintAlreadyExisted = true;
-                ctx.Results.BlueprintId = ctx.Config.AgentBlueprintId;
-                ctx.Results.BlueprintDisplayName = ctx.Config.AgentBlueprintDisplayName;
-                ctx.Results.BatchPermissionsPhase2Completed = true;
-                ctx.Results.AdminConsentGranted = true;
-                // Still check and prompt for consent even when skipping other steps — consent
-                // is required for the registration call and may have been missed in a prior run.
-                await EnsureConsentWithPromptAsync(ctx);
-                await ExecuteAgentIdentityAndRegistrationAsync(ctx, specs);
+                ctx.Results.PrerequisitesSkipped = true;
+                ctx.Results.BatchPermissionsPhase1Completed = true;
+                ctx.Results.PermissionGrantsSkipped = true;
+
+                // Fallback: if AgenticAppId is missing, try to find it via API using blueprint ID + display name.
+                if (string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
+                {
+                    if (!string.IsNullOrWhiteSpace(ctx.Config.AgentBlueprintId))
+                    {
+                        var identityDisplayName = ctx.Config.AgentIdentityDisplayName ?? "Agent";
+                        ctx.Logger.LogInformation("Agent identity ID not in config. Querying by display name '{Name}'...", identityDisplayName);
+                        var foundId = await ctx.BlueprintService.FindExistingAgentIdentityAsync(
+                            ctx.Config.TenantId!,
+                            ctx.Config.AgentBlueprintId!,
+                            identityDisplayName,
+                            ctx.CancellationToken);
+                        if (!string.IsNullOrWhiteSpace(foundId))
+                        {
+                            ctx.Config.AgenticAppId = foundId;
+                            await ctx.ConfigService.SaveStateAsync(ctx.Config);
+                            ctx.Logger.LogInformation("Found agent identity (ID: {Id}). Using it for registration.", foundId);
+                        }
+                    }
+                }
+
+                if (string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
+                {
+                    ctx.Logger.LogError("Agent identity ID is not set in config. Run 'a365 setup all' first to create the agent identity, then retry with --agent-registration-only.");
+                    ctx.Results.AgentIdentityFailed = true;
+                    ctx.Results.AgentRegistrationFailed = true;
+                    ctx.Results.Errors.Add("Agent identity ID not found in config. Run 'a365 setup all' (without --agent-registration-only) to create it first.");
+                }
+                else
+                {
+                    ctx.Results.AgentIdentityCreated = true;
+                    ctx.Results.AgentIdentityAlreadyExisted = true;
+                    ctx.Results.AgentIdentityId = ctx.Config.AgenticAppId;
+                    ctx.Results.AgentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName;
+                    ctx.Results.BlueprintId = ctx.Config.AgentBlueprintId;
+                    // Consent check required — AgentRegistration.ReadWrite.All must be consented for the registration token.
+                    await EnsureConsentWithPromptAsync(ctx);
+                    await ExecuteAgentIdentityAndRegistrationAsync(ctx, specs, skipIdentityAndPermissions: true);
+                }
             }
             else
             {
@@ -349,88 +381,95 @@ internal static class NonDwBlueprintSetupOrchestrator
     /// Executes Steps 5-8: agent identity creation, permission grants, agent registration,
     /// and project settings sync. Called from both the normal path and the --agent-registration-only
     /// shortcut path.
+    /// When <paramref name="skipIdentityAndPermissions"/> is true (--agent-registration-only),
+    /// identity creation and permission grants are skipped — only registration and project settings run.
     /// </summary>
     private static async Task ExecuteAgentIdentityAndRegistrationAsync(
         SetupContext ctx,
-        List<ResourcePermissionSpec> specs)
+        List<ResourcePermissionSpec> specs,
+        bool skipIdentityAndPermissions = false)
     {
         // Step 5: Create Agent Identity via Agent Identity Graph API.
-        ctx.Logger.LogInformation("");
-
-        if (!string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
+        // Skipped when --agent-registration-only: identity result flags are pre-set by the caller.
+        if (!skipIdentityAndPermissions)
         {
-            ctx.Logger.LogInformation("Agent identity already created (ID: {AgentId}). Skipping.", ctx.Config.AgenticAppId);
-            ctx.Results.AgentIdentityCreated = true;
-            ctx.Results.AgentIdentityAlreadyExisted = true;
-            ctx.Results.AgentIdentityId = ctx.Config.AgenticAppId;
-            ctx.Results.AgentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName;
-        }
-        else
-        {
-            var agentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName
-                ?? "Agent";
+            ctx.Logger.LogInformation("");
 
-            // API-level idempotency: check if an identity with this display name already exists
-            // for the blueprint. Handles re-runs where the generated config was cleared.
-            var existingIdentityId = await ctx.BlueprintService.FindExistingAgentIdentityAsync(
-                ctx.Config.TenantId!,
-                ctx.Config.AgentBlueprintId!,
-                agentIdentityDisplayName,
-                ctx.CancellationToken);
-
-            if (!string.IsNullOrWhiteSpace(existingIdentityId))
+            if (!string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
             {
-                ctx.Logger.LogInformation("Found existing agent identity (ID: {AgentId}). Skipping creation.", existingIdentityId);
-                ctx.Config.AgenticAppId = existingIdentityId;
-                await ctx.ConfigService.SaveStateAsync(ctx.Config);
+                ctx.Logger.LogInformation("Agent identity already created (ID: {AgentId}). Skipping.", ctx.Config.AgenticAppId);
                 ctx.Results.AgentIdentityCreated = true;
                 ctx.Results.AgentIdentityAlreadyExisted = true;
-                ctx.Results.AgentIdentityId = existingIdentityId;
-                ctx.Results.AgentIdentityDisplayName = agentIdentityDisplayName;
+                ctx.Results.AgentIdentityId = ctx.Config.AgenticAppId;
+                ctx.Results.AgentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName;
             }
             else
             {
-                // Agent identity creation via delegated flow (AgentIdentity.Create.All).
-                // Agent ID Developer role is sufficient — client credentials are not required.
-                ctx.Logger.LogInformation("Creating agent identity...");
-                var agentId = await ctx.GraphApiService.CreateAgentIdentityDelegatedAsync(
+                var agentIdentityDisplayName = ctx.Config.AgentIdentityDisplayName
+                    ?? "Agent";
+
+                // API-level idempotency: check if an identity with this display name already exists
+                // for the blueprint. Handles re-runs where the generated config was cleared.
+                var existingIdentityId = await ctx.BlueprintService.FindExistingAgentIdentityAsync(
                     ctx.Config.TenantId!,
                     ctx.Config.AgentBlueprintId!,
                     agentIdentityDisplayName,
                     ctx.CancellationToken);
 
-                if (agentId is not null)
+                if (!string.IsNullOrWhiteSpace(existingIdentityId))
                 {
-                    ctx.Config.AgenticAppId = agentId;
+                    ctx.Logger.LogInformation("Found existing agent identity (ID: {AgentId}). Skipping creation.", existingIdentityId);
+                    ctx.Config.AgenticAppId = existingIdentityId;
                     await ctx.ConfigService.SaveStateAsync(ctx.Config);
                     ctx.Results.AgentIdentityCreated = true;
-                    ctx.Results.AgentIdentityId = agentId;
+                    ctx.Results.AgentIdentityAlreadyExisted = true;
+                    ctx.Results.AgentIdentityId = existingIdentityId;
                     ctx.Results.AgentIdentityDisplayName = agentIdentityDisplayName;
-                    using (ctx.Logger.Indent())
-                        ctx.Logger.LogInformation("Agent identity created (ID: {AgentId})", agentId);
-                    ctx.Logger.LogInformation("");
                 }
-                else if (!ctx.Results.AgentIdentityFailed)
+                else
                 {
-                    ctx.Results.AgentIdentityFailed = true;
-                    ctx.Results.Warnings.Add("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
-                    ctx.Logger.LogWarning("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                    // Agent identity creation via delegated flow (AgentIdentity.Create.All).
+                    // Agent ID Developer role is sufficient — client credentials are not required.
+                    ctx.Logger.LogInformation("Creating agent identity...");
+                    var agentId = await ctx.GraphApiService.CreateAgentIdentityDelegatedAsync(
+                        ctx.Config.TenantId!,
+                        ctx.Config.AgentBlueprintId!,
+                        agentIdentityDisplayName,
+                        ctx.CancellationToken);
+
+                    if (agentId is not null)
+                    {
+                        ctx.Config.AgenticAppId = agentId;
+                        await ctx.ConfigService.SaveStateAsync(ctx.Config);
+                        ctx.Results.AgentIdentityCreated = true;
+                        ctx.Results.AgentIdentityId = agentId;
+                        ctx.Results.AgentIdentityDisplayName = agentIdentityDisplayName;
+                        using (ctx.Logger.Indent())
+                            ctx.Logger.LogInformation("Agent identity created (ID: {AgentId})", agentId);
+                        ctx.Logger.LogInformation("");
+                    }
+                    else if (!ctx.Results.AgentIdentityFailed)
+                    {
+                        ctx.Results.AgentIdentityFailed = true;
+                        ctx.Results.Warnings.Add("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                        ctx.Logger.LogWarning("Agent identity creation failed. Ensure you have the Agent ID Developer or Agent ID Administrator role in this tenant.");
+                    }
                 }
             }
-        }
 
-        // Step 5a: Grant permissions to the agent identity, gated by authMode.
-        if (!string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
-        {
-            ctx.Results.EffectiveAuthMode = ctx.IsBothMode ? "both" : ctx.IsS2sMode ? "s2s" : "obo";
+            // Step 5a: Grant permissions to the agent identity, gated by authMode.
+            if (!string.IsNullOrWhiteSpace(ctx.Config.AgenticAppId))
+            {
+                ctx.Results.EffectiveAuthMode = ctx.IsBothMode ? "both" : ctx.IsS2sMode ? "s2s" : "obo";
 
-            // OBO and Both: principal-scoped delegated grants (no admin required).
-            if (ctx.IsOboMode || ctx.IsBothMode)
-                await GrantAgentIdentityPermissionsAsync(ctx, specs);
+                // OBO and Both: principal-scoped delegated grants (no admin required).
+                if (ctx.IsOboMode || ctx.IsBothMode)
+                    await GrantAgentIdentityPermissionsAsync(ctx, specs);
 
-            // S2S and Both: app role assignments (requires Global Admin; falls back to PowerShell instructions).
-            if (ctx.IsS2sMode || ctx.IsBothMode)
-                await GrantOrInstructAgentIdentityAppPermissionsAsync(ctx, specs);
+                // S2S and Both: app role assignments (requires Global Admin; falls back to PowerShell instructions).
+                if (ctx.IsS2sMode || ctx.IsBothMode)
+                    await GrantOrInstructAgentIdentityAppPermissionsAsync(ctx, specs);
+            }
         }
 
         // Step 6: Register agent via Graph API (copilot/agentRegistrations).
@@ -537,17 +576,21 @@ internal static class NonDwBlueprintSetupOrchestrator
         } // end else (AgenticAppId present)
 
         // Step 6.5: Messaging endpoint registration — --m365 gated; no-op for non-M365 agents.
-        await AllSubcommand.ExecuteMessagingEndpointStepAsync(ctx);
+        // Skipped for --agent-registration-only (skipIdentityAndPermissions) — endpoint is already registered.
+        if (!skipIdentityAndPermissions)
+            await AllSubcommand.ExecuteMessagingEndpointStepAsync(ctx);
 
-        // Sync all settings (ServiceConnection, TokenValidation, Agent365Observability) to the app config file.
-        ctx.Logger.LogInformation("Updating project settings...");
-        using (ctx.Logger.Indent())
+        // Sync project settings — skipped for --agent-registration-only; the user's intent is purely
+        // to register the agent, not to regenerate appsettings files.
+        if (!skipIdentityAndPermissions)
         {
-            // Pass ctx.Config directly so AgentDescription and AgentIdentityDisplayName
-            // derived from --agent-name are written rather than stale values from disk.
-            ctx.Results.ProjectSettingsWritten = await ProjectSettingsSyncHelper.ExecuteAsync(
-                ctx.ConfigFile.FullName, ctx.Config,
-                ctx.PlatformDetector, ctx.Logger);
+            ctx.Logger.LogInformation("Updating project settings...");
+            using (ctx.Logger.Indent())
+            {
+                ctx.Results.ProjectSettingsWritten = await ProjectSettingsSyncHelper.ExecuteAsync(
+                    ctx.ConfigFile.FullName, ctx.Config,
+                    ctx.PlatformDetector, ctx.Logger);
+            }
         }
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -464,6 +464,29 @@ internal static class SetupHelpers
         var pendingS2SAction = permissionGrantsPending && isS2SFlow;
         var pendingDelegatedAction = results.AgentIdentityDelegatedGrantPending;
 
+        if (results.PermissionGrantsSkipped && isNonDw)
+        {
+            // --agent-registration-only: single focused block showing only the registration outcome.
+            if (results.AgentIdentityFailed)
+            {
+                logger.LogWarning(DryRunRow("  Agent Registration") + "not attempted — agent identity not found (run 'a365 setup all' to create it first)");
+            }
+            else if (results.AgentInstanceRegistered)
+            {
+                var verb = (results.AgentRegistrationAlreadyExisted ? "reused" : "registered").PadRight(12);
+                logger.LogInformation(DryRunRow("  Agent Registration") + verb + "'{Name}'",
+                    results.AgentRegistrationDisplayName ?? "unknown");
+                var sub = new string(' ', DryRunValCol);
+                logger.LogInformation(sub + "Registration ID:  {Id}", results.AgentInstanceId ?? "unknown");
+                logger.LogInformation(sub + "Agent identity:   {Id}", results.AgentIdentityId ?? "unknown");
+                if (!string.IsNullOrWhiteSpace(results.BlueprintId))
+                    logger.LogInformation(sub + "Blueprint:        {Id}", results.BlueprintId);
+            }
+            else if (results.AgentRegistrationFailed)
+                logger.LogWarning(DryRunRow("  Agent Registration") + "failed — see warnings");
+        }
+        else
+        {
         // ── Numbered step rows — mirrors the dry-run step list ─────────────────
         // Non-DW omits the Azure hosting step, so all steps after 1 are shifted down by 1.
         var s = isNonDw ? 0 : 1; // step offset: non-DW steps start at 2 (blueprint), DW at 3
@@ -521,6 +544,8 @@ internal static class SetupHelpers
         var permGrantStep = isNonDw ? 5 : 4 + s;
         if (results.BlueprintFailed)
             logger.LogInformation(DryRunRow(permGrantStep, "Permission Grants") + notRun);
+        else if (results.PermissionGrantsSkipped)
+            logger.LogInformation(DryRunRow(permGrantStep, "Permission Grants") + "skipped (--agent-registration-only)");
         else if (isS2SFlow && s2sOk)
         {
             if (isBothMode && !delegatedOk)
@@ -612,6 +637,8 @@ internal static class SetupHelpers
             logger.LogInformation(DryRunRow(settingsStep, "Project settings") + notRun);
         else if (results.ProjectSettingsWritten)
             logger.LogInformation(DryRunRow(settingsStep, "Project settings") + "written");
+
+        } // end full step table
 
         // ── Action Required ────────────────────────────────────────────────────
         var messagingEndpointManualRequired =
@@ -755,8 +782,8 @@ internal static class SetupHelpers
 
         if (results.Errors.Count > 0)
         {
-            logger.LogInformation("");
-            logger.LogInformation("Errors:");
+            logger.LogError("");
+            logger.LogError("Errors:");
             foreach (var error in results.Errors)
                 logger.LogError("  {Error}", error);
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -256,11 +256,7 @@ internal static class SetupHelpers
         logger.LogInformation("App created: {AppId}", appId);
 
         // Show all required permissions and ask for consent confirmation.
-        // AgentRegistration.ReadWrite.All is excluded from RequiredClientAppPermissions because
-        // ClientAppValidator acquires it via .default to avoid AADSTS650053; here we grant it explicitly.
-        var consentScopes = AuthenticationConstants.RequiredClientAppPermissions
-            .Append("AgentRegistration.ReadWrite.All")
-            .ToArray();
+        var consentScopes = AuthenticationConstants.RequiredClientAppPermissions;
 
         logger.LogInformation("The following permissions will be granted on behalf of all users:");
         logger.LogInformation("  Microsoft Graph / Agent 365 API:");
@@ -469,7 +465,7 @@ internal static class SetupHelpers
             // --agent-registration-only: single focused block showing only the registration outcome.
             if (results.AgentIdentityFailed)
             {
-                logger.LogWarning(DryRunRow("  Agent Registration") + "not attempted — agent identity not found (run 'a365 setup all' to create it first)");
+                logger.LogError(DryRunRow("  Agent Registration") + "not attempted — agent identity not found (run 'a365 setup all' to create it first)");
             }
             else if (results.AgentInstanceRegistered)
             {
@@ -483,7 +479,7 @@ internal static class SetupHelpers
                     logger.LogInformation(sub + "Blueprint:        {Id}", results.BlueprintId);
             }
             else if (results.AgentRegistrationFailed)
-                logger.LogWarning(DryRunRow("  Agent Registration") + "failed — see warnings");
+                logger.LogError(DryRunRow("  Agent Registration") + "failed — see errors");
         }
         else
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
@@ -226,6 +226,12 @@ public class SetupResults
     /// <summary>Whether step 8 (Project settings) was written to appsettings.json.</summary>
     public bool ProjectSettingsWritten { get; set; }
 
+    /// <summary>
+    /// True when the permission grants step was explicitly skipped because --agent-registration-only
+    /// was passed. Drives the "skipped" row in the setup summary instead of showing a grant status.
+    /// </summary>
+    public bool PermissionGrantsSkipped { get; set; }
+
     public List<string> Errors { get; } = new();
     public List<string> Warnings { get; } = new();
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
@@ -222,7 +222,7 @@ public static class AuthenticationConstants
         "DelegatedPermissionGrant.ReadWrite.All",
         "Directory.Read.All",
         "AgentInstance.ReadWrite.All",  // Required for POST /beta/agentRegistry/agentInstances (PublishCommand)
-        "AgentRegistration.ReadWrite.All",  // Required for POST/DELETE /beta/copilot/agentRegistrations (agent registration); token acquired via .default to avoid AADSTS650053
+        "AgentRegistration.ReadWrite.All",  // Required for POST/DELETE /beta/copilot/agentRegistrations (agent registration)
         // AgentIdentity.ReadWrite.All removed — no code requests it as a token scope.
         // Delete uses AgentIdentity.DeleteRestore.All. Read uses AgentIdentity.Read.All.
         // AgentIdentity.Create.All is a delegated scope used by CreateAgentIdentityDelegatedAsync
@@ -234,6 +234,16 @@ public static class AuthenticationConstants
         "User.ReadWrite.All",  // Required for agent user creation, usage location update, and license assignment
         // Note: RoleManagementReadDirectoryScope is excluded because Directory.Read.All covers the needed read operations.
     };
+
+    /// <summary>
+    /// Scopes for blueprint setup operations — same as <see cref="RequiredClientAppPermissions"/>
+    /// but without AgentRegistration.ReadWrite.All. Blueprint token acquisition must not request
+    /// the registration scope: apps that haven't yet been updated with that permission would get
+    /// an MSAL consent error with no actionable guidance.
+    /// </summary>
+    public static readonly string[] BlueprintOperationScopes = RequiredClientAppPermissions
+        .Where(s => s != "AgentRegistration.ReadWrite.All")
+        .ToArray();
 
     /// <summary>
     /// Required scopes for all PowerShell-based Microsoft Graph operations (OAuth2 grants,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
@@ -222,12 +222,7 @@ public static class AuthenticationConstants
         "DelegatedPermissionGrant.ReadWrite.All",
         "Directory.Read.All",
         "AgentInstance.ReadWrite.All",  // Required for POST /beta/agentRegistry/agentInstances (PublishCommand)
-        // AgentRegistration.ReadWrite.All (resource: 00000003-0000-0000-c000-000000000000, ID: 20f263bf-7d50-4e66-912c-16b4b4194fd4)
-        // is required for POST/DELETE /beta/copilot/agentRegistrations. It is acquired via .default
-        // on the custom app token provider (not enumerated explicitly) to avoid AADSTS650053.
-        // This permission must be configured on the custom app via the portal but is not validated here
-        // because ClientAppValidator queries /v1.0/oauth2PermissionGrants which only returns consented
-        // delegated scopes in the same resource app bundle as the existing permissions.
+        "AgentRegistration.ReadWrite.All",  // Required for POST/DELETE /beta/copilot/agentRegistrations (agent registration); token acquired via .default to avoid AADSTS650053
         // AgentIdentity.ReadWrite.All removed — no code requests it as a token scope.
         // Delete uses AgentIdentity.DeleteRestore.All. Read uses AgentIdentity.Read.All.
         // AgentIdentity.Create.All is a delegated scope used by CreateAgentIdentityDelegatedAsync

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
@@ -436,13 +436,13 @@ public class Agent365Config
     /// <summary>
     /// Azure AD application/identity ID for the agentic app.
     /// </summary>
-    [JsonPropertyName("AgenticAppId")]
+    [JsonPropertyName("agenticAppId")]
     public string? AgenticAppId { get; set; }
 
     /// <summary>
     /// User ID for the agentic user created during setup.
     /// </summary>
-    [JsonPropertyName("AgenticUserId")]
+    [JsonPropertyName("agenticUserId")]
     public string? AgenticUserId { get; set; }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -681,7 +681,7 @@ public class ConfigService : IConfigService
         // Migrate legacy key: generated configs written by older CLI versions use "botMessagingEndpoint".
         // If the new key "messagingEndpoint" was not found (BotMessagingEndpoint is still null),
         // fall back to the legacy key so existing setups continue to work without re-running setup.
-        if (config.BotMessagingEndpoint == null &&
+        if (string.IsNullOrWhiteSpace(config.BotMessagingEndpoint) &&
             stateData.TryGetProperty("botMessagingEndpoint", out var legacyEndpoint) &&
             legacyEndpoint.ValueKind == JsonValueKind.String)
         {
@@ -689,14 +689,14 @@ public class ConfigService : IConfigService
         }
 
         // Migrate legacy PascalCase keys written by older CLI versions (now camelCase).
-        if (config.AgenticAppId == null &&
+        if (string.IsNullOrWhiteSpace(config.AgenticAppId) &&
             stateData.TryGetProperty("AgenticAppId", out var legacyAgenticAppId) &&
             legacyAgenticAppId.ValueKind == JsonValueKind.String)
         {
             config.AgenticAppId = legacyAgenticAppId.GetString();
         }
 
-        if (config.AgenticUserId == null &&
+        if (string.IsNullOrWhiteSpace(config.AgenticUserId) &&
             stateData.TryGetProperty("AgenticUserId", out var legacyAgenticUserId) &&
             legacyAgenticUserId.ValueKind == JsonValueKind.String)
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -687,6 +687,21 @@ public class ConfigService : IConfigService
         {
             config.BotMessagingEndpoint = legacyEndpoint.GetString();
         }
+
+        // Migrate legacy PascalCase keys written by older CLI versions (now camelCase).
+        if (config.AgenticAppId == null &&
+            stateData.TryGetProperty("AgenticAppId", out var legacyAgenticAppId) &&
+            legacyAgenticAppId.ValueKind == JsonValueKind.String)
+        {
+            config.AgenticAppId = legacyAgenticAppId.GetString();
+        }
+
+        if (config.AgenticUserId == null &&
+            stateData.TryGetProperty("AgenticUserId", out var legacyAgenticUserId) &&
+            legacyAgenticUserId.ValueKind == JsonValueKind.String)
+        {
+            config.AgenticUserId = legacyAgenticUserId.GetString();
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -378,9 +378,9 @@ public class GraphApiService
     /// <summary>
     /// POST to Graph but always return HTTP response details (status, body, parsed JSON)
     /// </summary>
-    public virtual async Task<GraphResponse> GraphPostWithResponseAsync(string tenantId, string relativePath, object payload, CancellationToken ct = default, IEnumerable<string>? scopes = null)
+    public virtual async Task<GraphResponse> GraphPostWithResponseAsync(string tenantId, string relativePath, object payload, CancellationToken ct = default, IEnumerable<string>? scopes = null, bool forceRefresh = false)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct))
+        if (!await EnsureGraphHeadersAsync(tenantId, forceRefresh: forceRefresh, scopes: scopes, ct: ct))
         {
             return new GraphResponse { IsSuccess = false, StatusCode = 0, ReasonPhrase = "NoAuth", Body = "Failed to acquire token" };
         }
@@ -1336,7 +1336,7 @@ public class GraphApiService
         _logger.LogDebug("Body: {Body}", JsonSerializer.Serialize(payload));
 
         var response = await _retryHelper.ExecuteWithRetryAsync<GraphResponse>(
-            token => GraphPostWithResponseAsync(tenantId, AgentRegistrationsPath, payload, token, registrationScopes),
+            token => GraphPostWithResponseAsync(tenantId, AgentRegistrationsPath, payload, token, registrationScopes, forceRefresh: true),
             r =>
             {
                 if (r.StatusCode is not (502 or 503 or 504)) return false;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -1299,10 +1299,8 @@ public class GraphApiService
             return (null, false);
         }
 
-        // Use the custom app token provider with .default so the token is issued to the "Agent 365 CLI"
-        // app (7277bd3e-...) which has AgentRegistration.ReadWrite.All consented. Requesting the scope
-        // by name causes AADSTS650053 with the az CLI public client; .default includes all consented
-        // permissions for the resource without enumerating them.
+        // Use .default so the token includes all permissions consented on the "Agent 365 CLI" app,
+        // including AgentRegistration.ReadWrite.All, without enumerating scopes explicitly.
         IEnumerable<string>? registrationScopes = _tokenProvider != null
             ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
             : null;
@@ -1335,8 +1333,9 @@ public class GraphApiService
         _logger.LogDebug("POST {Url}", AgentRegistrationsPath);
         _logger.LogDebug("Body: {Body}", JsonSerializer.Serialize(payload));
 
+        var isRetry = false;
         var response = await _retryHelper.ExecuteWithRetryAsync<GraphResponse>(
-            token => GraphPostWithResponseAsync(tenantId, AgentRegistrationsPath, payload, token, registrationScopes, forceRefresh: true),
+            token => GraphPostWithResponseAsync(tenantId, AgentRegistrationsPath, payload, token, registrationScopes, forceRefresh: isRetry),
             r =>
             {
                 if (r.StatusCode is not (502 or 503 or 504)) return false;
@@ -1344,6 +1343,7 @@ public class GraphApiService
                     "Agent registration request returned HTTP {StatusCode} (transient); retrying...",
                     r.StatusCode);
                 r.Json?.Dispose();
+                isRetry = true;
                 return true;
             },
             maxRetries: 3,
@@ -1415,8 +1415,8 @@ public class GraphApiService
         string registrationId,
         CancellationToken ct = default)
     {
-        // Use the custom app token provider with .default so the token includes AgentRegistration.ReadWrite.All
-        // (consented on the "Agent 365 CLI" app). .default avoids AADSTS650053 from explicit scope names.
+        // Use .default so the token includes all permissions consented on the "Agent 365 CLI" app,
+        // including AgentRegistration.ReadWrite.All, without enumerating scopes explicitly.
         IEnumerable<string>? scopes = _tokenProvider != null
             ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
             : null;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
@@ -148,7 +148,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
             // and WAM on Windows authenticates via the OS broker (no browser, CAP-compliant).
             var token = MsalTokenAcquirerOverride != null
                 ? await MsalTokenAcquirerOverride(tenantId, validatedScopes, clientAppId, ct)
-                : await AcquireGraphTokenViaMsalAsync(tenantId, validatedScopes, clientAppId, ct, loginHint);
+                : await AcquireGraphTokenViaMsalAsync(tenantId, validatedScopes, clientAppId, ct, loginHint, forceRefresh);
 
             // Fall back to PowerShell Connect-MgGraph if MSAL is unavailable (e.g. no clientAppId)
             // or fails for any reason.
@@ -317,7 +317,8 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         string[] scopes,
         string? clientAppId,
         CancellationToken ct,
-        string? loginHint = null)
+        string? loginHint = null,
+        bool forceRefresh = false)
     {
         if (string.IsNullOrWhiteSpace(clientAppId))
         {
@@ -334,7 +335,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
 
             _logger.LogDebug("Acquiring Graph token via MSAL for scopes: {Scopes}", string.Join(", ", fullScopes));
 
-            var msalCredential = new MsalBrowserCredential(clientAppId, tenantId, logger: _logger, loginHint: loginHint);
+            var msalCredential = new MsalBrowserCredential(clientAppId, tenantId, logger: _logger, loginHint: loginHint, forceRefresh: forceRefresh);
             var tokenResult = await msalCredential.GetTokenAsync(new TokenRequestContext(fullScopes), ct);
 
             if (string.IsNullOrWhiteSpace(tokenResult.Token))

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -43,6 +43,7 @@ public sealed class MsalBrowserCredential : TokenCredential
     private readonly bool _useWam;
     private readonly IntPtr _windowHandle;
     private readonly string? _loginHint;
+    private readonly bool _forceRefresh;
 
     // Shared persistent cache helper - initialized once and reused across all instances.
     // This is the key to reducing multiple WAM prompts during setup operations.
@@ -88,7 +89,8 @@ public sealed class MsalBrowserCredential : TokenCredential
         ILogger? logger = null,
         bool useWam = true,
         string? authority = null,
-        string? loginHint = null)
+        string? loginHint = null,
+        bool forceRefresh = false)
     {
         if (string.IsNullOrWhiteSpace(clientId))
         {
@@ -104,6 +106,7 @@ public sealed class MsalBrowserCredential : TokenCredential
         _tenantId = tenantId;
         _logger = logger;
         _loginHint = loginHint;
+        _forceRefresh = forceRefresh;
 
         // Get window handle for WAM on Windows
         // Try multiple sources: console window, foreground window, or desktop window
@@ -330,6 +333,7 @@ public sealed class MsalBrowserCredential : TokenCredential
                     _logger?.LogDebug("Attempting to acquire token silently from cache...");
                     var silentResult = await _publicClientApp
                         .AcquireTokenSilent(scopes, account)
+                        .WithForceRefresh(_forceRefresh)
                         .ExecuteAsync(cancellationToken);
 
                     _logger?.LogDebug("Successfully acquired token from cache.");
@@ -353,6 +357,7 @@ public sealed class MsalBrowserCredential : TokenCredential
                     _logger?.LogDebug("Probing consent status silently via WAM OS account...");
                     var probeResult = await _publicClientApp
                         .AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount)
+                        .WithForceRefresh(_forceRefresh)
                         .ExecuteAsync(cancellationToken);
                     _logger?.LogDebug("WAM OS account probe succeeded — consent is granted.");
                     // Only return the OS account token when no login hint is set.

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
@@ -474,10 +474,11 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
     }
 
     /// <summary>
-    /// Step 5: When the lookup returns null, CreateAgentIdentityDelegatedAsync must be called.
+    /// Step 5 (--agent-registration-only): When the API lookup returns null, the path must error out
+    /// rather than create a new identity — identity creation is not the responsibility of this flag.
     /// </summary>
     [Fact]
-    public async Task Step5_CreatesNewIdentity_WhenNotFoundByApiLookup()
+    public async Task Step5_FailsWithError_WhenIdentityNotFoundByApiLookup()
     {
         var (ctx, graph, blueprintService) = BuildIdempotencyTestContext();
 
@@ -485,20 +486,15 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((string?)null);
 
-        graph.CreateAgentIdentityDelegatedAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns("new-sp-id");
+        var exitCode = await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
 
-        graph.RegisterAgentInstanceAsyncV2(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
-            Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(("new-reg-id", false));
-
-        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
-
-        ctx.Results.AgentIdentityId.Should().Be("new-sp-id",
-            because: "a new agent identity must be created when no existing one is found");
-        await graph.Received(1).CreateAgentIdentityDelegatedAsync(
+        exitCode.Should().Be(1,
+            because: "missing agent identity is a fatal error for --agent-registration-only");
+        ctx.Results.AgentIdentityFailed.Should().BeTrue(
+            because: "identity not found via API lookup must surface as an identity failure");
+        ctx.Results.AgentRegistrationFailed.Should().BeTrue(
+            because: "registration cannot proceed without an agent identity");
+        await graph.DidNotReceive().CreateAgentIdentityDelegatedAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
@@ -42,6 +42,7 @@ public class ClientAppValidatorTests
     private const string AgentInstanceReadWriteAllId = "aaaa0007-0000-0000-0000-000000000000";
     private const string UserReadId = "aaaa0008-0000-0000-0000-000000000000";
     private const string UserReadWriteAllId = "aaaa0009-0000-0000-0000-000000000000";
+    private const string AgentRegistrationReadWriteAllId = "aaaa000a-0000-0000-0000-000000000000";
 
     // Separate SP object ID used only by the consent-grant path (GetConsentedPermissionsAsync)
     // so it does not conflict with SetupAdminConsentSp / SetupAdminConsentGrantsEmpty.
@@ -210,6 +211,41 @@ public class ClientAppValidatorTests
             () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
     }
 
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenMissingAgentRegistrationPermission_ThrowsNamingThatPermission()
+    {
+        // App has all permissions except AgentRegistration.ReadWrite.All
+        var requiredResourceAccess = $$"""
+        [
+            {
+                "resourceAppId": "{{AuthenticationConstants.MicrosoftGraphResourceAppId}}",
+                "resourceAccess": [
+                    {"id": "{{AgentBlueprintPrincipalCreateId}}", "type": "Scope"},
+                    {"id": "{{AgentBlueprintReadWriteAllId}}", "type": "Scope"},
+                    {"id": "{{AgentBlueprintUpdateAuthId}}", "type": "Scope"},
+                    {"id": "{{AgentBlueprintAddRemoveCredsId}}", "type": "Scope"},
+                    {"id": "{{DelegatedPermissionGrantReadWriteAllId}}", "type": "Scope"},
+                    {"id": "{{DirectoryReadAllId}}", "type": "Scope"},
+                    {"id": "{{AgentInstanceReadWriteAllId}}", "type": "Scope"},
+                    {"id": "{{UserReadId}}", "type": "Scope"},
+                    {"id": "{{UserReadWriteAllId}}", "type": "Scope"}
+                ]
+            }
+        ]
+        """;
+
+        SetupAppInfoGet(ValidClientAppId, requiredResourceAccess: requiredResourceAccess);
+        SetupPermissionResolution();
+        SetupConsentGrantForAgentIdentityCreate();
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.ErrorCode.Should().Be(ErrorCodes.ClientAppValidationFailed);
+        exception.ErrorDetails.Should().Contain(d => d.Contains("AgentRegistration.ReadWrite.All"),
+            because: "the missing permission must be identified by name in the error details");
+    }
+
     #endregion
 
     #region EnsureValidClientAppAsync - Success Tests
@@ -350,6 +386,7 @@ public class ClientAppValidatorTests
                     {"id": "{{DelegatedPermissionGrantReadWriteAllId}}", "type": "Scope"},
                     {"id": "{{DirectoryReadAllId}}", "type": "Scope"},
                     {"id": "{{AgentInstanceReadWriteAllId}}", "type": "Scope"},
+                    {"id": "{{AgentRegistrationReadWriteAllId}}", "type": "Scope"},
                     {"id": "{{UserReadId}}", "type": "Scope"},
                     {"id": "{{UserReadWriteAllId}}", "type": "Scope"}
                 ]
@@ -393,6 +430,7 @@ public class ClientAppValidatorTests
                     {"id": "{{DelegatedPermissionGrantReadWriteAllId}}", "value": "DelegatedPermissionGrant.ReadWrite.All"},
                     {"id": "{{DirectoryReadAllId}}", "value": "Directory.Read.All"},
                     {"id": "{{AgentInstanceReadWriteAllId}}", "value": "AgentInstance.ReadWrite.All"},
+                    {"id": "{{AgentRegistrationReadWriteAllId}}", "value": "AgentRegistration.ReadWrite.All"},
                     {"id": "{{UserReadId}}", "value": "User.Read"},
                     {"id": "{{UserReadWriteAllId}}", "value": "User.ReadWrite.All"}
                 ]
@@ -841,6 +879,7 @@ public class ClientAppValidatorTests
                     {"id": "{{DelegatedPermissionGrantReadWriteAllId}}", "type": "Scope"},
                     {"id": "{{DirectoryReadAllId}}", "type": "Scope"},
                     {"id": "{{AgentInstanceReadWriteAllId}}", "type": "Scope"},
+                    {"id": "{{AgentRegistrationReadWriteAllId}}", "type": "Scope"},
                     {"id": "{{UserReadId}}", "type": "Scope"},
                     {"id": "{{UserReadWriteAllId}}", "type": "Scope"}
                 ]
@@ -871,6 +910,7 @@ public class ClientAppValidatorTests
                         {"id": "{{DelegatedPermissionGrantReadWriteAllId}}", "value": "DelegatedPermissionGrant.ReadWrite.All"},
                         {"id": "{{DirectoryReadAllId}}", "value": "Directory.Read.All"},
                         {"id": "{{AgentInstanceReadWriteAllId}}", "value": "AgentInstance.ReadWrite.All"},
+                        {"id": "{{AgentRegistrationReadWriteAllId}}", "value": "AgentRegistration.ReadWrite.All"},
                         {"id": "{{UserReadId}}", "value": "User.Read"},
                         {"id": "{{UserReadWriteAllId}}", "value": "User.ReadWrite.All"}
                     ]


### PR DESCRIPTION
## Summary

- `--agent-registration-only`: skip identity/permissions/project-settings steps; fall back to Graph API lookup when `agenticAppId` is missing; fail with error (not warning) when identity cannot be found
- Bootstrap (`--agent-name`): merge `agentBlueprintId` + `agenticAppId` from generated config, not just `agentRegistrationId`
- Fix `agenticAppId`/`agenticUserId` JSON key casing (camelCase); auto-migrate PascalCase keys in existing files
- Add `forceRefresh` on Graph token acquisition to bypass WAM cache on 401 retry
- Require `AgentRegistration.ReadWrite.All` in client app permissions; update tests

## New `--agent-registration-only` summary output

**Success:**
```
Setup Summary

  Agent Registration   registered   'My Agent'
                       Registration ID:  a1b2c3d4-...
                       Agent identity:   e5f6a7b8-...
                       Blueprint:        c9d0e1f2-...
```

**When agent identity is not found:**
```
Setup Summary

  Agent Registration   not attempted — agent identity not found
                       (run 'a365 setup all' to create it first)
```

