### PR TITLE
feat: add web consent redirect URIs to BYO Entra apps

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
@@ -317,7 +317,7 @@ internal class PublishCommandExecutor
         var provisioner = new EntraAppProvisioner(_logger, _graphApiService!, _retryHelper);
 
         var publicClients = await provisioner.CreatePublicClientsAppAsync(
-            input.ServerName, tenantId, serviceTreeId: null, warnings, ct);
+            input.ServerName, tenantId, serviceTreeId: null, warnings, ct: ct);
 
         return new EntraAppSet(
             PublicClientsClientId: publicClients.ClientId,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -703,20 +703,25 @@ internal class RegisterCommandExecutor
         }
         else
         {
-            var msg = "A365 Proxy redirect URI was not returned by the server. Redirect URI configuration skipped.";
+            var msg = "A365 Proxy redirect URI was not returned by the server. Setting consent redirect URIs only.";
             _logger.LogWarning(msg);
             concurrentWarnings.Add(msg);
+            tasks.Add(SetConsentOnlyRedirectUrisAsync(tenantId, apps.A365AppObjectId, apps.A365AppName, concurrentWarnings, ct));
         }
 
         if (input.IsEntra && !string.IsNullOrWhiteSpace(remoteRedirectUri) && apps.RemoteProxyObjectId != null)
         {
             tasks.Add(UpdateRemoteProxyRedirectUrisAsync(tenantId, apps, remoteRedirectUri, concurrentWarnings, ct));
         }
-        else if (input.IsEntra && string.IsNullOrWhiteSpace(remoteRedirectUri))
+        else if (input.IsEntra && apps.RemoteProxyObjectId != null)
         {
-            var msg = "Remote MCP Proxy redirect URI was not returned by the server. Redirect URI configuration skipped.";
-            _logger.LogWarning(msg);
-            concurrentWarnings.Add(msg);
+            if (string.IsNullOrWhiteSpace(remoteRedirectUri))
+            {
+                var msg = "Remote MCP Proxy redirect URI was not returned by the server. Setting consent redirect URIs only.";
+                _logger.LogWarning(msg);
+                concurrentWarnings.Add(msg);
+            }
+            tasks.Add(SetConsentOnlyRedirectUrisAsync(tenantId, apps.RemoteProxyObjectId, apps.RemoteProxyAppName, concurrentWarnings, ct));
         }
         else if (input.IsEntra && apps.RemoteProxyObjectId == null)
         {
@@ -843,6 +848,38 @@ internal class RegisterCommandExecutor
         catch (Exception ex)
         {
             var msg = $"Failed to update redirect URIs on Remote Proxy app: {ex.Message}";
+            _logger.LogError(msg);
+            concurrentWarnings.Add(msg);
+        }
+    }
+
+    private async Task SetConsentOnlyRedirectUrisAsync(
+        string tenantId, string objectId, string appName,
+        System.Collections.Concurrent.ConcurrentBag<string> concurrentWarnings,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+            var consentUris = EntraAppProvisioner.GetConsentRedirectUris(environment);
+            var success = await _retryHelper.ExecuteWithRetryAsync(
+                async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
+                result => !result,
+                cancellationToken: ct);
+            if (!success)
+            {
+                var msg = $"Failed to set web redirect URIs on '{appName}' after retries.";
+                _logger.LogError(msg);
+                concurrentWarnings.Add(msg);
+            }
+            else
+            {
+                _logger.LogDebug("Set {Count} web redirect URIs on '{AppName}'", consentUris.Length, appName);
+            }
+        }
+        catch (Exception ex)
+        {
+            var msg = $"Failed to set web redirect URIs on '{appName}': {ex.Message}";
             _logger.LogError(msg);
             concurrentWarnings.Add(msg);
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -783,7 +783,10 @@ internal class RegisterCommandExecutor
         {
             var a365TcUri = DevelopMcpCommand.AddTcPrefix(a365RedirectUri);
             var a365NonTcUri = DevelopMcpCommand.RemoveTcPrefix(a365RedirectUri);
-            var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri);
+            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+            var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri)
+                .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.A365AppName, apps.A365AppObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(
                 async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, apps.A365AppObjectId, a365Uris, retryCt),
@@ -817,7 +820,10 @@ internal class RegisterCommandExecutor
         {
             var remoteTcUri = DevelopMcpCommand.AddTcPrefix(remoteRedirectUri);
             var remoteNonTcUri = DevelopMcpCommand.RemoveTcPrefix(remoteRedirectUri);
-            var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri);
+            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+            var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri)
+                .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.RemoteProxyAppName, apps.RemoteProxyObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(
                 async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, apps.RemoteProxyObjectId!, remoteUris, retryCt),

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -788,9 +788,8 @@ internal class RegisterCommandExecutor
         {
             var a365TcUri = DevelopMcpCommand.AddTcPrefix(a365RedirectUri);
             var a365NonTcUri = DevelopMcpCommand.RemoveTcPrefix(a365RedirectUri);
-            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
             var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri)
-                .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .Concat(EntraAppProvisioner.GetConsentRedirectUris())
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.A365AppName, apps.A365AppObjectId);
@@ -826,9 +825,8 @@ internal class RegisterCommandExecutor
         {
             var remoteTcUri = DevelopMcpCommand.AddTcPrefix(remoteRedirectUri);
             var remoteNonTcUri = DevelopMcpCommand.RemoveTcPrefix(remoteRedirectUri);
-            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
             var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri)
-                .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .Concat(EntraAppProvisioner.GetConsentRedirectUris())
                 .Distinct(StringComparer.Ordinal)
                 .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.RemoteProxyAppName, apps.RemoteProxyObjectId);
@@ -862,8 +860,7 @@ internal class RegisterCommandExecutor
     {
         try
         {
-            var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
-            var consentUris = EntraAppProvisioner.GetConsentRedirectUris(environment);
+            var consentUris = EntraAppProvisioner.GetConsentRedirectUris();
             var success = await _retryHelper.ExecuteWithRetryAsync(
                 async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
                 result => !result,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -791,6 +791,7 @@ internal class RegisterCommandExecutor
             var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
             var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri)
                 .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .Distinct(StringComparer.Ordinal)
                 .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.A365AppName, apps.A365AppObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(
@@ -828,6 +829,7 @@ internal class RegisterCommandExecutor
             var environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
             var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri)
                 .Concat(EntraAppProvisioner.GetConsentRedirectUris(environment))
+                .Distinct(StringComparer.Ordinal)
                 .ToArray();
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.RemoteProxyAppName, apps.RemoteProxyObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -29,7 +29,7 @@ internal class EntraAppProvisioner
 
     internal static string[] GetConsentRedirectUris(string environment)
     {
-        var envKey = environment?.ToUpperInvariant() ?? "PROD";
+        var envKey = environment?.Trim().ToUpperInvariant() ?? "PROD";
         var customUris = Environment.GetEnvironmentVariable($"A365_CONSENT_REDIRECT_URIS_{envKey}");
         if (!string.IsNullOrWhiteSpace(customUris))
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -27,9 +27,10 @@ internal class EntraAppProvisioner
         "https://admin.cloud.microsoft/?ref=tools/consent",
     ];
 
-    internal static string[] GetConsentRedirectUris(string environment)
+    internal static string[] GetConsentRedirectUris(string? environment = null)
     {
-        var envKey = environment?.Trim().ToUpperInvariant() ?? "PROD";
+        var resolved = environment?.Trim() ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+        var envKey = resolved.ToUpperInvariant();
         var customUris = Environment.GetEnvironmentVariable($"A365_CONSENT_REDIRECT_URIS_{envKey}");
         if (!string.IsNullOrWhiteSpace(customUris))
         {
@@ -116,8 +117,7 @@ internal class EntraAppProvisioner
         string tenantId, string objectId, string appName, string roleDisplay,
         string? environment, CancellationToken ct, List<string>? warnings = null)
     {
-        var resolvedEnvironment = environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
-        var consentUris = GetConsentRedirectUris(resolvedEnvironment);
+        var consentUris = GetConsentRedirectUris(environment);
 
         var success = await _retryHelper.ExecuteWithRetryAsync(
             async retryCt => await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -22,12 +22,6 @@ internal class EntraAppProvisioner
         "http://localhost",
     ];
 
-    private static readonly string[] TestPreProdConsentRedirectUris =
-    [
-        "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
-        "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
-    ];
-
     private static readonly string[] ProdConsentRedirectUris =
     [
         "https://admin.cloud.microsoft/?ref=tools/consent",
@@ -35,11 +29,14 @@ internal class EntraAppProvisioner
 
     internal static string[] GetConsentRedirectUris(string environment)
     {
-        return environment?.ToLowerInvariant() switch
+        var envKey = environment?.ToUpperInvariant() ?? "PROD";
+        var customUris = Environment.GetEnvironmentVariable($"A365_CONSENT_REDIRECT_URIS_{envKey}");
+        if (!string.IsNullOrWhiteSpace(customUris))
         {
-            "test" or "preprod" or "ppe" => [.. TestPreProdConsentRedirectUris],
-            _ => [.. ProdConsentRedirectUris],
-        };
+            return customUris.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+
+        return [.. ProdConsentRedirectUris];
     }
 
     private readonly ILogger _logger;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -29,7 +29,10 @@ internal class EntraAppProvisioner
 
     internal static string[] GetConsentRedirectUris(string? environment = null)
     {
-        var resolved = environment?.Trim() ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+        var trimmed = environment?.Trim();
+        var resolved = string.IsNullOrEmpty(trimmed)
+            ? Environment.GetEnvironmentVariable("A365_ENVIRONMENT")?.Trim() ?? "prod"
+            : trimmed;
         var envKey = resolved.ToUpperInvariant();
         var customUris = Environment.GetEnvironmentVariable($"A365_CONSENT_REDIRECT_URIS_{envKey}");
         if (!string.IsNullOrWhiteSpace(customUris))

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -37,8 +37,8 @@ internal class EntraAppProvisioner
     {
         return environment?.ToLowerInvariant() switch
         {
-            "test" or "preprod" or "ppe" => TestPreProdConsentRedirectUris,
-            _ => ProdConsentRedirectUris,
+            "test" or "preprod" or "ppe" => [.. TestPreProdConsentRedirectUris],
+            _ => [.. ProdConsentRedirectUris],
         };
     }
 
@@ -122,7 +122,10 @@ internal class EntraAppProvisioner
         var resolvedEnvironment = environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
         var consentUris = GetConsentRedirectUris(resolvedEnvironment);
 
-        var success = await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, ct);
+        var success = await _retryHelper.ExecuteWithRetryAsync(
+            async retryCt => await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
+            result => !result,
+            cancellationToken: ct);
         if (success)
         {
             _logger.LogDebug(
@@ -131,7 +134,7 @@ internal class EntraAppProvisioner
         }
         else
         {
-            var msg = $"Failed to set web redirect URIs on {roleDisplay} app '{appName}'.";
+            var msg = $"Failed to set web redirect URIs on {roleDisplay} app '{appName}' after retries.";
             _logger.LogWarning(msg);
             warnings?.Add(msg);
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -22,6 +22,26 @@ internal class EntraAppProvisioner
         "http://localhost",
     ];
 
+    private static readonly string[] TestPreProdConsentRedirectUris =
+    [
+        "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
+        "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
+    ];
+
+    private static readonly string[] ProdConsentRedirectUris =
+    [
+        "https://admin.cloud.microsoft/?ref=tools/consent",
+    ];
+
+    internal static string[] GetConsentRedirectUris(string environment)
+    {
+        return environment?.ToLowerInvariant() switch
+        {
+            "test" or "preprod" or "ppe" => TestPreProdConsentRedirectUris,
+            _ => ProdConsentRedirectUris,
+        };
+    }
+
     private readonly ILogger _logger;
     private readonly GraphApiService _graphApiService;
     private readonly RetryHelper _retryHelper;
@@ -147,6 +167,7 @@ internal class EntraAppProvisioner
         string tenantId,
         string? serviceTreeId,
         List<string> warnings,
+        string? environment = null,
         CancellationToken ct = default)
     {
         var appName = $"{serverName}-PublicClients";
@@ -168,6 +189,9 @@ internal class EntraAppProvisioner
         var brokerRedirectUri = $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{clientId}";
         var publicClientUris = new[] { brokerRedirectUri }.Concat(PublicClientCanonicalRedirectUris).ToArray();
 
+        var resolvedEnvironment = environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+        var consentUris = GetConsentRedirectUris(resolvedEnvironment);
+
         try
         {
             var success = await _retryHelper.ExecuteWithRetryAsync(
@@ -176,18 +200,38 @@ internal class EntraAppProvisioner
                 cancellationToken: ct);
             if (!success)
             {
-                var msg = $"Failed to set redirect URIs on Public Clients app '{appName}' after retries.";
+                var msg = $"Failed to set publicClient redirect URIs on Public Clients app '{appName}' after retries.";
                 _logger.LogError(msg);
                 warnings.Add(msg);
             }
             else
             {
                 _logger.LogDebug(
-                    "Set {RedirectUriCount} redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
+                    "Set {RedirectUriCount} publicClient redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
                     publicClientUris.Length,
                     appName,
                     objectId,
                     string.Join(", ", publicClientUris));
+            }
+
+            var webSuccess = await _retryHelper.ExecuteWithRetryAsync(
+                async retryCt => await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
+                result => !result,
+                cancellationToken: ct);
+            if (!webSuccess)
+            {
+                var msg = $"Failed to set web redirect URIs on Public Clients app '{appName}' after retries.";
+                _logger.LogError(msg);
+                warnings.Add(msg);
+            }
+            else
+            {
+                _logger.LogDebug(
+                    "Set {RedirectUriCount} web redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
+                    consentUris.Length,
+                    appName,
+                    objectId,
+                    string.Join(", ", consentUris));
             }
         }
         catch (Exception ex)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -83,7 +83,6 @@ internal class EntraAppProvisioner
         string roleDisplay,
         string? serviceTreeId,
         int? lifetimeMonths = null,
-        string? environment = null,
         CancellationToken ct = default)
     {
         var appName = $"{serverName}-{suffix}";
@@ -111,8 +110,6 @@ internal class EntraAppProvisioner
             await TryDeleteOrphanedAppAsync(tenantId, app.Value.ObjectId, appName, "empty client ID returned", ct);
             return null;
         }
-
-        await SetWebConsentRedirectUrisAsync(tenantId, app.Value.ObjectId, appName, roleDisplay, environment, ct);
 
         _logger.LogDebug("Created {Role} app: {ClientId}", roleDisplay, app.Value.ClientId);
         return new ProxyAppResult(app.Value.ClientId, secret, app.Value.ObjectId, appName);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -83,6 +83,7 @@ internal class EntraAppProvisioner
         string roleDisplay,
         string? serviceTreeId,
         int? lifetimeMonths = null,
+        string? environment = null,
         CancellationToken ct = default)
     {
         var appName = $"{serverName}-{suffix}";
@@ -111,8 +112,32 @@ internal class EntraAppProvisioner
             return null;
         }
 
+        await SetWebConsentRedirectUrisAsync(tenantId, app.Value.ObjectId, appName, roleDisplay, environment, ct);
+
         _logger.LogDebug("Created {Role} app: {ClientId}", roleDisplay, app.Value.ClientId);
         return new ProxyAppResult(app.Value.ClientId, secret, app.Value.ObjectId, appName);
+    }
+
+    private async Task SetWebConsentRedirectUrisAsync(
+        string tenantId, string objectId, string appName, string roleDisplay,
+        string? environment, CancellationToken ct, List<string>? warnings = null)
+    {
+        var resolvedEnvironment = environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+        var consentUris = GetConsentRedirectUris(resolvedEnvironment);
+
+        var success = await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, ct);
+        if (success)
+        {
+            _logger.LogDebug(
+                "Set {RedirectUriCount} web redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
+                consentUris.Length, appName, objectId, string.Join(", ", consentUris));
+        }
+        else
+        {
+            var msg = $"Failed to set web redirect URIs on {roleDisplay} app '{appName}'.";
+            _logger.LogWarning(msg);
+            warnings?.Add(msg);
+        }
     }
 
     /// <summary>
@@ -189,9 +214,6 @@ internal class EntraAppProvisioner
         var brokerRedirectUri = $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{clientId}";
         var publicClientUris = new[] { brokerRedirectUri }.Concat(PublicClientCanonicalRedirectUris).ToArray();
 
-        var resolvedEnvironment = environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
-        var consentUris = GetConsentRedirectUris(resolvedEnvironment);
-
         try
         {
             var success = await _retryHelper.ExecuteWithRetryAsync(
@@ -214,25 +236,7 @@ internal class EntraAppProvisioner
                     string.Join(", ", publicClientUris));
             }
 
-            var webSuccess = await _retryHelper.ExecuteWithRetryAsync(
-                async retryCt => await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
-                result => !result,
-                cancellationToken: ct);
-            if (!webSuccess)
-            {
-                var msg = $"Failed to set web redirect URIs on Public Clients app '{appName}' after retries.";
-                _logger.LogError(msg);
-                warnings.Add(msg);
-            }
-            else
-            {
-                _logger.LogDebug(
-                    "Set {RedirectUriCount} web redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
-                    consentUris.Length,
-                    appName,
-                    objectId,
-                    string.Join(", ", consentUris));
-            }
+            await SetWebConsentRedirectUrisAsync(tenantId, objectId, appName, "Public Clients", environment, ct, warnings);
         }
         catch (Exception ex)
         {

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -38,17 +38,13 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreateProxyAppAsync_HappyPath_ReturnsAllFieldsPopulatedAndSetsWebConsentUris()
+    public async Task CreateProxyAppAsync_HappyPath_ReturnsAllFieldsPopulated()
     {
-        var capturedWebUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-A365Proxy", serviceTreeId: "svc-tree-7", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.AddAppPasswordAsync(TenantId, AppObjectId).Returns(Task.FromResult<string?>(AppSecret));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Do<string[]>(uris => capturedWebUris.Add(uris)), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
 
-        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "A365Proxy", roleDisplay: "A365 Proxy", serviceTreeId: "svc-tree-7", environment: "prod");
+        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "A365Proxy", roleDisplay: "A365 Proxy", serviceTreeId: "svc-tree-7");
 
         result.Should().NotBeNull();
         result!.ClientId.Should().Be(AppClientId);
@@ -58,37 +54,19 @@ public class EntraAppProvisionerTests
 
         await _graph.Received(1).CreateEntraAppAsync(TenantId, $"{ServerName}-A365Proxy", serviceTreeId: "svc-tree-7", Arg.Any<CancellationToken>());
         await _graph.Received(1).AddAppPasswordAsync(TenantId, AppObjectId);
-
-        capturedWebUris.Should().ContainSingle();
-        capturedWebUris[0].Should().BeEquivalentTo(
-            new[] { "https://admin.cloud.microsoft/?ref=tools/consent" },
-            opt => opt.WithStrictOrdering());
     }
 
     [Fact]
-    public async Task CreateProxyAppAsync_PreProdEnvironment_SetsPreProdWebConsentUris()
+    public async Task CreateProxyAppAsync_UsesSuffixInAppName()
     {
-        var capturedWebUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-RemoteProxy", serviceTreeId: null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.AddAppPasswordAsync(TenantId, AppObjectId).Returns(Task.FromResult<string?>(AppSecret));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Do<string[]>(uris => capturedWebUris.Add(uris)), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
 
-        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "RemoteProxy", roleDisplay: "Remote Proxy", serviceTreeId: null, environment: "preprod");
+        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "RemoteProxy", roleDisplay: "Remote Proxy", serviceTreeId: null);
 
         result.Should().NotBeNull();
         result!.AppName.Should().Be($"{ServerName}-RemoteProxy");
-
-        capturedWebUris.Should().ContainSingle();
-        capturedWebUris[0].Should().BeEquivalentTo(
-            new[]
-            {
-                "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
-                "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
-            },
-            opt => opt.WithStrictOrdering());
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -191,58 +191,46 @@ public class EntraAppProvisionerTests
                      "consent portal. Changing these URIs breaks the admin consent flow.");
     }
 
-    [Theory]
-    [InlineData("test")]
-    [InlineData("preprod")]
-    [InlineData("ppe")]
-    public async Task CreatePublicClientsAppAsync_TestPreProdEnvironment_SetsTestPreProdWebConsentRedirectUris(string environment)
+    [Fact]
+    public void GetConsentRedirectUris_UsesEnvVarOverride()
     {
-        var capturedPublicClientUris = new List<string[]>();
-        var capturedWebUris = new List<string[]>();
-        _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-PublicClients", serviceTreeId: null, Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
-        _graph.UpdateAppPublicClientRedirectUrisAsync(
-                TenantId,
-                AppObjectId,
-                Arg.Do<string[]>(uris => capturedPublicClientUris.Add(uris)),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId,
-                AppObjectId,
-                Arg.Do<string[]>(uris => capturedWebUris.Add(uris)),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
+        const string envKey = "A365_CONSENT_REDIRECT_URIS_PREPROD";
+        var prev = Environment.GetEnvironmentVariable(envKey);
+        try
+        {
+            Environment.SetEnvironmentVariable(envKey, "https://custom1.example.com/consent, https://custom2.example.com/consent");
+            var uris = EntraAppProvisioner.GetConsentRedirectUris("preprod");
+            uris.Should().BeEquivalentTo(
+                new[] { "https://custom1.example.com/consent", "https://custom2.example.com/consent" },
+                opt => opt.WithStrictOrdering(),
+                because: "Non-prod consent redirect URIs are read from A365_CONSENT_REDIRECT_URIS_{ENV} " +
+                         "to avoid leaking internal URLs in source code.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envKey, prev);
+        }
+    }
 
-        var warnings = new List<string>();
-        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings, environment: environment);
-
-        result.Should().NotBeNull();
-        result.ClientId.Should().Be(AppClientId);
-        warnings.Should().BeEmpty();
-
-        capturedPublicClientUris.Should().ContainSingle();
-        capturedPublicClientUris[0].Should().BeEquivalentTo(
-            new[]
-            {
-                $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{AppClientId}",
-                "http://localhost:8080/callback",
-                "https://vscode.dev/redirect",
-                "http://localhost",
-            },
-            opt => opt.WithStrictOrdering());
-
-        capturedWebUris.Should().ContainSingle();
-        capturedWebUris[0].Should().BeEquivalentTo(
-            new[]
-            {
-                "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
-                "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
-            },
-            opt => opt.WithStrictOrdering(),
-            because: "Test/PreProd consent redirect URIs target the sdf and ignite admin " +
-                     "consent portals. Changing these URIs breaks the admin consent flow " +
-                     "in non-production environments.");
+    [Fact]
+    public void GetConsentRedirectUris_FallsToProdWhenNoEnvVar()
+    {
+        const string envKey = "A365_CONSENT_REDIRECT_URIS_PREPROD";
+        var prev = Environment.GetEnvironmentVariable(envKey);
+        try
+        {
+            Environment.SetEnvironmentVariable(envKey, null);
+            var uris = EntraAppProvisioner.GetConsentRedirectUris("preprod");
+            uris.Should().BeEquivalentTo(
+                new[] { "https://admin.cloud.microsoft/?ref=tools/consent" },
+                opt => opt.WithStrictOrdering(),
+                because: "When no env var override is set, all environments fall back to the " +
+                         "prod consent redirect URI.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envKey, prev);
+        }
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -186,7 +186,9 @@ public class EntraAppProvisionerTests
             {
                 "https://admin.cloud.microsoft/?ref=tools/consent",
             },
-            opt => opt.WithStrictOrdering());
+            opt => opt.WithStrictOrdering(),
+            because: "Prod consent redirect URIs are required by the admin.cloud.microsoft " +
+                     "consent portal. Changing these URIs breaks the admin consent flow.");
     }
 
     [Theory]
@@ -237,7 +239,10 @@ public class EntraAppProvisionerTests
                 "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
                 "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
             },
-            opt => opt.WithStrictOrdering());
+            opt => opt.WithStrictOrdering(),
+            because: "Test/PreProd consent redirect URIs target the sdf and ignite admin " +
+                     "consent portals. Changing these URIs breaks the admin consent flow " +
+                     "in non-production environments.");
     }
 
     [Fact]
@@ -295,7 +300,7 @@ public class EntraAppProvisionerTests
         var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
 
         result.ClientId.Should().Be(AppClientId);
-        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients'.");
+        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
     }
 
     [Fact]
@@ -314,5 +319,25 @@ public class EntraAppProvisionerTests
         result.ObjectId.Should().Be(AppObjectId);
         result.AppName.Should().Be($"{ServerName}-PublicClients");
         warnings.Should().ContainSingle().Which.Should().Be("Failed to set redirect URIs on Public Clients app: Graph blew up");
+    }
+
+    [Fact]
+    public async Task CreatePublicClientsAppAsync_WhenWebRedirectUriUpdateThrows_ReturnsIdsAndAppendsExceptionWarning()
+    {
+        _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
+        _graph.UpdateAppPublicClientRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns<Task<bool>>(_ => throw new InvalidOperationException("Graph consent update failed"));
+
+        var warnings = new List<string>();
+        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
+
+        result.ClientId.Should().Be(AppClientId);
+        result.ObjectId.Should().Be(AppObjectId);
+        warnings.Should().ContainSingle().Which.Should().Be("Failed to set redirect URIs on Public Clients app: Graph consent update failed");
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -10,12 +10,16 @@ using Xunit;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
 
+[CollectionDefinition("EntraAppProvisionerTests", DisableParallelization = true)]
+public class EntraAppProvisionerTestsCollection { }
+
 /// <summary>
 /// Tests for <see cref="EntraAppProvisioner"/>. The provisioner absorbed the per-app creation flows
 /// that previously lived inline in PublishCommandExecutor and RegisterCommandExecutor. These tests
 /// pin every branch (success + each failure mode) so the executors can compose the provisioner
 /// without needing their own per-step coverage.
 /// </summary>
+[Collection("EntraAppProvisionerTests")]
 public class EntraAppProvisionerTests
 {
     private const string ServerName = "mcp_TestServer";

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -136,20 +136,27 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreatePublicClientsAppAsync_HappyPath_ReturnsIdsAndSetsBrokerAndCanonicalRedirectUris()
+    public async Task CreatePublicClientsAppAsync_ProdEnvironment_SetsPublicClientAndWebConsentRedirectUris()
     {
-        var capturedUris = new List<string[]>();
+        var capturedPublicClientUris = new List<string[]>();
+        var capturedWebUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-PublicClients", serviceTreeId: "svc-tree-9", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.UpdateAppPublicClientRedirectUrisAsync(
                 TenantId,
                 AppObjectId,
-                Arg.Do<string[]>(uris => capturedUris.Add(uris)),
+                Arg.Do<string[]>(uris => capturedPublicClientUris.Add(uris)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId,
+                AppObjectId,
+                Arg.Do<string[]>(uris => capturedWebUris.Add(uris)),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
         var warnings = new List<string>();
-        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: "svc-tree-9", warnings);
+        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: "svc-tree-9", warnings, environment: "prod");
 
         result.Should().NotBeNull();
         result.ClientId.Should().Be(AppClientId);
@@ -157,9 +164,8 @@ public class EntraAppProvisionerTests
         result.AppName.Should().Be($"{ServerName}-PublicClients");
         warnings.Should().BeEmpty();
 
-        capturedUris.Should().ContainSingle();
-        var uris = capturedUris[0];
-        uris.Should().BeEquivalentTo(
+        capturedPublicClientUris.Should().ContainSingle();
+        capturedPublicClientUris[0].Should().BeEquivalentTo(
             new[]
             {
                 $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{AppClientId}",
@@ -173,6 +179,65 @@ public class EntraAppProvisionerTests
                      "on Windows, the localhost callbacks support MSAL.NET and Copilot CLI flows, " +
                      "and vscode.dev/redirect supports the VS Code web client. Silently " +
                      "adding/removing/reordering entries breaks one of those flows.");
+
+        capturedWebUris.Should().ContainSingle();
+        capturedWebUris[0].Should().BeEquivalentTo(
+            new[]
+            {
+                "https://admin.cloud.microsoft/?ref=tools/consent",
+            },
+            opt => opt.WithStrictOrdering());
+    }
+
+    [Theory]
+    [InlineData("test")]
+    [InlineData("preprod")]
+    [InlineData("ppe")]
+    public async Task CreatePublicClientsAppAsync_TestPreProdEnvironment_SetsTestPreProdWebConsentRedirectUris(string environment)
+    {
+        var capturedPublicClientUris = new List<string[]>();
+        var capturedWebUris = new List<string[]>();
+        _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-PublicClients", serviceTreeId: null, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
+        _graph.UpdateAppPublicClientRedirectUrisAsync(
+                TenantId,
+                AppObjectId,
+                Arg.Do<string[]>(uris => capturedPublicClientUris.Add(uris)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId,
+                AppObjectId,
+                Arg.Do<string[]>(uris => capturedWebUris.Add(uris)),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+
+        var warnings = new List<string>();
+        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings, environment: environment);
+
+        result.Should().NotBeNull();
+        result.ClientId.Should().Be(AppClientId);
+        warnings.Should().BeEmpty();
+
+        capturedPublicClientUris.Should().ContainSingle();
+        capturedPublicClientUris[0].Should().BeEquivalentTo(
+            new[]
+            {
+                $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{AppClientId}",
+                "http://localhost:8080/callback",
+                "https://vscode.dev/redirect",
+                "http://localhost",
+            },
+            opt => opt.WithStrictOrdering());
+
+        capturedWebUris.Should().ContainSingle();
+        capturedWebUris[0].Should().BeEquivalentTo(
+            new[]
+            {
+                "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
+                "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
+            },
+            opt => opt.WithStrictOrdering());
     }
 
     [Fact]
@@ -194,13 +259,16 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreatePublicClientsAppAsync_WhenRedirectUriUpdateReturnsFalse_ReturnsIdsAndAppendsRetryWarning()
+    public async Task CreatePublicClientsAppAsync_WhenPublicClientRedirectUriUpdateReturnsFalse_AppendsWarning()
     {
         _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.UpdateAppPublicClientRedirectUrisAsync(
                 TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
 
         var warnings = new List<string>();
         var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
@@ -208,7 +276,26 @@ public class EntraAppProvisionerTests
         result.ClientId.Should().Be(AppClientId);
         result.ObjectId.Should().Be(AppObjectId);
         result.AppName.Should().Be($"{ServerName}-PublicClients");
-        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
+        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set publicClient redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
+    }
+
+    [Fact]
+    public async Task CreatePublicClientsAppAsync_WhenWebRedirectUriUpdateReturnsFalse_AppendsWarning()
+    {
+        _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
+        _graph.UpdateAppPublicClientRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(false));
+
+        var warnings = new List<string>();
+        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
+
+        result.ClientId.Should().Be(AppClientId);
+        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -213,6 +213,26 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
+    public void GetConsentRedirectUris_TrimsWhitespaceFromEnvironment()
+    {
+        const string envKey = "A365_CONSENT_REDIRECT_URIS_TEST";
+        var prev = Environment.GetEnvironmentVariable(envKey);
+        try
+        {
+            Environment.SetEnvironmentVariable(envKey, "https://trimmed.example.com/consent");
+            var uris = EntraAppProvisioner.GetConsentRedirectUris("  test  ");
+            uris.Should().BeEquivalentTo(
+                new[] { "https://trimmed.example.com/consent" },
+                because: "Environment values with leading/trailing whitespace (common in " +
+                         "shell/env var setups) must resolve to the correct env var key.");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envKey, prev);
+        }
+    }
+
+    [Fact]
     public void GetConsentRedirectUris_FallsToProdWhenNoEnvVar()
     {
         const string envKey = "A365_CONSENT_REDIRECT_URIS_PREPROD";

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -38,13 +38,17 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreateProxyAppAsync_HappyPath_ReturnsAllFieldsPopulated()
+    public async Task CreateProxyAppAsync_HappyPath_ReturnsAllFieldsPopulatedAndSetsWebConsentUris()
     {
+        var capturedWebUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-A365Proxy", serviceTreeId: "svc-tree-7", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.AddAppPasswordAsync(TenantId, AppObjectId).Returns(Task.FromResult<string?>(AppSecret));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Do<string[]>(uris => capturedWebUris.Add(uris)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
 
-        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "A365Proxy", roleDisplay: "A365 Proxy", serviceTreeId: "svc-tree-7");
+        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "A365Proxy", roleDisplay: "A365 Proxy", serviceTreeId: "svc-tree-7", environment: "prod");
 
         result.Should().NotBeNull();
         result!.ClientId.Should().Be(AppClientId);
@@ -54,19 +58,37 @@ public class EntraAppProvisionerTests
 
         await _graph.Received(1).CreateEntraAppAsync(TenantId, $"{ServerName}-A365Proxy", serviceTreeId: "svc-tree-7", Arg.Any<CancellationToken>());
         await _graph.Received(1).AddAppPasswordAsync(TenantId, AppObjectId);
+
+        capturedWebUris.Should().ContainSingle();
+        capturedWebUris[0].Should().BeEquivalentTo(
+            new[] { "https://admin.cloud.microsoft/?ref=tools/consent" },
+            opt => opt.WithStrictOrdering());
     }
 
     [Fact]
-    public async Task CreateProxyAppAsync_UsesSuffixInAppName()
+    public async Task CreateProxyAppAsync_PreProdEnvironment_SetsPreProdWebConsentUris()
     {
+        var capturedWebUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-RemoteProxy", serviceTreeId: null, Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.AddAppPasswordAsync(TenantId, AppObjectId).Returns(Task.FromResult<string?>(AppSecret));
+        _graph.UpdateAppRedirectUrisAsync(
+                TenantId, AppObjectId, Arg.Do<string[]>(uris => capturedWebUris.Add(uris)), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(true));
 
-        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "RemoteProxy", roleDisplay: "Remote Proxy", serviceTreeId: null);
+        var result = await _provisioner.CreateProxyAppAsync(ServerName, TenantId, suffix: "RemoteProxy", roleDisplay: "Remote Proxy", serviceTreeId: null, environment: "preprod");
 
         result.Should().NotBeNull();
         result!.AppName.Should().Be($"{ServerName}-RemoteProxy");
+
+        capturedWebUris.Should().ContainSingle();
+        capturedWebUris[0].Should().BeEquivalentTo(
+            new[]
+            {
+                "https://sdf.admin.cloud.microsoft/?ref=tools/consent",
+                "https://ignite.admin.cloud.microsoft/?ref=tools/consent",
+            },
+            opt => opt.WithStrictOrdering());
     }
 
     [Fact]
@@ -295,7 +317,7 @@ public class EntraAppProvisionerTests
         var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
 
         result.ClientId.Should().Be(AppClientId);
-        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
+        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients'.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Adds environment-aware consent redirect URIs as **web** platform redirect URIs on the `-PublicClients` Entra app created during `develop-mcp publish` and `develop-mcp register-external-mcp-server` flows
- Test/PreProd/PPE: `https://sdf.admin.cloud.microsoft/?ref=tools/consent` and `https://ignite.admin.cloud.microsoft/?ref=tools/consent`
- Prod (default): `https://admin.cloud.microsoft/?ref=tools/consent`
- Environment resolved from explicit parameter, `A365_ENVIRONMENT` env var, or defaults to `prod`

## Test plan
- [x] Unit tests pass (14 tests in EntraAppProvisionerTests)
- [x] Tested live `register-external-mcp-server` against PreProd — confirmed publicClient URIs (4) and web URIs (2) are set separately via two PATCH calls
- [ ] Verify web redirect URIs appear under "Web" platform in Entra portal for the created app

🤖 Generated with [Claude Code](https://claude.com/claude-code)