### PR TITLE
Add auth-cache clear command

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/AuthCacheCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/AuthCacheCommand.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Commands;
+
+public class AuthCacheCommand
+{
+    public static Command CreateCommand(
+        ILogger<AuthCacheCommand> logger,
+        string? cacheDirectory = null)
+    {
+        var authCacheCommand = new Command(CommandNames.AuthCache, "Manage cached authentication tokens");
+        authCacheCommand.AddCommand(CreateClearCommand(logger, cacheDirectory));
+        return authCacheCommand;
+    }
+
+    private static Command CreateClearCommand(
+        ILogger<AuthCacheCommand> logger,
+        string? cacheDirectory)
+    {
+        var clearCommand = new Command("clear", "Clear the Agent 365 CLI authentication token cache");
+
+        clearCommand.SetHandler((InvocationContext context) =>
+        {
+            var resolvedCacheDirectory = cacheDirectory ?? ConfigService.GetGlobalConfigDirectory();
+            var path = Path.Combine(resolvedCacheDirectory, AuthenticationConstants.TokenCacheFileName);
+            try
+            {
+                if (!File.Exists(path))
+                {
+                    logger.LogInformation("Not found: {Path}", path);
+                    logger.LogInformation("No Agent 365 CLI authentication cache file was found.");
+                    return;
+                }
+
+                File.Delete(path);
+                logger.LogInformation("Deleted: {Path}", path);
+                logger.LogInformation("Cleared Agent 365 CLI authentication cache.");
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or System.Security.SecurityException)
+            {
+                logger.LogError("Failed to delete {Path}: {Message}", path, ex.Message);
+                context.ExitCode = 1;
+            }
+        });
+
+        return clearCommand;
+    }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/CommandNames.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/CommandNames.cs
@@ -18,4 +18,5 @@ public static class CommandNames
     public const string Develop = "develop";
     public const string CreateInstance = "create-instance";
     public const string Logs = "logs";
+    public const string AuthCache = "auth-cache";
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.A365.DevTools.Cli.Commands;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
@@ -182,6 +183,8 @@ class Program
             var logsLogger = serviceProvider.GetRequiredService<ILogger<LogsCommand>>();
             var logRedactionService = serviceProvider.GetRequiredService<ILogRedactionService>();
             rootCommand.AddCommand(LogsCommand.CreateCommand(logsLogger, logRedactionService));
+            var authCacheLogger = serviceProvider.GetRequiredService<ILogger<AuthCacheCommand>>();
+            rootCommand.AddCommand(AuthCacheCommand.CreateCommand(authCacheLogger));
 
             // Build pipeline manually so we can skip UseTypoCorrections() ("Did you mean?" noise)
             // and UseParseErrorReporting() (full help dump on any parse error), replacing both
@@ -247,7 +250,8 @@ class Program
                 || args.Any(a => a is "--help" or "-h" or "--version");
             var isShowSecret = args.Any(a => a.Equals("--show-secret", StringComparison.Ordinal)
                 || a.StartsWith("--show-secret=", StringComparison.Ordinal));
-            if (!isHelpOrVersion && !isShowSecret)
+            var isAuthCacheCommand = args.FirstOrDefault(arg => !arg.StartsWith("-")) == CommandNames.AuthCache;
+            if (!isHelpOrVersion && !isShowSecret && !isAuthCacheCommand)
             {
                 try
                 {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/AuthenticationService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/AuthenticationService.cs
@@ -43,7 +43,7 @@ public interface IAuthenticationService
 /// - Typical user experience: 1-2 authentication prompts for entire CLI workflow
 ///
 /// TOKEN CACHING:
-/// - Cache Location: %LocalApplicationData%\Agent365\token-cache.json (Windows)
+/// - Cache Location: %LocalApplicationData%\Microsoft.Agents.A365.DevTools.Cli\auth-token.json (Windows)
 /// - Cache Key Format: {resourceUrl}:tenant:{tenantId}[:user:{userId}]
 /// - Cache Expiration: Validated with 5-minute buffer before token expiry
 /// - Reuse Across Commands: All CLI commands share the same token cache

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 /// Uses Microsoft.Identity.Client.Extensions.Msal to persist tokens across all CLI instances.
 /// This dramatically reduces authentication prompts during multi-step operations like 'a365 setup all'.
 ///
-/// Cache Location: [LocalApplicationData]/Agent365/msal-token-cache (Windows/macOS)
+/// Cache Location: [LocalApplicationData]/Microsoft.Agents.A365.DevTools.Cli/msal-token-cache (Windows/macOS)
 /// Security: Tokens are stored using platform-appropriate mechanisms:
 ///   - Windows: DPAPI (Data Protection API) - tokens encrypted with user credentials, persisted to disk
 ///   - macOS: Keychain - tokens stored in secure keychain, persisted to disk

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AuthCacheCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AuthCacheCommandTests.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Commands;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
+
+public class AuthCacheCommandTests : IDisposable
+{
+    private readonly ILogger<AuthCacheCommand> _logger = Substitute.For<ILogger<AuthCacheCommand>>();
+    private readonly string _cacheDirectory = Path.Combine(Path.GetTempPath(), $"a365-auth-cache-test-{Guid.NewGuid():N}");
+
+    public AuthCacheCommandTests()
+    {
+        Directory.CreateDirectory(_cacheDirectory);
+    }
+
+    [Fact]
+    public async Task Clear_WhenCacheFilesExist_DeletesOnlyCliAuthTokenFile()
+    {
+        var authTokenPath = Path.Combine(_cacheDirectory, AuthenticationConstants.TokenCacheFileName);
+        var msalTokenPath = Path.Combine(_cacheDirectory, "msal-token-cache");
+        await File.WriteAllTextAsync(authTokenPath, "auth-cache");
+        await File.WriteAllTextAsync(msalTokenPath, "msal-cache");
+
+        var command = AuthCacheCommand.CreateCommand(_logger, _cacheDirectory);
+
+        var result = await command.InvokeAsync(["clear"]);
+
+        result.Should().Be(0);
+        File.Exists(authTokenPath).Should().BeFalse();
+        File.Exists(msalTokenPath).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Clear_WhenCacheFilesDoNotExist_Succeeds()
+    {
+        var command = AuthCacheCommand.CreateCommand(_logger, _cacheDirectory);
+
+        var result = await command.InvokeAsync(["clear"]);
+
+        result.Should().Be(0);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_cacheDirectory, recursive: true); } catch { }
+    }
+}


### PR DESCRIPTION
Add a top-level auth-cache clear command that removes the Agent 365 CLI auth-token cache without touching the MSAL/WAM broker cache or triggering authenticated startup work before clearing.

why?
a365 cli stores token in cache & if it gets stale due to any reasons - the next runs just fails.  Thus, auth-cache clear command can help users.