### PR TITLE
Preserve McpServersMetadata.Read.All when --remove-legacy-scopes is set

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
@@ -138,20 +138,30 @@ internal static class PermissionsSubcommand
                 var dryRunAtgAppId = ConfigConstants.GetAgent365ToolsResourceAppId(dryRunConfig.Environment);
                 if (removeLegacyScopes)
                 {
+                    // Source-of-truth: drive both the "Would CONFIGURE" and "Would REMOVE" sets
+                    // from the same GetScopesByAudienceAsync(excludeLegacyAtg: true) call that the
+                    // non-dry-run flow uses. The diff is computed per-scope (not per-audience) so
+                    // the ATG audience correctly shows McpServersMetadata.Read.All under CONFIGURE
+                    // and only the legacy McpServers.*.All scopes under REMOVE.
                     var allScopes = await ManifestHelper.GetScopesByAudienceAsync(manifestPath, excludeLegacyAtg: false, resolvedAtgAppId: dryRunAtgAppId);
-                    var remainingScopes = allScopes
-                        .Where(kvp => !string.Equals(kvp.Key, dryRunAtgAppId, StringComparison.OrdinalIgnoreCase))
-                        .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
-                    var removedAudiences = allScopes.Keys
-                        .Where(k => !remainingScopes.ContainsKey(k))
-                        .ToList();
+                    var remainingScopes = await ManifestHelper.GetScopesByAudienceAsync(manifestPath, excludeLegacyAtg: true, resolvedAtgAppId: dryRunAtgAppId);
 
-                    if (removedAudiences.Count > 0)
+                    var removedByAudience = new SortedDictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var (audience, scopes) in allScopes)
+                    {
+                        remainingScopes.TryGetValue(audience, out var kept);
+                        var keptSet = new HashSet<string>(kept ?? Array.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+                        var dropped = scopes.Where(s => !keptSet.Contains(s)).ToArray();
+                        if (dropped.Length > 0)
+                            removedByAudience[audience] = dropped;
+                    }
+
+                    if (removedByAudience.Count > 0)
                     {
                         logger.LogInformation("Would REMOVE (--remove-legacy-scopes):");
-                        foreach (var audience in removedAudiences)
+                        foreach (var (audience, scopes) in removedByAudience)
                             logger.LogInformation("  - Resource: {Audience}  Scopes: {Scopes}",
-                                audience, string.Join(", ", allScopes[audience]));
+                                audience, string.Join(", ", scopes));
                     }
 
                     logger.LogInformation("Would CONFIGURE:");

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
@@ -202,9 +202,11 @@ internal static class PermissionsSubcommand
             if (removeLegacyScopes)
             {
                 logger.LogWarning(
-                    "WARNING: --remove-legacy-scopes will permanently remove the shared ATG audience ({AtgAppId}) " +
-                    "from the agent blueprint. Any agent instances still using the old SDK will immediately lose " +
-                    "access to MCP tools. Ensure all agent instances have been upgraded to the new SDK before proceeding.",
+                    "WARNING: --remove-legacy-scopes will permanently remove the legacy per-server scopes that resolve " +
+                    "to the shared ATG audience ({AtgAppId}) from the agent blueprint. The Agent 365 Tools resource " +
+                    "itself remains with the required McpServersMetadata.Read.All scope. Any agent instances still using " +
+                    "the old SDK will immediately lose access to MCP tools. Ensure all agent instances have been upgraded " +
+                    "to the new SDK before proceeding.",
                     McpConstants.WorkIQToolsProdAppId);
 
                 var confirmed = await confirmationProvider.ConfirmAsync("Continue? [y/N]: ");

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Helpers/ManifestHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Helpers/ManifestHelper.cs
@@ -282,8 +282,10 @@ public static class ManifestHelper
     /// </summary>
     /// <param name="manifestPath">Path to ToolingManifest.json</param>
     /// <param name="excludeLegacyAtg">
-    /// When true, omits all entries whose resolved audience is the shared ATG AppId.
-    /// Only pass true when V2 SDK is confirmed live (--remove-legacy-scopes flag).
+    /// When true, omits legacy per-server scopes whose resolved audience is the shared ATG AppId.
+    /// The ATG audience itself is still seeded with <c>McpServersMetadata.Read.All</c> because that
+    /// scope is required on the Agent 365 Tools resource regardless of SDK version — it is not a
+    /// legacy V1 scope. Only pass true when V2 SDK is confirmed live (--remove-legacy-scopes flag).
     /// </param>
     /// <param name="resolvedAtgAppId">
     /// Environment-resolved ATG resource app ID. Defaults to <see cref="McpConstants.WorkIQToolsProdAppId"/>
@@ -299,14 +301,13 @@ public static class ManifestHelper
         var atgAppId = resolvedAtgAppId ?? McpConstants.WorkIQToolsProdAppId;
         var scopesByAudience = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
-        // McpServersMetadata.Read.All is always required and belongs to the ATG AppId
-        if (!excludeLegacyAtg)
+        // McpServersMetadata.Read.All is always required on the ATG AppId — it is a scope on the
+        // Agent 365 Tools resource itself (used for tool discovery), not a legacy V1 MCP scope, so
+        // it is seeded unconditionally even when excludeLegacyAtg drops the other ATG-mapped scopes.
+        scopesByAudience[atgAppId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
-            scopesByAudience[atgAppId] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "McpServersMetadata.Read.All"
-            };
-        }
+            "McpServersMetadata.Read.All"
+        };
 
         var parsed = await ReadManifestAsync(manifestPath);
         if (parsed is null)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/ManifestHelperGetScopesByAudienceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/ManifestHelperGetScopesByAudienceTests.cs
@@ -186,7 +186,7 @@ public class ManifestHelperGetScopesByAudienceTests : IDisposable
     }
 
     [Fact]
-    public async Task MixedManifest_ExcludeLegacyAtg_RemovesAtgKey()
+    public async Task MixedManifest_ExcludeLegacyAtg_DropsLegacyAtgScopesButKeepsMetadataReadAll()
     {
         // Arrange
         var path = WriteManifest($$"""
@@ -209,8 +209,12 @@ public class ManifestHelperGetScopesByAudienceTests : IDisposable
         // Act
         var result = await ManifestHelper.GetScopesByAudienceAsync(path, excludeLegacyAtg: true);
 
-        // Assert — ATG key gone, per-server key remains
-        Assert.False(result.ContainsKey(McpConstants.WorkIQToolsProdAppId));
+        // Assert — ATG key retained with only the always-required metadata read scope (legacy
+        // per-server scopes mapped to the ATG audience are dropped); per-server key still present
+        Assert.True(result.ContainsKey(McpConstants.WorkIQToolsProdAppId));
+        Assert.Equal(new[] { "McpServersMetadata.Read.All" }, result[McpConstants.WorkIQToolsProdAppId]);
+        Assert.DoesNotContain("McpServers.Mail.All", result[McpConstants.WorkIQToolsProdAppId]);
+
         Assert.True(result.ContainsKey("2cc60bb0-1024-48c8-95f0-1fce211a04d8"));
         Assert.Contains("Tools.ListInvoke.All", result["2cc60bb0-1024-48c8-95f0-1fce211a04d8"]);
     }
@@ -232,7 +236,7 @@ public class ManifestHelperGetScopesByAudienceTests : IDisposable
     }
 
     [Fact]
-    public async Task ExcludeLegacyAtg_AllV1Entries_ReturnsEmptyDictionary()
+    public async Task ExcludeLegacyAtg_AllV1Entries_RetainsAtgWithOnlyMetadataReadAll()
     {
         // Arrange — all entries are V1 (ATG audience)
         var path = WriteManifest($$"""
@@ -250,7 +254,10 @@ public class ManifestHelperGetScopesByAudienceTests : IDisposable
         // Act
         var result = await ManifestHelper.GetScopesByAudienceAsync(path, excludeLegacyAtg: true);
 
-        // Assert — all entries excluded, empty result
-        Assert.Empty(result);
+        // Assert — legacy per-server ATG scopes excluded, but ATG audience still carries the
+        // always-required McpServersMetadata.Read.All (a scope on the Agent 365 Tools resource itself)
+        Assert.Single(result);
+        Assert.True(result.ContainsKey(McpConstants.WorkIQToolsProdAppId));
+        Assert.Equal(new[] { "McpServersMetadata.Read.All" }, result[McpConstants.WorkIQToolsProdAppId]);
     }
 }


### PR DESCRIPTION
## Summary

- `GetScopesByAudienceAsync` previously skipped the ATG audience entry entirely when `excludeLegacyAtg=true`, which dropped `McpServersMetadata.Read.All` together with the legacy `McpServers.*.All` scopes. That scope lives on the Agent 365 Tools resource itself (used for tool discovery) and must remain regardless of SDK version.
- Seed `McpServersMetadata.Read.All` on the ATG AppId unconditionally; `excludeLegacyAtg` now only suppresses per-server scopes from the manifest that resolve to the ATG audience.
- Update the `--remove-legacy-scopes` warning text so operators know the metadata read scope is preserved.
- Update two affected tests to reflect the new contract.

## What `--remove-legacy-scopes` does after this change

When the flag is set on `a365 setup permissions mcp`, the desired scope set sent into the admin-consent / inheritable-permissions flow becomes:

- ATG AppId → `[McpServersMetadata.Read.All]` (legacy `McpServers.Mail.All`, `McpServers.Calendar.All`, ... etc. are dropped)
- V2 per-server AppIds → their `Tools.ListInvoke.All` scopes (unchanged)

`McpServersMetadata.Read.All` is protected by four independent guards:
1. Seeded unconditionally in `GetScopesByAudienceAsync` (this PR).
2. `IsV1Scope` returns false for it (`McpServersMetadata.Read.All` does not start with `McpServers.` — char 11 is `M`, not `.`).
3. `RemoveStaleCustomPermissionsAsync` protects the ATG AppId from reconciliation cleanup.
4. The non-blueprint (classic App Registration) path hard-codes it in `NonDwSetupOrchestrator.Agent365ToolsDelegatedPermissions`.

## Test plan

- [x] `dotnet build` clean (0 warnings, 0 errors).
- [x] Full test suite: 1425 passed, 0 failed, 16 skipped.
- [x] Updated `MixedManifest_ExcludeLegacyAtg_DropsLegacyAtgScopesButKeepsMetadataReadAll` — asserts ATG key retained with `[McpServersMetadata.Read.All]` and no `McpServers.Mail.All`.
- [x] Updated `ExcludeLegacyAtg_AllV1Entries_RetainsAtgWithOnlyMetadataReadAll` — asserts single ATG entry containing only the metadata read scope.
- [ ] Manual: run `a365 setup permissions mcp --remove-legacy-scopes` against a test blueprint that previously had both V1 (Mail/Calendar) and V2 entries; confirm the resulting blueprint state retains the ATG inheritable permission with only `McpServersMetadata.Read.All`.