### PR TITLE
Fix #452: unify 'setup blueprint' consent through BatchPermissionsOrchestrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `--yes` / `-y` option on `develop-mcp publish` — skips the interactive "Proceed with publish? (y/N)" confirmation.
 
 ### Fixed
-- `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, and no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically; non-admins are shown the admin-consent URL to hand off (#452).
+- `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically, and ends with a setup summary whose Action Required block surfaces the admin-consent URL for non-admins to hand off (#452).
 - Messaging endpoint registration and removal now retry on transient network errors instead of failing on a momentary DNS or connection blip.
 - Commands requiring authentication no longer return misleading Graph 403 errors when Windows has multiple cached work accounts. The CLI detects a wrong-tenant token (`tid` claim mismatch), clears the MSAL token cache, and retries automatically (#430).
 - `setup all` now exits silently on Ctrl+C instead of printing `ERROR: Setup failed: A task was canceled.` followed by a misleading partial summary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `--yes` / `-y` option on `develop-mcp publish` — skips the interactive "Proceed with publish? (y/N)" confirmation.
 
 ### Fixed
+- `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, and no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically; non-admins are shown the admin-consent URL to hand off (#452).
 - Messaging endpoint registration and removal now retry on transient network errors instead of failing on a momentary DNS or connection blip.
 - Commands requiring authentication no longer return misleading Graph 403 errors when Windows has multiple cached work accounts. The CLI detects a wrong-tenant token (`tid` claim mismatch), clears the MSAL token cache, and retries automatically (#430).
 - `setup all` now exits silently on Ctrl+C instead of printing `ERROR: Setup failed: A task was canceled.` followed by a misleading partial summary.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
@@ -40,12 +40,14 @@ internal class PublishCommandExecutor
     internal PublishCommandExecutor(
         ILogger logger,
         IAgent365ToolingService toolingService,
-        GraphApiService? graphApiService)
+        GraphApiService? graphApiService,
+        RetryHelper? retryHelper = null)
     {
         _logger = logger;
         _toolingService = toolingService;
         _graphApiService = graphApiService;
-        _retryHelper = new RetryHelper(logger, maxRetries: 5, baseDelaySeconds: 3);
+        // Injectable so tests can supply a zero-delay RetryHelper (mirrors GraphApiService / ArmApiService).
+        _retryHelper = retryHelper ?? new RetryHelper(logger, maxRetries: 5, baseDelaySeconds: 3);
     }
 
     private sealed record ResolvedInput

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -47,12 +47,14 @@ internal class RegisterCommandExecutor
     internal RegisterCommandExecutor(
         ILogger logger,
         IAgent365ToolingService toolingService,
-        GraphApiService? graphApiService)
+        GraphApiService? graphApiService,
+        RetryHelper? retryHelper = null)
     {
         _logger = logger;
         _toolingService = toolingService;
         _graphApiService = graphApiService;
-        _retryHelper = new RetryHelper(logger, maxRetries: 5, baseDelaySeconds: 3);
+        // Injectable so tests can supply a zero-delay RetryHelper (mirrors GraphApiService / ArmApiService).
+        _retryHelper = retryHelper ?? new RetryHelper(logger, maxRetries: 5, baseDelaySeconds: 3);
     }
 
     private sealed record ResolvedInput

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupCommand.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Commands
                 logger, configService, authValidator, clientAppValidator, executor, graphApiService, requirementChecksOverride));
 
             command.AddCommand(BlueprintSubcommand.CreateCommand(
-                logger, configService, executor, authValidator, platformDetector, backendConfigurator, graphApiService, blueprintService, clientAppValidator, blueprintLookupService, federatedCredentialService, resolver: resolver));
+                logger, configService, executor, authValidator, platformDetector, backendConfigurator, graphApiService, blueprintService, clientAppValidator, blueprintLookupService, federatedCredentialService, confirmationProvider, resolver: resolver));
 
             command.AddCommand(PermissionsSubcommand.CreateCommand(
                 logger, authValidator, configService, executor, graphApiService, blueprintService, confirmationProvider, resolver: resolver));

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
@@ -1195,9 +1195,16 @@ internal static class BatchPermissionsOrchestrator
     /// Default <strong>false</strong> so the helper actually runs in production. Tests
     /// for <see cref="ConfigureAllPermissionsAsync"/> that do not want the helper firing
     /// must set this to true in their setup. Tests that exercise the helper directly
-    /// leave it false. Pattern mirrors <see cref="AdminConsentHelper.BypassConsentChecksForTests"/>.
+    /// leave it false. Backed by <see cref="AsyncLocal{T}"/> (mirrors
+    /// <see cref="AdminConsentHelper.BypassConsentChecksForTests"/>) so the flag is scoped to the
+    /// setting test's async flow and cannot leak across parallel test classes.
     /// </summary>
-    internal static bool BypassSpProvisioningForTests { get; set; } = false;
+    internal static bool BypassSpProvisioningForTests
+    {
+        get => _bypassSpProvisioning.Value;
+        set => _bypassSpProvisioning.Value = value;
+    }
+    private static readonly AsyncLocal<bool> _bypassSpProvisioning = new();
 
     /// <summary>
     /// Builds the <c>az ad sp create</c> command that provisions a missing resource SP in

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -125,6 +125,7 @@ internal static class BlueprintSubcommand
         IClientAppValidator clientAppValidator,
         BlueprintLookupService blueprintLookupService,
         FederatedCredentialService federatedCredentialService,
+        IConfirmationProvider? confirmationProvider = null,
         IBootstrapConfigResolver? resolver = null)
     {
         var command = new Command("blueprint",
@@ -399,12 +400,12 @@ internal static class BlueprintSubcommand
 
             logger.LogInformation("Starting blueprint setup... (TraceId: {TraceId})", correlationId);
 
-            // --m365 only affects --endpoint-only / --update-endpoint paths. Surface a one-line note when the flag
-            // was passed in isolation so the user does not assume it triggered messaging endpoint registration.
+            // On 'setup blueprint' --m365 only tailors the follow-up guidance; it does not register the
+            // messaging endpoint. Surface a note when it's passed in isolation so the user isn't misled.
             if (isM365 && !endpointOnly && string.IsNullOrWhiteSpace(updateEndpoint))
             {
                 logger.LogInformation(
-                    "Note: --m365 has no effect on 'setup blueprint' by itself. Use 'a365 setup all --m365' to register the messaging endpoint, " +
+                    "Note: --m365 does not register the messaging endpoint on 'setup blueprint'. Use 'a365 setup all --m365' to register the messaging endpoint, " +
                     "or 'a365 setup blueprint --endpoint-only' after the blueprint exists.");
             }
 
@@ -448,7 +449,9 @@ internal static class BlueprintSubcommand
                 blueprintLookupService,
                 federatedCredentialService,
                 skipEndpointRegistration,
-                correlationId: correlationId
+                correlationId: correlationId,
+                confirmationProvider: confirmationProvider,
+                isM365: isM365
                 );
 
         });
@@ -515,7 +518,9 @@ internal static class BlueprintSubcommand
         string? correlationId = null,
         CancellationToken cancellationToken = default,
         BlueprintCreationOptions? options = null,
-        Func<Task<string?>>? loginHintResolver = null)
+        Func<Task<string?>>? loginHintResolver = null,
+        IConfirmationProvider? confirmationProvider = null,
+        bool isM365 = false)
     {
         logger.LogInformation("");
         logger.LogInformation("Creating agent blueprint...");
@@ -622,7 +627,8 @@ internal static class BlueprintSubcommand
                 config,
                 cancellationToken,
                 options,
-                loginHintResolver: loginHintResolver);
+                loginHintResolver: loginHintResolver,
+                confirmationProvider: confirmationProvider);
 
         if (!blueprintResult.success)
         {
@@ -749,7 +755,11 @@ internal static class BlueprintSubcommand
         {
             logger.LogInformation("Next steps:");
             logger.LogInformation("  1. Run 'a365 setup permissions mcp' to configure MCP permissions");
-            logger.LogInformation("  2. Run 'a365 setup permissions bot' to configure Bot API permissions");
+            // 'setup permissions bot' also covers Observability + Power Platform (needed by all agents),
+            // so always show it; name the M365-only Bot API explicitly only when --m365.
+            logger.LogInformation(isM365
+                ? "  2. Run 'a365 setup permissions bot' to configure Bot API, Observability, and Power Platform permissions"
+                : "  2. Run 'a365 setup permissions bot' to configure Observability and Power Platform permissions");
         }
 
         return new BlueprintCreationResult
@@ -858,7 +868,8 @@ internal static class BlueprintSubcommand
         FileInfo configFile,
         CancellationToken ct,
         BlueprintCreationOptions? options = null,
-        Func<Task<string?>>? loginHintResolver = null)
+        Func<Task<string?>>? loginHintResolver = null,
+        IConfirmationProvider? confirmationProvider = null)
     {
         // ========================================================================
         // Idempotency Check: DisplayName-First Discovery
@@ -1000,7 +1011,6 @@ internal static class BlueprintSubcommand
                 executor,
                 graphApiService,
                 blueprintService,
-                blueprintLookupService,
                 federatedCredentialService,
                 tenantId,
                 displayName,
@@ -1013,7 +1023,8 @@ internal static class BlueprintSubcommand
                 existingServicePrincipalId,
                 alreadyExisted: true,
                 ct,
-                options);
+                options,
+                confirmationProvider: confirmationProvider);
         }
 
         // ========================================================================
@@ -1405,7 +1416,6 @@ internal static class BlueprintSubcommand
                 executor,
                 graphApiService,
                 blueprintService,
-                blueprintLookupService,
                 federatedCredentialService,
                 tenantId,
                 displayName,
@@ -1419,7 +1429,8 @@ internal static class BlueprintSubcommand
                 alreadyExisted: false,
                 ct,
                 options,
-                ownerSetAtCreation: !string.IsNullOrEmpty(sponsorUserId));
+                ownerSetAtCreation: !string.IsNullOrEmpty(sponsorUserId),
+                confirmationProvider: confirmationProvider);
         }
         catch (Exception ex)
         {
@@ -1499,7 +1510,6 @@ internal static class BlueprintSubcommand
         CommandExecutor executor,
         GraphApiService graphApiService,
         AgentBlueprintService blueprintService,
-        BlueprintLookupService blueprintLookupService,
         FederatedCredentialService federatedCredentialService,
         string tenantId,
         string displayName,
@@ -1513,7 +1523,8 @@ internal static class BlueprintSubcommand
         bool alreadyExisted,
         CancellationToken ct,
         BlueprintCreationOptions? options = null,
-        bool ownerSetAtCreation = false)
+        bool ownerSetAtCreation = false,
+        IConfirmationProvider? confirmationProvider = null)
     {
         // ========================================================================
         // Application Owner Validation
@@ -1687,15 +1698,13 @@ internal static class BlueprintSubcommand
             executor,
             graphApiService,
             blueprintService,
-            blueprintLookupService,
             tenantId,
             appId,
-            objectId,
             servicePrincipalId,
             setupConfig,
-            alreadyExisted,
             ct,
-            deferConsent: options?.DeferConsent ?? false);
+            deferConsent: options?.DeferConsent ?? false,
+            confirmationProvider: confirmationProvider);
 
         // Add Graph API consent to the resource consents collection
         var applicationScopes = GetApplicationScopes(setupConfig, logger);
@@ -1836,25 +1845,25 @@ internal static class BlueprintSubcommand
     }
 
     /// <summary>
-    /// Ensures admin consent for the blueprint application.
-    /// For existing blueprints, checks if consent already exists before requesting browser interaction.
-    /// For new blueprints, skips verification and directly requests consent.
+    /// Ensures admin consent and Graph inheritable permissions for the blueprint by delegating to
+    /// <see cref="BatchPermissionsOrchestrator.ConfigureAllPermissionsAsync"/> (the engine <c>setup all</c>
+    /// uses) with a Graph-only spec. Inheritable permissions are configured independently of the OAuth2
+    /// grant, a failed grant is non-fatal, and a consent URL is returned for non-admins to hand off.
     /// Returns: (consentSuccess, consentUrl, graphInheritablePermissionsConfigured, graphInheritablePermissionsError)
     /// </summary>
-    private static async Task<(bool consentSuccess, string consentUrl, bool graphInheritablePermissionsConfigured, string? graphInheritablePermissionsError)> EnsureAdminConsentAsync(
+    /// <remarks>Internal (not private) so the delegation can be unit tested directly.</remarks>
+    internal static async Task<(bool consentSuccess, string consentUrl, bool graphInheritablePermissionsConfigured, string? graphInheritablePermissionsError)> EnsureAdminConsentAsync(
         ILogger logger,
         CommandExecutor executor,
         GraphApiService graphApiService,
         AgentBlueprintService blueprintService,
-        BlueprintLookupService blueprintLookupService,
         string tenantId,
         string appId,
-        string objectId,
         string? servicePrincipalId,
         Models.Agent365Config setupConfig,
-        bool alreadyExisted,
         CancellationToken ct,
-        bool deferConsent = false)
+        bool deferConsent = false,
+        IConfirmationProvider? confirmationProvider = null)
     {
         // When called from AllSubcommand via DeferConsent: true, skip consent and Graph
         // inheritable permissions entirely. The batch orchestrator handles both as Phase 3
@@ -1869,186 +1878,74 @@ internal static class BlueprintSubcommand
         }
 
         var applicationScopes = GetApplicationScopes(setupConfig, logger);
-        bool consentAlreadyExists = false;
+        setupConfig.AgentBlueprintId = appId;
 
-        // Resolve blueprint SP object ID once — reused by both pre-check and polling.
-        // servicePrincipalId comes from generated config (persisted on previous runs).
-        // If absent, look it up using MSAL scopes that include Application.Read.All.
-        // Without Application.Read.All the az CLI token causes Graph to return empty results silently.
-        var blueprintSpId = servicePrincipalId;
-        if (string.IsNullOrWhiteSpace(blueprintSpId))
-        {
-            logger.LogDebug("Looking up service principal for blueprint...");
-            var spLookup = await blueprintLookupService.GetServicePrincipalByAppIdAsync(
-                tenantId, appId, ct,
-                scopes: AuthenticationConstants.RequiredPermissionGrantScopes);
-            blueprintSpId = spLookup.ObjectId;
-        }
+        // Graph-only spec — MCP/Bot/Power Platform remain the separate 'a365 setup permissions' steps.
+        var graphSpec = new ResourcePermissionSpec(
+            AuthenticationConstants.MicrosoftGraphResourceAppId,
+            "Microsoft Graph",
+            applicationScopes.ToArray(),
+            SetInheritable: true);
 
-        // Only check for existing consent if blueprint already existed
-        // New blueprints cannot have consent yet, so skip the verification
-        if (alreadyExisted)
-        {
-            logger.LogInformation("Verifying admin consent for application");
-            logger.LogDebug("  - Application scopes: {Scopes}", string.Join(", ", applicationScopes));
-
-            if (!string.IsNullOrWhiteSpace(blueprintSpId))
-            {
-                // Get Microsoft Graph service principal ID (needs Application.Read.All)
-                var graphSpId = await graphApiService.LookupServicePrincipalByAppIdAsync(
-                    tenantId,
-                    AuthenticationConstants.MicrosoftGraphResourceAppId,
-                    ct,
-                    AuthenticationConstants.RequiredPermissionGrantScopes);
-
-                if (!string.IsNullOrWhiteSpace(graphSpId))
-                {
-                    // Use shared helper to check existing consent
-                    consentAlreadyExists = await AdminConsentHelper.CheckConsentExistsAsync(
-                        graphApiService,
-                        tenantId,
-                        blueprintSpId,
-                        graphSpId,
-                        applicationScopes,
-                        logger,
-                        ct,
-                        scopes: AuthenticationConstants.RequiredPermissionGrantScopes);
-                }
-            }
-
-            if (consentAlreadyExists)
-            {
-                logger.LogInformation("Admin consent already granted for all required scopes");
-                logger.LogDebug("  - Scopes: {Scopes}", string.Join(", ", applicationScopes));
-            }
-        }
-
+        // Build the reference/handoff URL up front so it is available even if the orchestrator throws.
         var consentUrlGraph = SetupHelpers.BuildAdminConsentUrl(
             tenantId, appId,
             applicationScopes.Select(s => $"{AuthenticationConstants.MicrosoftGraphResourceUri}/{s}"));
 
-        if (consentAlreadyExists)
+        bool consentSuccess;
+        bool inheritedConfigured;
+        try
         {
-            // For existing consent, we still need to verify/configure inheritable permissions
-            logger.LogInformation("Configuring inheritable permissions for Microsoft Graph...");
-            bool graphInheritableConfigured = false;
-            string? graphInheritableError = null;
-            try
-            {
-                setupConfig.AgentBlueprintId = appId;
-
-                await SetupHelpers.EnsureResourcePermissionsAsync(
+            var (_, configured, consentGranted, consentHandoffUrl) =
+                await BatchPermissionsOrchestrator.ConfigureAllPermissionsAsync(
                     graph: graphApiService,
                     blueprintService: blueprintService,
                     config: setupConfig,
-                    resourceAppId: AuthenticationConstants.MicrosoftGraphResourceAppId,
-                    resourceName: "Microsoft Graph",
-                    scopes: applicationScopes.ToArray(),
+                    blueprintAppId: appId,
+                    tenantId: tenantId,
+                    specs: new[] { graphSpec },
                     logger: logger,
-                    addToRequiredResourceAccess: false,
-                    setInheritablePermissions: true,
                     setupResults: null,
-                    ct: ct);
+                    ct: ct,
+                    knownBlueprintSpObjectId: servicePrincipalId,
+                    confirmationProvider: confirmationProvider,
+                    commandExecutor: executor);
 
-                logger.LogInformation("Microsoft Graph inheritable permissions configured successfully");
-                graphInheritableConfigured = true;
-            }
-            catch (Exception ex)
-            {
-                graphInheritableError = ex.Message;
-                logger.LogWarning("Failed to configure Microsoft Graph inheritable permissions: {Message}", ex.Message);
-                logger.LogWarning("Agent instances may not be able to access Microsoft Graph resources");
-                logger.LogWarning("You can configure these manually later with: a365 setup blueprint");
-            }
-
-            return (true, consentUrlGraph, graphInheritableConfigured, graphInheritableError);
+            inheritedConfigured = configured;
+            // consentHandoffUrl is non-null only when consent could not be verified (e.g. non-admin) —
+            // prefer it. consentSuccess maps to the orchestrator's "url == null ⇒ verified" contract.
+            if (consentHandoffUrl is not null)
+                consentUrlGraph = consentHandoffUrl;
+            consentSuccess = consentGranted && consentHandoffUrl is null;
         }
-
-        // Check if the current user has an admin role that can grant tenant-wide consent
-        var adminCheck = await graphApiService.IsCurrentUserAdminAsync(tenantId, ct);
-        if (adminCheck == Models.RoleCheckResult.DoesNotHaveRole)
+        catch (OperationCanceledException)
         {
-            logger.LogWarning("Tenant-wide admin consent is needed for the agent blueprint's delegated scopes (per-blueprint).");
-            logger.LogWarning("  Reason: the blueprint's API permissions require tenant-wide consent, which only an admin can grant.");
-            logger.LogWarning("  Ask a tenant administrator to open this URL to grant consent:");
-            logger.LogWarning("    {ConsentUrl}", consentUrlGraph);
-
-            return (false, consentUrlGraph, false, null);
-        }
-
-        if (adminCheck == Models.RoleCheckResult.Unknown)
-        {
-            logger.LogDebug("Admin role check inconclusive — attempting consent anyway; API will surface any permission error.");
-        }
-
-        // Request consent via browser
-        logger.LogInformation("Requesting admin consent for application");
-        logger.LogDebug("  - Application scopes: {Scopes}", string.Join(", ", applicationScopes));
-        logger.LogInformation("Opening browser for Graph API admin consent...");
-        logger.LogInformation("If the browser does not open automatically, navigate to this URL to grant consent: {ConsentUrl}", consentUrlGraph);
-        BrowserHelper.TryOpenUrl(consentUrlGraph, logger);
-
-        // Poll via az rest. The Graph overload of PollAdminConsentAsync cannot reliably read
-        // /oauth2PermissionGrants with the CLI's delegated token (DelegatedPermissionGrant.Read.All
-        // was removed from the CLI client app in PR #409), so it timed out into AssumedComplete on
-        // every successful consent — printing a misleading "continuing without auto-verification"
-        // hint even when the grant had actually landed. The az rest path uses the Azure CLI's GA
-        // directory-role access to read grants directly, matching the pattern used by
-        // BatchPermissionsOrchestrator's pre-check and post-consent polling.
-        var consentSuccess = await AdminConsentHelper.PollAdminConsentAsync(
-            executor, logger, appId, "Graph API Scopes", 180, 5, ct);
-        if (consentSuccess)
-        {
-            logger.LogInformation("Graph API admin consent granted successfully!");
-        }
-        else
-        {
-            logger.LogWarning("Graph API admin consent may not have completed.");
-            logger.LogWarning("  Open this URL to grant consent manually: {ConsentUrl}", consentUrlGraph);
-        }
-
-        // Configure Graph inheritable permissions regardless of admin consent outcome.
-        // Inheritable permissions define what scopes agent instances *can* inherit from the blueprint
-        // and require AgentIdentityBlueprint.ReadWrite.All (already consented on the client app).
-        // Admin consent is a separate gate that controls whether those inherited scopes are usable
-        // at runtime — it does not block configuring the permission manifest here.
-        bool graphInheritablePermissionsConfigured = false;
-        string? graphInheritablePermissionsError = null;
-
-        logger.LogInformation("Configuring inheritable permissions for Microsoft Graph...");
-        try
-        {
-            setupConfig.AgentBlueprintId = appId;
-
-            await SetupHelpers.EnsureResourcePermissionsAsync(
-                graph: graphApiService,
-                blueprintService: blueprintService,
-                config: setupConfig,
-                resourceAppId: AuthenticationConstants.MicrosoftGraphResourceAppId,
-                resourceName: "Microsoft Graph",
-                scopes: applicationScopes.ToArray(),
-                logger: logger,
-                addToRequiredResourceAccess: false,
-                setInheritablePermissions: true,
-                setupResults: null,
-                ct: ct);
-
-            logger.LogInformation("Microsoft Graph inheritable permissions configured successfully");
-            if (!consentSuccess)
-            {
-                logger.LogWarning("Note: Admin consent has not been granted — Graph permissions will not be usable at runtime until an admin grants consent via: {Url}", consentUrlGraph);
-            }
-            graphInheritablePermissionsConfigured = true;
+            throw; // Ctrl+C must abort, not be swallowed.
         }
         catch (Exception ex)
         {
-            graphInheritablePermissionsError = ex.Message;
-            logger.LogWarning("Failed to configure Microsoft Graph inheritable permissions: {Message}", ex.Message);
-            logger.LogWarning("Agent instances may not be able to access Microsoft Graph resources");
-            logger.LogWarning("You can configure these manually later with: a365 setup blueprint");
+            // Non-fatal: a consent/permissions failure must not abort blueprint creation. AllSubcommand
+            // wraps this same orchestrator call for the same reason; the standalone path must too.
+            logger.LogWarning("Failed to configure Microsoft Graph consent / inheritable permissions: {Message}", ex.Message);
+            return (consentSuccess: false, consentUrl: consentUrlGraph,
+                    graphInheritablePermissionsConfigured: false, graphInheritablePermissionsError: ex.Message);
         }
 
-        return (consentSuccess, consentUrlGraph, graphInheritablePermissionsConfigured, graphInheritablePermissionsError);
+        if (!consentSuccess)
+        {
+            // Surface the consent URL inline — standalone 'setup blueprint' renders no batch summary, so
+            // without this a non-admin gets no handoff and the granted scopes never land.
+            logger.LogWarning("Tenant-wide admin consent is needed for the agent blueprint's delegated Microsoft Graph scopes.");
+            logger.LogWarning("  Reason: granting tenant-wide consent for these scopes requires a tenant administrator.");
+            logger.LogWarning("  Ask a tenant administrator to open this URL to grant consent:");
+            logger.LogWarning("    {ConsentUrl}", consentUrlGraph);
+        }
+
+        var graphInheritablePermissionsError = inheritedConfigured
+            ? null
+            : "Inheritable permissions for Microsoft Graph were not configured. Ensure you have the Agent ID Administrator (or Global Administrator) role, then re-run 'a365 setup blueprint'.";
+
+        return (consentSuccess, consentUrlGraph, inheritedConfigured, graphInheritablePermissionsError);
     }
 
     /// <summary>
@@ -2179,20 +2076,9 @@ internal static class BlueprintSubcommand
         using var clientSecretScope = logger.Indent();
         try
         {
-            // Check ownership before attempting creation — warn early if the current user is not an
-            // owner so they know why the POST /addPassword will return 403 Authorization_RequestDenied.
-            if (!string.IsNullOrWhiteSpace(setupConfig.TenantId) && !string.IsNullOrWhiteSpace(blueprintObjectId))
-            {
-                var isOwner = await graphService.IsApplicationOwnerAsync(
-                    setupConfig.TenantId, blueprintObjectId, ct: ct,
-                    scopes: AuthenticationConstants.BlueprintOperationScopes);
-                if (isOwner == false)
-                {
-                    logger.LogWarning("You are not an owner of this blueprint. Client secret creation will fail.");
-                    logger.LogWarning("Ask a blueprint owner to run setup, or add yourself as an owner first:");
-                    logger.LogWarning("  https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/{AppId}", blueprintAppId);
-                }
-            }
+            // No pre-flight owner check: right after creation the owner edge hasn't replicated, so a
+            // one-shot check false-negatives. addPassword below retries that lag; a genuine non-owner
+            // surfaces as Authorization_RequestDenied in the catch, with guidance there.
 
             // Resolve login hint so WAM targets the az-logged-in user, not the OS default account.
             // Without this, WAM may return a cached token for a different user who is not the owner.
@@ -2309,8 +2195,20 @@ internal static class BlueprintSubcommand
         catch (Exception ex)
         {
             logger.LogDebug(ex, "Failed to create blueprint client secret (detail)");
-            logger.LogWarning("Insufficient privileges to create blueprint client secret automatically. You must create it manually.");
-            logger.LogWarning("Create the client secret manually for blueprint app {AppId} and add it to a365.generated.config.json, then re-run: a365 setup all", blueprintAppId);
+            logger.LogWarning("Could not create the blueprint client secret automatically. You must create it manually.");
+
+            // Surface ownership remediation only when the failure actually looks like a permission/owner
+            // denial (the addPassword 403) — not for unrelated failures such as token acquisition.
+            var looksLikeOwnershipDenial =
+                ex.Message.Contains("Authorization_RequestDenied", StringComparison.OrdinalIgnoreCase)
+                || ex.Message.Contains("Insufficient privileges", StringComparison.OrdinalIgnoreCase);
+            if (looksLikeOwnershipDenial)
+            {
+                logger.LogWarning("This usually means you are not an owner of the blueprint. Add yourself as an owner (or ask a blueprint owner to run setup):");
+                logger.LogWarning("  https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/{AppId}", blueprintAppId);
+            }
+
+            logger.LogWarning("Then create the client secret manually, add it to a365.generated.config.json, and re-run: a365 setup all");
             logger.LogWarning("See: https://learn.microsoft.com/en-us/entra/identity-platform/how-to-add-credentials");
             return false;
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -753,13 +753,30 @@ internal static class BlueprintSubcommand
 
         if (!isSetupAll)
         {
-            logger.LogInformation("Next steps:");
-            logger.LogInformation("  1. Run 'a365 setup permissions mcp' to configure MCP permissions");
-            // 'setup permissions bot' also covers Observability + Power Platform (needed by all agents),
-            // so always show it; name the M365-only Bot API explicitly only when --m365.
-            logger.LogInformation(isM365
-                ? "  2. Run 'a365 setup permissions bot' to configure Bot API, Observability, and Power Platform permissions"
-                : "  2. Run 'a365 setup permissions bot' to configure Observability and Power Platform permissions");
+            // Blueprint-only summary: scopes the shared renderer to the steps this command runs and
+            // surfaces the consent-URL / client-secret hand-offs in its Action Required block.
+            var summary = new SetupResults
+            {
+                IsNonDwBlueprintFlow = true,
+                IsBlueprintOnlyFlow = true,
+                IsM365 = isM365,
+                TenantId = setupConfig.TenantId,
+                BlueprintCreated = true,
+                BlueprintAlreadyExisted = blueprintAlreadyExisted,
+                BlueprintId = blueprintResult.appId,
+                BlueprintDisplayName = setupConfig.AgentBlueprintDisplayName,
+                BlueprintServicePrincipalCreated = !string.IsNullOrWhiteSpace(blueprintResult.servicePrincipalId),
+                BatchPermissionsPhase1Completed = true,
+                BatchPermissionsPhase2Completed = !blueprintResult.graphInheritablePermissionsFailed,
+                TenantWideConsentOutcome = blueprintResult.adminConsentUrl is null
+                    ? Models.GrantOutcome.Granted
+                    : Models.GrantOutcome.Failed,
+                AdminConsentUrl = blueprintResult.adminConsentUrl,
+                ClientSecretManualActionRequired = clientSecretManualActionRequired,
+                GraphInheritablePermissionsError = blueprintResult.graphInheritablePermissionsError,
+                FederatedCredentialError = blueprintResult.ficError,
+            };
+            SetupHelpers.DisplaySetupSummary(summary, logger);
         }
 
         return new BlueprintCreationResult
@@ -1931,16 +1948,7 @@ internal static class BlueprintSubcommand
                     graphInheritablePermissionsConfigured: false, graphInheritablePermissionsError: ex.Message);
         }
 
-        if (!consentSuccess)
-        {
-            // Surface the consent URL inline — standalone 'setup blueprint' renders no batch summary, so
-            // without this a non-admin gets no handoff and the granted scopes never land.
-            logger.LogWarning("Tenant-wide admin consent is needed for the agent blueprint's delegated Microsoft Graph scopes.");
-            logger.LogWarning("  Reason: granting tenant-wide consent for these scopes requires a tenant administrator.");
-            logger.LogWarning("  Ask a tenant administrator to open this URL to grant consent:");
-            logger.LogWarning("    {ConsentUrl}", consentUrlGraph);
-        }
-
+        // The consent-URL hand-off for non-admins is surfaced in the setup summary's Action Required block.
         var graphInheritablePermissionsError = inheritedConfigured
             ? null
             : "Inheritable permissions for Microsoft Graph were not configured. Ensure you have the Agent ID Administrator (or Global Administrator) role, then re-run 'a365 setup blueprint'.";

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
@@ -998,10 +998,6 @@ internal static class PermissionsSubcommand
         CancellationToken cancellationToken = default,
         IConfirmationProvider? confirmationProvider = null)
     {
-        logger.LogInformation("");
-        logger.LogInformation("Configuring custom blueprint permissions...");
-        logger.LogInformation("");
-
         try
         {
             // Build the set of resource app IDs desired by the current config
@@ -1010,16 +1006,22 @@ internal static class PermissionsSubcommand
                     .Select(p => p.ResourceAppId),
                 StringComparer.OrdinalIgnoreCase);
 
-            // Reconcile: remove permissions that are no longer in the config
+            // Reconcile: remove permissions that are no longer present (RemoveStale logs any removals).
             await RemoveStaleCustomPermissionsAsync(
                 logger, graphApiService, blueprintService, setupConfig, desiredCustomIds, cancellationToken);
 
+            // Custom blueprint permissions are an opt-in feature; most agents define none. When there
+            // is nothing to configure, stay silent rather than printing a header and a skip notice.
             if (setupConfig.CustomBlueprintPermissions == null || setupConfig.CustomBlueprintPermissions.Count == 0)
             {
-                logger.LogInformation("No custom blueprint permissions specified in config. Skipping.");
+                logger.LogDebug("No custom blueprint permissions to configure.");
                 await configService.SaveStateAsync(setupConfig);
                 return true;
             }
+
+            logger.LogInformation("");
+            logger.LogInformation("Configuring custom blueprint permissions...");
+            logger.LogInformation("");
 
             var hasValidationFailures = false;
             var specList = new List<ResourcePermissionSpec>();

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -462,6 +462,11 @@ internal static class SetupHelpers
     public static void DisplaySetupSummary(SetupResults results, ILogger logger)
     {
         var isNonDw = results.IsNonDwBlueprintFlow;
+        var isBlueprintOnly = results.IsBlueprintOnlyFlow;
+        // Which row groups this run actually performs. Blueprint-only ('setup blueprint') stops after
+        // Graph consent + inheritable permissions, so it shows neither the agent rows nor endpoint/settings.
+        var showAgentIdentityAndRegistration = isNonDw && !isBlueprintOnly;
+        var showEndpointAndProjectSettings = !isBlueprintOnly;
         var notRun = "not run (previous step failed)";
 
         logger.LogInformation("");
@@ -662,7 +667,7 @@ internal static class SetupHelpers
         }
 
         // Non-DW only: Agent identity — step 5 (after blueprint rows are grouped together)
-        if (isNonDw)
+        if (showAgentIdentityAndRegistration)
         {
             if (results.BlueprintFailed)
                 logger.LogInformation(DryRunRow(5, "Agent identity") + notRun);
@@ -677,7 +682,7 @@ internal static class SetupHelpers
         }
 
         // Non-DW only: Agent Registration — step 6
-        if (isNonDw)
+        if (showAgentIdentityAndRegistration)
         {
             if (results.BlueprintFailed)
                 logger.LogInformation(DryRunRow(6, "Agent Registration") + notRun);
@@ -694,64 +699,68 @@ internal static class SetupHelpers
             }
         }
 
-        // Messaging endpoint: step 6 for DW (after Permission Grants at 5),
-        // step 7 for non-DW (after Agent Registration at 6).
-        var endpointStep = isNonDw ? 7 : 6;
-        if (results.BlueprintFailed)
+        // Endpoint + project-settings rows are not part of standalone 'setup blueprint'.
+        if (showEndpointAndProjectSettings)
         {
-            logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + notRun);
-        }
-        else
-        {
-            switch (results.MessagingEndpointResult)
+            // Messaging endpoint: step 6 for DW (after Permission Grants at 5),
+            // step 7 for non-DW (after Agent Registration at 6).
+            var endpointStep = isNonDw ? 7 : 6;
+            if (results.BlueprintFailed)
             {
-                case null:
-                    logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + "skipped (non-M365 agent)");
-                    break;
-                case Models.EndpointRegistrationResult.Created:
-                    logger.LogInformation(
-                        DryRunRow(endpointStep, "Messaging endpoint") + "registered   '{Endpoint}'",
-                        results.MessagingEndpoint ?? "unknown");
-                    break;
-                case Models.EndpointRegistrationResult.AlreadyExists:
-                    logger.LogInformation(
-                        DryRunRow(endpointStep, "Messaging endpoint") + "reused       '{Endpoint}'",
-                        results.MessagingEndpoint ?? "unknown");
-                    break;
-                case Models.EndpointRegistrationResult.SkippedContractMismatch:
-                    logger.LogWarning(
-                        DryRunRow(endpointStep, "Messaging endpoint") + "manual config required — see Action Required");
-                    break;
-                case Models.EndpointRegistrationResult.Failed:
-                default:
-                    if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.NotOwner, StringComparison.Ordinal))
-                    {
-                        logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "failed (not blueprint owner) — see Action Required");
-                    }
-                    else if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.BlueprintMissing, StringComparison.Ordinal))
-                    {
-                        logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "not attempted (blueprint creation failed) — see Action Required");
-                    }
-                    else if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.NotConfigured, StringComparison.Ordinal))
-                    {
-                        // Deferred, not failed: the endpoint is a post-deploy artifact. Render it as an
-                        // expected pending step (informational, not a warning) with a single pointer below.
-                        logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + "deferred — configure after you deploy (see Next steps)");
-                    }
-                    else
-                    {
-                        logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "failed — see Action Required");
-                    }
-                    break;
+                logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + notRun);
             }
-        }
+            else
+            {
+                switch (results.MessagingEndpointResult)
+                {
+                    case null:
+                        logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + "skipped (non-M365 agent)");
+                        break;
+                    case Models.EndpointRegistrationResult.Created:
+                        logger.LogInformation(
+                            DryRunRow(endpointStep, "Messaging endpoint") + "registered   '{Endpoint}'",
+                            results.MessagingEndpoint ?? "unknown");
+                        break;
+                    case Models.EndpointRegistrationResult.AlreadyExists:
+                        logger.LogInformation(
+                            DryRunRow(endpointStep, "Messaging endpoint") + "reused       '{Endpoint}'",
+                            results.MessagingEndpoint ?? "unknown");
+                        break;
+                    case Models.EndpointRegistrationResult.SkippedContractMismatch:
+                        logger.LogWarning(
+                            DryRunRow(endpointStep, "Messaging endpoint") + "manual config required — see Action Required");
+                        break;
+                    case Models.EndpointRegistrationResult.Failed:
+                    default:
+                        if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.NotOwner, StringComparison.Ordinal))
+                        {
+                            logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "failed (not blueprint owner) — see Action Required");
+                        }
+                        else if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.BlueprintMissing, StringComparison.Ordinal))
+                        {
+                            logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "not attempted (blueprint creation failed) — see Action Required");
+                        }
+                        else if (string.Equals(results.MessagingEndpointFailureReason, MessagingEndpointFailureReasons.NotConfigured, StringComparison.Ordinal))
+                        {
+                            // Deferred, not failed: the endpoint is a post-deploy artifact. Render it as an
+                            // expected pending step (informational, not a warning) with a single pointer below.
+                            logger.LogInformation(DryRunRow(endpointStep, "Messaging endpoint") + "deferred — configure after you deploy (see Next steps)");
+                        }
+                        else
+                        {
+                            logger.LogWarning(DryRunRow(endpointStep, "Messaging endpoint") + "failed — see Action Required");
+                        }
+                        break;
+                }
+            }
 
-        // Project settings: step 8 for non-DW, step 7 for DW (pushed down by the messaging endpoint row).
-        var settingsStep = isNonDw ? 8 : 7;
-        if (results.BlueprintFailed)
-            logger.LogInformation(DryRunRow(settingsStep, "Project settings") + notRun);
-        else if (results.ProjectSettingsWritten)
-            logger.LogInformation(DryRunRow(settingsStep, "Project settings") + "written");
+            // Project settings: step 8 for non-DW, step 7 for DW (pushed down by the messaging endpoint row).
+            var settingsStep = isNonDw ? 8 : 7;
+            if (results.BlueprintFailed)
+                logger.LogInformation(DryRunRow(settingsStep, "Project settings") + notRun);
+            else if (results.ProjectSettingsWritten)
+                logger.LogInformation(DryRunRow(settingsStep, "Project settings") + "written");
+        }
 
         } // end full step table
 
@@ -794,13 +803,13 @@ internal static class SetupHelpers
                 // can still complete the hand-off manually.
                 if (isNonDw && string.IsNullOrWhiteSpace(consentUrl))
                 {
-                    logger.LogInformation("  {N}. Permission Grants — an {Roles} must grant admin consent in the Entra portal:", actionCount, AuthenticationConstants.DelegatedGrantRequiredRoles);
+                    logger.LogInformation("  {N}. Permission Grants — must be granted by {Roles} in the Entra portal:", actionCount, AuthenticationConstants.DelegatedGrantRequiredRoles);
                     LogNonDwAdminConsentInstructions(logger, adminCmdBlueprintId, tenantId: results.TenantId);
                 }
                 else
                 {
                     // Standard hand-off block — used for DW (always) and for non-DW when Slice 5a produced a URL.
-                    logger.LogInformation("  {N}. Permission Grants — forward the following to an {Roles}:", actionCount, AuthenticationConstants.DelegatedGrantRequiredRoles);
+                    logger.LogInformation("  {N}. Permission Grants — forward the following to {Roles}:", actionCount, AuthenticationConstants.DelegatedGrantRequiredRoles);
                     logger.LogInformation("");
                     logger.LogInformation("     Blueprint : {BlueprintId}", adminCmdBlueprintId);
                     if (!string.IsNullOrWhiteSpace(results.TenantId))
@@ -976,7 +985,8 @@ internal static class SetupHelpers
             || !string.IsNullOrEmpty(results.GraphInheritablePermissionsError)
             || !string.IsNullOrEmpty(results.FederatedCredentialError)
             || results.AgentRegistrationFailed
-            || messagingEndpointDeferred;
+            || messagingEndpointDeferred
+            || isBlueprintOnly;
 
         if (hasNextSteps)
         {
@@ -1012,6 +1022,15 @@ internal static class SetupHelpers
 
             if (results.AgentRegistrationFailed)
                 nextStepLines.Add(() => logger.LogInformation("  To retry agent registration: a365 setup all --agent-registration-only"));
+
+            // Standalone blueprint: point to the remaining permission steps.
+            if (isBlueprintOnly)
+            {
+                nextStepLines.Add(() => logger.LogInformation("  1. Run 'a365 setup permissions mcp' to configure MCP permissions"));
+                nextStepLines.Add(() => logger.LogInformation(results.IsM365
+                    ? "  2. Run 'a365 setup permissions bot' to configure Bot API, Observability, and Power Platform permissions"
+                    : "  2. Run 'a365 setup permissions bot' to configure Observability and Power Platform permissions"));
+            }
 
             if (nextStepLines.Count > 0)
             {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
@@ -187,6 +187,18 @@ public class SetupResults
     public bool IsNonDwBlueprintFlow { get; set; }
 
     /// <summary>
+    /// True for standalone `setup blueprint`: scopes the summary to the rows that command runs,
+    /// suppressing the agent identity / registration / endpoint / project-settings rows.
+    /// </summary>
+    public bool IsBlueprintOnlyFlow { get; set; }
+
+    /// <summary>
+    /// Whether the agent is an M365 AI Teammate. Used only to tailor the "Next steps" wording
+    /// (naming the Bot API explicitly). Does not change which steps run.
+    /// </summary>
+    public bool IsM365 { get; set; }
+
+    /// <summary>
     /// The effective --authmode value used during the non-DW grant step.
     /// Null when the non-DW grant step was not reached (e.g. agent identity creation failed) or
     /// when the run is a DW (AI Teammate) flow — DW does not use --authmode.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
@@ -157,20 +157,30 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
             {
                 _logger.LogDebug("MSAL token acquisition failed, falling back to PowerShell Connect-MgGraph...");
                 var script = BuildPowerShellScript(tenantId, validatedScopes, useDeviceCode, clientAppId);
-                var result = await ExecuteWithFallbackAsync(script, ct);
-                token = ProcessResult(result);
 
-                // If PowerShell browser auth was blocked (Conditional Access Policy or interactive
-                // browser unavailable in embedded terminal), retry with device code.
-                if (string.IsNullOrWhiteSpace(token) && !useDeviceCode &&
-                    (IsConditionalAccessError(result) || IsInteractiveBrowserFailure(result)))
+                // The first attempt is recoverable via a device-code retry, so suppress its error logging;
+                // re-log below only if the failure turns out to be terminal.
+                var canRetryWithDeviceCode = !useDeviceCode;
+                var result = await ExecuteWithFallbackAsync(script, ct, suppressErrorLogging: canRetryWithDeviceCode);
+                token = ProcessResult(result, logErrors: !canRetryWithDeviceCode);
+
+                if (string.IsNullOrWhiteSpace(token) && canRetryWithDeviceCode)
                 {
-                    _logger.LogWarning(
-                        "PowerShell interactive browser authentication failed (Conditional Access Policy or embedded terminal). " +
-                        "Retrying with device code authentication...");
-                    var deviceCodeScript = BuildPowerShellScript(tenantId, validatedScopes, useDeviceCode: true, clientAppId);
-                    var deviceCodeResult = await ExecuteWithFallbackAsync(deviceCodeScript, ct);
-                    token = ProcessResult(deviceCodeResult);
+                    if (IsConditionalAccessError(result) || IsInteractiveBrowserFailure(result))
+                    {
+                        _logger.LogWarning(
+                            "PowerShell interactive browser authentication failed (Conditional Access Policy or embedded terminal). " +
+                            "Retrying with device code authentication...");
+                        var deviceCodeScript = BuildPowerShellScript(tenantId, validatedScopes, useDeviceCode: true, clientAppId);
+                        var deviceCodeResult = await ExecuteWithFallbackAsync(deviceCodeScript, ct);
+                        token = ProcessResult(deviceCodeResult);
+                    }
+                    else
+                    {
+                        // Not a recoverable interactive-browser/CAP failure — its error was suppressed
+                        // above on the assumption a retry would apply. Surface the real cause now.
+                        LogResultFailure(result);
+                    }
                 }
             }
 
@@ -336,18 +346,19 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
 
     private async Task<CommandResult> ExecuteWithFallbackAsync(
         string script,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool suppressErrorLogging = false)
     {
         // Try PowerShell Core first (cross-platform)
         var shell = "pwsh";
-        var result = await ExecutePowerShellAsync(shell, script, ct);
+        var result = await ExecutePowerShellAsync(shell, script, ct, suppressErrorLogging);
 
         // Fallback to Windows PowerShell if pwsh is not available
         if (!result.Success && IsPowerShellNotFoundError(result))
         {
             _logger.LogDebug("PowerShell Core not found, falling back to Windows PowerShell");
             shell = "powershell";
-            result = await ExecutePowerShellAsync(shell, script, ct);
+            result = await ExecutePowerShellAsync(shell, script, ct, suppressErrorLogging);
         }
 
         // If the failure is due to a missing or broken module, attempt auto-install and retry once.
@@ -358,7 +369,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
             if (await TryAutoInstallRequiredModulesAsync(shell, ct))
             {
                 _logger.LogInformation("Auto-installed missing PowerShell module(s). Retrying...");
-                result = await ExecutePowerShellAsync(shell, script, ct);
+                result = await ExecutePowerShellAsync(shell, script, ct, suppressErrorLogging);
             }
         }
 
@@ -459,7 +470,8 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
     private async Task<CommandResult> ExecutePowerShellAsync(
         string shell,
         string script,
-        CancellationToken ct)
+        CancellationToken ct,
+        bool suppressErrorLogging = false)
     {
         var arguments = BuildPowerShellArguments(shell, script);
 
@@ -470,6 +482,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
             outputPrefix: "",
             interactive: true,
             outputTransform: FormatDeviceCodeLine,
+            suppressErrorLogging: suppressErrorLogging,
             cancellationToken: ct);
     }
 
@@ -520,20 +533,14 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         return $"{baseArgs} -Command \"{wrappedScript}\"";
     }
 
-    private string? ProcessResult(CommandResult result)
+    private string? ProcessResult(CommandResult result, bool logErrors = true)
     {
         if (!result.Success)
         {
-            _logger.LogError(
-                "Failed to acquire Microsoft Graph access token. Error: {Error}",
-                result.StandardError);
-
-            if (IsPowerShellModuleMissingError(result))
-            {
-                _logger.LogError(
-                    "Required PowerShell module could not be loaded (auto-install was attempted but failed). " +
-                    "Run 'a365 setup requirements' to manually install missing modules.");
-            }
+            // logErrors is false for a recoverable first attempt (retried with device code); the caller
+            // re-logs via LogResultFailure if the failure turns out to be terminal.
+            if (logErrors)
+                LogResultFailure(result);
 
             return null;
         }
@@ -560,6 +567,20 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
 
         _logger.LogDebug("Microsoft Graph access token acquired successfully");
         return token;
+    }
+
+    private void LogResultFailure(CommandResult result)
+    {
+        _logger.LogError(
+            "Failed to acquire Microsoft Graph access token. Error: {Error}",
+            result.StandardError);
+
+        if (IsPowerShellModuleMissingError(result))
+        {
+            _logger.LogError(
+                "Required PowerShell module could not be loaded (auto-install was attempted but failed). " +
+                "Run 'a365 setup requirements' to manually install missing modules.");
+        }
     }
 
     private static bool IsConditionalAccessError(CommandResult result)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintConsentDelegationTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintConsentDelegationTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Agents.A365.DevTools.Cli.Helpers;
+using Microsoft.Agents.A365.DevTools.Cli.Models;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using System.Text.Json;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
+
+/// <summary>
+/// Tests for BlueprintSubcommand.EnsureAdminConsentAsync, which delegates the standalone
+/// `setup blueprint` consent + inheritable-permissions flow to BatchPermissionsOrchestrator.
+/// Regression guard for #452: inheritable permissions must be configured independently of the OAuth2
+/// grant (a non-admin grant failure must not skip them).
+/// </summary>
+[Collection("Sequential")]
+public class BlueprintConsentDelegationTests : IDisposable
+{
+    private const string TenantId = "00000000-0000-0000-0000-000000000001";
+    private const string BlueprintAppId = "00000000-0000-0000-0000-000000000002";
+    private const string BlueprintSpObjectId = "00000000-0000-0000-0000-000000000003";
+
+    private readonly GraphApiService _graph;
+    private readonly AgentBlueprintService _blueprintService;
+    private readonly CommandExecutor _executor;
+    private readonly ILogger _logger = NullLogger.Instance;
+
+    public BlueprintConsentDelegationTests()
+    {
+        _graph = Substitute.ForPartsOf<GraphApiService>();
+        _blueprintService = Substitute.ForPartsOf<AgentBlueprintService>(
+            Substitute.For<ILogger<AgentBlueprintService>>(), _graph);
+        _executor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
+
+        // Suppress real browser launches and the 180s consent poll during these tests.
+        BrowserHelper.OpenUrlOverrideForTests = (_, _) => { };
+        AdminConsentHelper.BypassConsentChecksForTests = true;
+        BatchPermissionsOrchestrator.BypassSpProvisioningForTests = true;
+    }
+
+    public void Dispose()
+    {
+        BrowserHelper.OpenUrlOverrideForTests = null;
+        AdminConsentHelper.BypassConsentChecksForTests = false;
+        BatchPermissionsOrchestrator.BypassSpProvisioningForTests = false;
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// deferConsent: true (the `setup all` path) must short-circuit: a neutral, non-failure result and
+    /// no Graph calls, leaving consent to the batch orchestrator.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAdminConsent_WhenDeferConsent_ReturnsNeutralResultWithoutCallingGraph()
+    {
+        var config = new Agent365Config { TenantId = TenantId, AgentBlueprintId = BlueprintAppId };
+
+        var (consentSuccess, consentUrl, inheritableConfigured, inheritableError) =
+            await BlueprintSubcommand.EnsureAdminConsentAsync(
+                _logger, _executor, _graph, _blueprintService,
+                TenantId, BlueprintAppId, BlueprintSpObjectId, config,
+                ct: default, deferConsent: true);
+
+        consentSuccess.Should().BeFalse(because: "consent is deferred to the batch orchestrator, not granted in this step");
+        consentUrl.Should().BeEmpty(because: "this step produces no consent URL when deferring");
+        inheritableConfigured.Should().BeTrue(because: "deferring is not a failure — AllSubcommand must not add a spurious inheritable-permissions warning");
+        inheritableError.Should().BeNull();
+
+        await _graph.DidNotReceive().IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// #452 core: Graph inheritable permissions are configured via the orchestrator's dedicated phase,
+    /// not skipped by an OAuth2 grant failure. With them succeeding, the result reports configured + no error.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAdminConsent_WhenInheritableSucceeds_ReportsConfiguredWithNoError()
+    {
+        ArrangePhase1Success();
+
+        _blueprintService.SetInheritablePermissionsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IEnumerable<string>>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult((ok: true, alreadyExists: false, error: (string?)null)));
+        _blueprintService.VerifyInheritablePermissionsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            .Returns(Task.FromResult((exists: true, scopesAllAllowed: true, rolesAllAllowed: true, error: (string?)null)));
+
+        var config = new Agent365Config { TenantId = TenantId, AgentBlueprintId = BlueprintAppId };
+
+        var (_, consentUrl, inheritableConfigured, inheritableError) =
+            await BlueprintSubcommand.EnsureAdminConsentAsync(
+                _logger, _executor, _graph, _blueprintService,
+                TenantId, BlueprintAppId, BlueprintSpObjectId, config,
+                ct: default, deferConsent: false);
+
+        inheritableConfigured.Should().BeTrue(
+            because: "#452: Graph inheritable permissions must be configured via the orchestrator phase, not skipped by an OAuth2 grant failure");
+        inheritableError.Should().BeNull(
+            because: "inheritable permissions succeeded, so no error should be reported");
+        consentUrl.Should().Contain(BlueprintAppId, because: "a consent URL referencing the blueprint application is always produced");
+    }
+
+    /// <summary>
+    /// #452 decoupling: when inheritable permissions genuinely fail, the error is reported based on the
+    /// inheritable outcome — not conflated with the separate OAuth2 consent grant.
+    /// </summary>
+    [Fact]
+    public async Task EnsureAdminConsent_WhenInheritableFails_ReportsInheritableErrorIndependentOfConsent()
+    {
+        ArrangePhase1Success();
+
+        _blueprintService.SetInheritablePermissionsAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<IEnumerable<string>>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult((ok: false, alreadyExists: false, error: (string?)"insufficient role")));
+
+        var config = new Agent365Config { TenantId = TenantId, AgentBlueprintId = BlueprintAppId };
+
+        var (_, _, inheritableConfigured, inheritableError) =
+            await BlueprintSubcommand.EnsureAdminConsentAsync(
+                _logger, _executor, _graph, _blueprintService,
+                TenantId, BlueprintAppId, BlueprintSpObjectId, config,
+                ct: default, deferConsent: false);
+
+        inheritableConfigured.Should().BeFalse(
+            because: "the inheritable-permissions write failed, so it must be reported as not configured");
+        inheritableError.Should().NotBeNullOrWhiteSpace(
+            because: "#452: a genuine inheritable-permissions failure must surface an inheritable-permissions error (not be silently swallowed or mislabeled)");
+    }
+
+    /// <summary>
+    /// #452-adjacent: standalone `setup blueprint` renders no batch summary, so when consent isn't granted
+    /// the consent URL must be surfaced inline. Phase-1 auth failure drives the not-granted path; a spy
+    /// logger captures the handoff (it's a log side-effect, not a return value).
+    /// </summary>
+    [Fact]
+    public async Task EnsureAdminConsent_WhenConsentNotGranted_SurfacesConsentUrlHandoff()
+    {
+        var spyLogger = Substitute.For<ILogger>();
+        spyLogger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
+
+        // GraphGetAsync returns null → orchestrator Phase 1 fails → consent not granted, hand-off URL returned.
+        _graph.GraphGetAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            .Returns((JsonDocument?)null);
+        _graph.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(RoleCheckResult.DoesNotHaveRole);
+
+        var config = new Agent365Config { TenantId = TenantId, AgentBlueprintId = BlueprintAppId };
+
+        var (consentSuccess, consentUrl, _, _) =
+            await BlueprintSubcommand.EnsureAdminConsentAsync(
+                spyLogger, _executor, _graph, _blueprintService,
+                TenantId, BlueprintAppId, BlueprintSpObjectId, config,
+                ct: default, deferConsent: false);
+
+        consentSuccess.Should().BeFalse(because: "consent could not be granted/verified");
+        consentUrl.Should().Contain(BlueprintAppId, because: "the hand-off URL must reference the blueprint application");
+        spyLogger.Received().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Ask a tenant administrator to open this URL")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    /// <summary>Phase 1 (auth + resource SP resolution) succeeds, so the orchestrator reaches Phase 2a/3.</summary>
+    private void ArrangePhase1Success()
+    {
+        _graph.GraphGetAsync(
+            Arg.Any<string>(), Arg.Any<string>(),
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            .Returns(JsonDocument.Parse("{\"id\":\"user-id\"}"));
+        _graph.EnsureServicePrincipalForAppIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>())
+            .Returns(Task.FromResult<string?>("graph-sp-id"));
+        _graph.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(RoleCheckResult.HasRole);
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintConsentDelegationTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintConsentDelegationTests.cs
@@ -140,16 +140,12 @@ public class BlueprintConsentDelegationTests : IDisposable
     }
 
     /// <summary>
-    /// #452-adjacent: standalone `setup blueprint` renders no batch summary, so when consent isn't granted
-    /// the consent URL must be surfaced inline. Phase-1 auth failure drives the not-granted path; a spy
-    /// logger captures the handoff (it's a log side-effect, not a return value).
+    /// #452-adjacent: when consent isn't granted, EnsureAdminConsentAsync returns consentSuccess=false and a
+    /// consent URL referencing the blueprint, which the setup summary's Action Required block surfaces.
     /// </summary>
     [Fact]
-    public async Task EnsureAdminConsent_WhenConsentNotGranted_SurfacesConsentUrlHandoff()
+    public async Task EnsureAdminConsent_WhenConsentNotGranted_ReturnsConsentUrlForHandoff()
     {
-        var spyLogger = Substitute.For<ILogger>();
-        spyLogger.IsEnabled(Arg.Any<LogLevel>()).Returns(true);
-
         // GraphGetAsync returns null → orchestrator Phase 1 fails → consent not granted, hand-off URL returned.
         _graph.GraphGetAsync(
             Arg.Any<string>(), Arg.Any<string>(),
@@ -162,18 +158,12 @@ public class BlueprintConsentDelegationTests : IDisposable
 
         var (consentSuccess, consentUrl, _, _) =
             await BlueprintSubcommand.EnsureAdminConsentAsync(
-                spyLogger, _executor, _graph, _blueprintService,
+                _logger, _executor, _graph, _blueprintService,
                 TenantId, BlueprintAppId, BlueprintSpObjectId, config,
                 ct: default, deferConsent: false);
 
         consentSuccess.Should().BeFalse(because: "consent could not be granted/verified");
         consentUrl.Should().Contain(BlueprintAppId, because: "the hand-off URL must reference the blueprint application");
-        spyLogger.Received().Log(
-            LogLevel.Warning,
-            Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("Ask a tenant administrator to open this URL")),
-            Arg.Any<Exception?>(),
-            Arg.Any<Func<object, Exception?, string>>());
     }
 
     /// <summary>Phase 1 (auth + resource SP resolution) succeeds, so the orchestrator reaches Phase 2a/3.</summary>

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintSubcommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintSubcommandTests.cs
@@ -1863,20 +1863,16 @@ public class BlueprintSubcommandTests
     #region Ownership Check Tests
 
     [Fact]
-    public async Task CreateBlueprintClientSecret_WhenUserIsNotOwner_LogsOwnershipWarning()
+    public async Task CreateBlueprintClientSecret_DoesNotPerformPreflightOwnerCheck()
     {
-        // Arrange
-        _mockGraphApiService.IsApplicationOwnerAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns(Task.FromResult<bool?>(false));
-
+        // The pre-flight ownership probe was removed (it false-negatived on the not-yet-replicated owner
+        // edge and printed a "will fail" warning addPassword then contradicted). It must no longer run.
         var config = new Agent365Config
         {
             TenantId = "00000000-0000-0000-0000-000000000001",
-            ClientAppId = "" // empty → AcquireMsalGraphTokenAsync guard returns null immediately
+            ClientAppId = "" // token acquisition fails fast; we only assert that no owner pre-check ran
         };
 
-        // Act — method returns false after token acquisition fails; that is expected in this test
         await BlueprintSubcommand.CreateBlueprintClientSecretAsync(
             blueprintObjectId: "object-id",
             blueprintAppId: "app-id",
@@ -1887,80 +1883,45 @@ public class BlueprintSubcommandTests
             generatedConfigPath: "a365.generated.config.json",
             loginHintResolver: () => Task.FromResult<string?>(null));
 
-        // Assert
+        await _mockGraphApiService.DidNotReceive().IsApplicationOwnerAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+    }
+
+    [Fact]
+    public async Task CreateBlueprintClientSecret_WhenNonPermissionFailure_DoesNotClaimOwnership()
+    {
+        // Ownership guidance must show only for a real permission denial, not unrelated failures. An empty
+        // ClientAppId fails at token acquisition, so "not an owner" must NOT appear (only the generic
+        // manual-creation guidance). The genuine-403 positive case has no unit seam (integration-only).
+        var config = new Agent365Config
+        {
+            TenantId = "00000000-0000-0000-0000-000000000001",
+            ClientAppId = "" // token acquisition fails — NOT a permission denial
+        };
+
+        var created = await BlueprintSubcommand.CreateBlueprintClientSecretAsync(
+            blueprintObjectId: "object-id",
+            blueprintAppId: "app-id",
+            graphService: _mockGraphApiService,
+            setupConfig: config,
+            configService: _mockConfigService,
+            logger: _mockLogger,
+            generatedConfigPath: "a365.generated.config.json",
+            loginHintResolver: () => Task.FromResult<string?>(null));
+
+        created.Should().BeFalse(because: "token acquisition failed, so the secret could not be created");
+
+        _mockLogger.DidNotReceive().Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("not an owner")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+
         _mockLogger.Received().Log(
             LogLevel.Warning,
             Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("not an owner")),
-            Arg.Any<Exception?>(),
-            Arg.Any<Func<object, Exception?, string>>());
-    }
-
-    [Fact]
-    public async Task CreateBlueprintClientSecret_WhenUserIsOwner_DoesNotLogOwnershipWarning()
-    {
-        // Arrange
-        _mockGraphApiService.IsApplicationOwnerAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns(Task.FromResult<bool?>(true));
-
-        var config = new Agent365Config
-        {
-            TenantId = "00000000-0000-0000-0000-000000000001",
-            ClientAppId = ""
-        };
-
-        // Act
-        await BlueprintSubcommand.CreateBlueprintClientSecretAsync(
-            blueprintObjectId: "object-id",
-            blueprintAppId: "app-id",
-            graphService: _mockGraphApiService,
-            setupConfig: config,
-            configService: _mockConfigService,
-            logger: _mockLogger,
-            generatedConfigPath: "a365.generated.config.json",
-            loginHintResolver: () => Task.FromResult<string?>(null));
-
-        // Assert — ownership warning must not fire when current user is an owner
-        _mockLogger.DidNotReceive().Log(
-            LogLevel.Warning,
-            Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("not an owner")),
-            Arg.Any<Exception?>(),
-            Arg.Any<Func<object, Exception?, string>>());
-    }
-
-    [Fact]
-    public async Task CreateBlueprintClientSecret_WhenOwnershipIsIndeterminate_DoesNotLogOwnershipWarning()
-    {
-        // Arrange — null means Graph returned an error; ownership cannot be determined.
-        // The caller uses `if (isOwner == false)` so null must not trigger the warning.
-        _mockGraphApiService.IsApplicationOwnerAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns(Task.FromResult<bool?>(null));
-
-        var config = new Agent365Config
-        {
-            TenantId = "00000000-0000-0000-0000-000000000001",
-            ClientAppId = ""
-        };
-
-        // Act
-        await BlueprintSubcommand.CreateBlueprintClientSecretAsync(
-            blueprintObjectId: "object-id",
-            blueprintAppId: "app-id",
-            graphService: _mockGraphApiService,
-            setupConfig: config,
-            configService: _mockConfigService,
-            logger: _mockLogger,
-            generatedConfigPath: "a365.generated.config.json",
-            loginHintResolver: () => Task.FromResult<string?>(null));
-
-        // Assert — indeterminate ownership must not log a "not an owner" warning
-        _mockLogger.DidNotReceive().Log(
-            LogLevel.Warning,
-            Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("not an owner")),
+            Arg.Is<object>(o => o.ToString()!.Contains("create it manually")),
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
@@ -4,6 +4,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Agents.A365.DevTools.Cli.Commands;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using NSubstitute;
 using FluentAssertions;
@@ -316,7 +317,9 @@ public class DevelopMcpCommandRegressionTests
             IAgent365ToolingService toolingService,
             GraphApiService? graphApiService,
             string? tenantId)
-            : base(logger, toolingService, graphApiService)
+            // Zero-delay retry so the non-dry-run path doesn't spend ~45s in exponential backoff when a
+            // best-effort Graph step is left unmocked (mirrors GraphApiService/ArmApiService test injection).
+            : base(logger, toolingService, graphApiService, new RetryHelper(logger, maxRetries: 1, baseDelaySeconds: 0))
         {
             _tenantId = tenantId;
         }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersDisplaySetupSummaryTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersDisplaySetupSummaryTests.cs
@@ -531,6 +531,68 @@ public class SetupHelpersDisplaySetupSummaryTests
             because: "the re-grant URL must be surfaced verbatim so the operator can complete consent if 'query-entra inheritance' confirms nothing was granted");
     }
 
+    // ── blueprint-only scope (standalone `setup blueprint`) ───────────────────
+
+    [Fact]
+    public void DisplaySetupSummary_BlueprintOnly_SuppressesAgentAndEndpointRows()
+    {
+        var logger = new CapturingLogger();
+        SetupHelpers.DisplaySetupSummary(BuildBlueprintOnlyResults(consentPending: false), logger);
+
+        logger.AllOutput.Should().Contain("Blueprint",
+            because: "the blueprint row is part of what 'setup blueprint' runs");
+        logger.AllOutput.Should().NotContain("Agent identity",
+            because: "'setup blueprint' does not create an agent identity — that row must be suppressed");
+        logger.AllOutput.Should().NotContain("Agent Registration",
+            because: "'setup blueprint' does not register an agent — that row must be suppressed");
+        logger.AllOutput.Should().NotContain("Messaging endpoint",
+            because: "'setup blueprint' does not configure the messaging endpoint — that row must be suppressed");
+        logger.AllOutput.Should().NotContain("Project settings",
+            because: "'setup blueprint' does not write project settings — that row must be suppressed");
+    }
+
+    [Fact]
+    public void DisplaySetupSummary_BlueprintOnly_ConsentPending_ShowsConsentUrlInActionRequired()
+    {
+        var logger = new CapturingLogger();
+        SetupHelpers.DisplaySetupSummary(BuildBlueprintOnlyResults(consentPending: true), logger);
+
+        logger.AllOutput.Should().Contain("Action Required",
+            because: "a non-admin blueprint run leaves consent pending and must flag the hand-off");
+        logger.AllOutput.Should().Contain(BlueprintConsentUrl,
+            because: "the consent URL must be surfaced so an admin can grant tenant-wide consent");
+    }
+
+    [Fact]
+    public void DisplaySetupSummary_BlueprintOnly_EmitsPermissionsNextSteps()
+    {
+        var logger = new CapturingLogger();
+        SetupHelpers.DisplaySetupSummary(BuildBlueprintOnlyResults(consentPending: false), logger);
+
+        logger.AllOutput.Should().Contain("a365 setup permissions mcp",
+            because: "the blueprint summary must point to the remaining MCP permissions step");
+        logger.AllOutput.Should().Contain("a365 setup permissions bot",
+            because: "the blueprint summary must point to the bot/observability permissions step");
+    }
+
+    private const string BlueprintConsentUrl = "https://login.microsoftonline.com/" + TenantId + "/v2.0/adminconsent?client_id=" + BlueprintId;
+
+    private static SetupResults BuildBlueprintOnlyResults(bool consentPending) => new()
+    {
+        IsNonDwBlueprintFlow = true,
+        IsBlueprintOnlyFlow = true,
+        IsM365 = true,
+        TenantId = TenantId,
+        BlueprintCreated = true,
+        BlueprintId = BlueprintId,
+        BlueprintDisplayName = "Repro Blueprint",
+        BlueprintServicePrincipalCreated = true,
+        BatchPermissionsPhase1Completed = true,
+        BatchPermissionsPhase2Completed = true,
+        TenantWideConsentOutcome = consentPending ? Cli.Models.GrantOutcome.Failed : Cli.Models.GrantOutcome.Granted,
+        AdminConsentUrl = consentPending ? BlueprintConsentUrl : null,
+    };
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private static SetupResults BuildDelegatedPendingResults() => new()


### PR DESCRIPTION
## Summary
Fixes #452. The standalone `a365 setup blueprint` path issued a **redundant programmatic AllPrincipals OAuth2 grant** after browser admin consent. For non-Global-Admins that grant returns `403 Authorization_RequestDenied`, and the thrown exception **skipped configuring the blueprint's inheritable Microsoft Graph permissions** (and mislabeled the failure as an inheritable-permissions error). Result: agent instances created from the blueprint inherited no Graph permissions at runtime.

This routes the standalone consent + inheritable-permissions flow through `BatchPermissionsOrchestrator` — the same engine `setup all` uses — with a **Graph-only spec**, so:
- inheritable permissions are configured in their own phase, independent of the OAuth2 grant;
- a failed/redundant grant is non-fatal;
- non-admins get the admin-consent URL surfaced inline to hand off.

## Folded-in fixes (same `setup blueprint` output path)
- Silence the "No custom blueprint permissions… Skipping" noise when none are defined.
- Always show the `setup permissions bot` next step (it also covers Observability + Power Platform, needed by all agents); name the M365-only Bot API only with `--m365`.
- Downgrade the recoverable interactive-browser token-fallback `ERROR` logs (device-code retry) to debug; re-log only on terminal failure.
- Remove the premature pre-flight owner "will fail" warning (it false-negatived on owner-edge propagation lag, then was contradicted by success); surface ownership guidance only on a genuine permission denial.
- Make `PublishCommandExecutor`/`RegisterCommandExecutor` `RetryHelper` injectable (zero-delay in tests) — fixes two ~45s tests; **full suite ~93s → ~5s**.
- `BypassSpProvisioningForTests` is now `AsyncLocal` (matches the other bypass flags).

## Tests
- New `BlueprintConsentDelegationTests`: defer short-circuit, inheritable-configured, inheritable-failure decoupling, non-GA consent-URL handoff.
- Ownership tests updated to assert the new gating.
- Full suite: **1905 passed, 0 failed, 12 skipped, 0 warnings**.

## Manual verification
- Non-GA `setup blueprint` now configures inheritable permissions (verified via `a365 query-entra inheritance`) and surfaces the consent URL for an admin to grant the delegated scopes; `setup all` behavior unchanged.
