### PR TITLE
Fix auto-triage dependency install on Python 3.11

### DIFF
--- a/autoTriage/requirements.txt
+++ b/autoTriage/requirements.txt
@@ -15,7 +15,7 @@
 # pip-tools to generate. See docs/SECRETS.md for details.
 
 # Azure Functions
-azure-functions==2.1.0
+azure-functions==1.24.0
 
 # FastAPI (local development)
 fastapi==0.136.1


### PR DESCRIPTION
Pin azure-functions to the latest 1.x release because azure-functions 2.1.0 requires Python 3.13+, while the auto-triage workflow runs on Python 3.11.

## Summary

Fixes the `Auto-Triage Issues` workflow dependency install failure by pinning `azure-functions` to a Python 3.11-compatible release.

## Why

The failing workflow run stopped in the `Install dependencies` step before triage logic executed:

Workflow: https://github.com/microsoft/Agent365-devTools/actions/runs/26569467763/workflow
Job: https://github.com/microsoft/Agent365-devTools/actions/runs/26569467763/job/78272607391

The workflow uses Python 3.11 and then installs `autoTriage/requirements.txt`:

```yaml
- name: Set up Python
  uses: actions/setup-python@v5
  with:
    python-version: '3.11'

- name: Install dependencies
  run: |
    cd autoTriage
    pip install -r requirements.txt
```

`azure-functions==2.1.0` declares `Requires-Python: >=3.13`, so it cannot be installed by the workflow's Python 3.11 environment.

## Fix

Changed:

```diff
-azure-functions==2.1.0
+azure-functions==1.24.0
```

`azure-functions==1.24.0` declares `Requires-Python: >=3.7`, which is compatible with Python 3.11.

## Verification

Reproduced the workflow's dependency install path in a Python 3.11 environment.

Old pin fails:

```text
Using Python 3.11.14 environment
x No solution found when resolving dependencies:
  Because the current Python version (3.11.14) does not satisfy Python>=3.13
  and azure-functions==2.1.0 depends on Python>=3.13,
  azure-functions==2.1.0 cannot be used.
```

Fixed pin installs successfully:

```text
Using Python 3.11.14 environment
Resolved 56 packages in 2.27s

azure-functions    1.24.0
fastapi            0.136.1
openai             2.38.0
pygithub           2.9.1
pytest             9.0.3
requests           2.34.2

Checked 56 packages
All installed packages are compatible
```
```
