### PR TITLE
Fix Graph scope in SP provisioning script (#414)

### DIFF
--- a/scripts/cli/Auth/New-Agent365ToolsServicePrincipalProdPublic.ps1
+++ b/scripts/cli/Auth/New-Agent365ToolsServicePrincipalProdPublic.ps1
@@ -190,7 +190,7 @@ Write-Host "You need admin permissions for this operation." -ForegroundColor Yel
 Write-Host ""
 
 try {
-    Connect-MgGraph -Scopes "AppRoleAssignment.ReadWrite.All" -NoWelcome
+    Connect-MgGraph -Scopes "Application.ReadWrite.All" -NoWelcome
     $context = Get-MgContext
     Write-Host "Connected to tenant: $($context.TenantId)" -ForegroundColor Green
     Write-Host ""
@@ -231,7 +231,7 @@ catch {
         Write-Host "This error usually means you don't have admin permissions." -ForegroundColor Yellow
         Write-Host ""
         Write-Host "Required Permissions:" -ForegroundColor Cyan
-        Write-Host "  - AppRoleAssignment.ReadWrite.All" -ForegroundColor White
+        Write-Host "  - Application.ReadWrite.All" -ForegroundColor White
         Write-Host "  - Or Global Administrator / Application Administrator role" -ForegroundColor White
         Write-Host ""
         Write-Host "Please contact your Microsoft Entra ID administrator to run this script." -ForegroundColor Yellow


### PR DESCRIPTION
## Summary
- Replace `AppRoleAssignment.ReadWrite.All` with `Application.ReadWrite.All` in `Connect-MgGraph` — the script only calls `Get-MgServicePrincipal`/`New-MgServicePrincipal`, both of which require `Application.*`, not `AppRoleAssignment.*`.
- Update the 403 error-handler hint at line 234 so it no longer points users at the wrong permission.

Fixes #414. With the previous scope, V2 per-server SPs that didn't already exist failed with `Authorization_RequestDenied (403)`. The V1 ATG SP is typically pre-existing so the bug was masked there.

Chose **replace** over **append** (the reporter's suggested diff) for least-privilege: the script never exercises `AppRoleAssignment.*` APIs, so admins shouldn't be asked to consent to that permission.

## Test plan
- [ ] Run script on macOS in `V1` mode against a tenant where the V1 SP already exists (verify no regression on the pre-existing-SP path).
- [ ] Run script on macOS in `V2` mode against a tenant missing one or more V2 per-server SPs (verify creation succeeds where it previously hit 403).
- [ ] Run script in `All` mode end-to-end.
- [ ] Verify the consent dialog now requests only `Application.ReadWrite.All`.
- [ ] Trigger the 403 path (e.g. with a non-admin account) and confirm the error hint now displays `Application.ReadWrite.All`.