### PR TITLE
Fix CS1998 async warning in PromptForMessagingEndpointAsync

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
@@ -960,10 +960,10 @@ internal static class AllSubcommand
     /// Prompts for the messaging endpoint URL. Returns the entered HTTPS URL, or null to defer
     /// (blank entry). The caller prints the section header and opens the indent scope.
     /// </summary>
-    private static async Task<string?> PromptForMessagingEndpointAsync(SetupContext ctx)
+    private static Task<string?> PromptForMessagingEndpointAsync(SetupContext ctx)
     {
         if (ctx.NonInteractive)
-            return null;
+            return Task.FromResult<string?>(null);
 
         ctx.Logger.LogInformation("The HTTPS URL where your deployed agent receives messages.");
         ctx.Logger.LogInformation("Leave blank to configure it later, after you deploy the agent.");
@@ -975,15 +975,15 @@ internal static class AllSubcommand
             var entered = ConsoleHelper.ReadLineCancellable(ctx.CancellationToken)?.Trim();
 
             if (string.IsNullOrWhiteSpace(entered))
-                return null;
+                return Task.FromResult<string?>(null);
 
             if (Uri.TryCreate(entered, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps)
-                return entered;
+                return Task.FromResult<string?>(entered);
 
             ctx.Logger.LogWarning("Enter a valid HTTPS URL (e.g. https://my-agent.example.com/api/messages), or leave blank to skip.");
         }
 
-        return null;
+        return Task.FromResult<string?>(null);
     }
 
     /// <summary>


### PR DESCRIPTION
## Why

PR #440 introduced `PromptForMessagingEndpointAsync`, which was declared `async` but contains no `await` operators (it only performs synchronous console I/O). With warnings treated as errors, this produced a build break:

```
AllSubcommand.cs(963,40): Error CS1998: This async method lacks 'await' operators and will run synchronously.
```

## What

Removed the `async` modifier from `PromptForMessagingEndpointAsync` and returned its values via `Task.FromResult`. The `Task<string?>` return type is preserved, so the caller's `await` at the call site is unchanged and the original prompt/validation behavior is fully intact.

## Verification

`dotnet build -c Release` on the CLI project now succeeds with 0 errors.