### PR TITLE
Revert: add web consent redirect URIs to BYO Entra apps

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommandExecutor.cs
@@ -319,7 +319,7 @@ internal class PublishCommandExecutor
         var provisioner = new EntraAppProvisioner(_logger, _graphApiService!, _retryHelper);
 
         var publicClients = await provisioner.CreatePublicClientsAppAsync(
-            input.ServerName, tenantId, serviceTreeId: null, warnings, ct: ct);
+            input.ServerName, tenantId, serviceTreeId: null, warnings, ct);
 
         return new EntraAppSet(
             PublicClientsClientId: publicClients.ClientId,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/RegisterCommandExecutor.cs
@@ -705,25 +705,20 @@ internal class RegisterCommandExecutor
         }
         else
         {
-            var msg = "A365 Proxy redirect URI was not returned by the server. Setting consent redirect URIs only.";
+            var msg = "A365 Proxy redirect URI was not returned by the server. Redirect URI configuration skipped.";
             _logger.LogWarning(msg);
             concurrentWarnings.Add(msg);
-            tasks.Add(SetConsentOnlyRedirectUrisAsync(tenantId, apps.A365AppObjectId, apps.A365AppName, concurrentWarnings, ct));
         }
 
         if (input.IsEntra && !string.IsNullOrWhiteSpace(remoteRedirectUri) && apps.RemoteProxyObjectId != null)
         {
             tasks.Add(UpdateRemoteProxyRedirectUrisAsync(tenantId, apps, remoteRedirectUri, concurrentWarnings, ct));
         }
-        else if (input.IsEntra && apps.RemoteProxyObjectId != null)
+        else if (input.IsEntra && string.IsNullOrWhiteSpace(remoteRedirectUri))
         {
-            if (string.IsNullOrWhiteSpace(remoteRedirectUri))
-            {
-                var msg = "Remote MCP Proxy redirect URI was not returned by the server. Setting consent redirect URIs only.";
-                _logger.LogWarning(msg);
-                concurrentWarnings.Add(msg);
-            }
-            tasks.Add(SetConsentOnlyRedirectUrisAsync(tenantId, apps.RemoteProxyObjectId, apps.RemoteProxyAppName, concurrentWarnings, ct));
+            var msg = "Remote MCP Proxy redirect URI was not returned by the server. Redirect URI configuration skipped.";
+            _logger.LogWarning(msg);
+            concurrentWarnings.Add(msg);
         }
         else if (input.IsEntra && apps.RemoteProxyObjectId == null)
         {
@@ -790,10 +785,7 @@ internal class RegisterCommandExecutor
         {
             var a365TcUri = DevelopMcpCommand.AddTcPrefix(a365RedirectUri);
             var a365NonTcUri = DevelopMcpCommand.RemoveTcPrefix(a365RedirectUri);
-            var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri)
-                .Concat(EntraAppProvisioner.GetConsentRedirectUris())
-                .Distinct(StringComparer.Ordinal)
-                .ToArray();
+            var a365Uris = DevelopMcpCommand.BuildRedirectUriList(a365RedirectUri, a365TcUri, a365NonTcUri);
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.A365AppName, apps.A365AppObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(
                 async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, apps.A365AppObjectId, a365Uris, retryCt),
@@ -827,10 +819,7 @@ internal class RegisterCommandExecutor
         {
             var remoteTcUri = DevelopMcpCommand.AddTcPrefix(remoteRedirectUri);
             var remoteNonTcUri = DevelopMcpCommand.RemoveTcPrefix(remoteRedirectUri);
-            var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri)
-                .Concat(EntraAppProvisioner.GetConsentRedirectUris())
-                .Distinct(StringComparer.Ordinal)
-                .ToArray();
+            var remoteUris = DevelopMcpCommand.BuildRedirectUriList(remoteRedirectUri, remoteTcUri, remoteNonTcUri);
             _logger.LogDebug("Updating redirect URIs on '{AppName}' ({ObjectId})", apps.RemoteProxyAppName, apps.RemoteProxyObjectId);
             var success = await _retryHelper.ExecuteWithRetryAsync(
                 async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, apps.RemoteProxyObjectId!, remoteUris, retryCt),
@@ -850,37 +839,6 @@ internal class RegisterCommandExecutor
         catch (Exception ex)
         {
             var msg = $"Failed to update redirect URIs on Remote Proxy app: {ex.Message}";
-            _logger.LogError(msg);
-            concurrentWarnings.Add(msg);
-        }
-    }
-
-    private async Task SetConsentOnlyRedirectUrisAsync(
-        string tenantId, string objectId, string appName,
-        System.Collections.Concurrent.ConcurrentBag<string> concurrentWarnings,
-        CancellationToken ct = default)
-    {
-        try
-        {
-            var consentUris = EntraAppProvisioner.GetConsentRedirectUris();
-            var success = await _retryHelper.ExecuteWithRetryAsync(
-                async retryCt => await _graphApiService!.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
-                result => !result,
-                cancellationToken: ct);
-            if (!success)
-            {
-                var msg = $"Failed to set web redirect URIs on '{appName}' after retries.";
-                _logger.LogError(msg);
-                concurrentWarnings.Add(msg);
-            }
-            else
-            {
-                _logger.LogDebug("Set {Count} web redirect URIs on '{AppName}'", consentUris.Length, appName);
-            }
-        }
-        catch (Exception ex)
-        {
-            var msg = $"Failed to set web redirect URIs on '{appName}': {ex.Message}";
             _logger.LogError(msg);
             concurrentWarnings.Add(msg);
         }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/EntraAppProvisioner.cs
@@ -22,27 +22,6 @@ internal class EntraAppProvisioner
         "http://localhost",
     ];
 
-    private static readonly string[] ProdConsentRedirectUris =
-    [
-        "https://admin.cloud.microsoft/?ref=tools/consent",
-    ];
-
-    internal static string[] GetConsentRedirectUris(string? environment = null)
-    {
-        var trimmed = environment?.Trim();
-        var resolved = string.IsNullOrEmpty(trimmed)
-            ? Environment.GetEnvironmentVariable("A365_ENVIRONMENT")?.Trim() ?? "prod"
-            : trimmed;
-        var envKey = resolved.ToUpperInvariant();
-        var customUris = Environment.GetEnvironmentVariable($"A365_CONSENT_REDIRECT_URIS_{envKey}");
-        if (!string.IsNullOrWhiteSpace(customUris))
-        {
-            return customUris.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-        }
-
-        return [.. ProdConsentRedirectUris];
-    }
-
     private readonly ILogger _logger;
     private readonly GraphApiService _graphApiService;
     private readonly RetryHelper _retryHelper;
@@ -116,30 +95,6 @@ internal class EntraAppProvisioner
         return new ProxyAppResult(app.Value.ClientId, secret, app.Value.ObjectId, appName);
     }
 
-    private async Task SetWebConsentRedirectUrisAsync(
-        string tenantId, string objectId, string appName, string roleDisplay,
-        string? environment, CancellationToken ct, List<string>? warnings = null)
-    {
-        var consentUris = GetConsentRedirectUris(environment);
-
-        var success = await _retryHelper.ExecuteWithRetryAsync(
-            async retryCt => await _graphApiService.UpdateAppRedirectUrisAsync(tenantId, objectId, consentUris, retryCt),
-            result => !result,
-            cancellationToken: ct);
-        if (success)
-        {
-            _logger.LogDebug(
-                "Set {RedirectUriCount} web redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
-                consentUris.Length, appName, objectId, string.Join(", ", consentUris));
-        }
-        else
-        {
-            var msg = $"Failed to set web redirect URIs on {roleDisplay} app '{appName}' after retries.";
-            _logger.LogWarning(msg);
-            warnings?.Add(msg);
-        }
-    }
-
     /// <summary>
     /// Best-effort compensating delete for an Entra app that was successfully created but failed
     /// a follow-up step (secret creation, post-create validation). Without this, partial failures
@@ -192,7 +147,6 @@ internal class EntraAppProvisioner
         string tenantId,
         string? serviceTreeId,
         List<string> warnings,
-        string? environment = null,
         CancellationToken ct = default)
     {
         var appName = $"{serverName}-PublicClients";
@@ -222,21 +176,19 @@ internal class EntraAppProvisioner
                 cancellationToken: ct);
             if (!success)
             {
-                var msg = $"Failed to set publicClient redirect URIs on Public Clients app '{appName}' after retries.";
+                var msg = $"Failed to set redirect URIs on Public Clients app '{appName}' after retries.";
                 _logger.LogError(msg);
                 warnings.Add(msg);
             }
             else
             {
                 _logger.LogDebug(
-                    "Set {RedirectUriCount} publicClient redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
+                    "Set {RedirectUriCount} redirect URIs on '{AppName}' ({ObjectId}): {RedirectUris}",
                     publicClientUris.Length,
                     appName,
                     objectId,
                     string.Join(", ", publicClientUris));
             }
-
-            await SetWebConsentRedirectUrisAsync(tenantId, objectId, appName, "Public Clients", environment, ct, warnings);
         }
         catch (Exception ex)
         {

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/EntraAppProvisionerTests.cs
@@ -10,16 +10,12 @@ using Xunit;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
 
-[CollectionDefinition("EntraAppProvisionerTests", DisableParallelization = true)]
-public class EntraAppProvisionerTestsCollection { }
-
 /// <summary>
 /// Tests for <see cref="EntraAppProvisioner"/>. The provisioner absorbed the per-app creation flows
 /// that previously lived inline in PublishCommandExecutor and RegisterCommandExecutor. These tests
 /// pin every branch (success + each failure mode) so the executors can compose the provisioner
 /// without needing their own per-step coverage.
 /// </summary>
-[Collection("EntraAppProvisionerTests")]
 public class EntraAppProvisionerTests
 {
     private const string ServerName = "mcp_TestServer";
@@ -140,27 +136,20 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreatePublicClientsAppAsync_ProdEnvironment_SetsPublicClientAndWebConsentRedirectUris()
+    public async Task CreatePublicClientsAppAsync_HappyPath_ReturnsIdsAndSetsBrokerAndCanonicalRedirectUris()
     {
-        var capturedPublicClientUris = new List<string[]>();
-        var capturedWebUris = new List<string[]>();
+        var capturedUris = new List<string[]>();
         _graph.CreateEntraAppAsync(TenantId, $"{ServerName}-PublicClients", serviceTreeId: "svc-tree-9", Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.UpdateAppPublicClientRedirectUrisAsync(
                 TenantId,
                 AppObjectId,
-                Arg.Do<string[]>(uris => capturedPublicClientUris.Add(uris)),
-                Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId,
-                AppObjectId,
-                Arg.Do<string[]>(uris => capturedWebUris.Add(uris)),
+                Arg.Do<string[]>(uris => capturedUris.Add(uris)),
                 Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(true));
 
         var warnings = new List<string>();
-        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: "svc-tree-9", warnings, environment: "prod");
+        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: "svc-tree-9", warnings);
 
         result.Should().NotBeNull();
         result.ClientId.Should().Be(AppClientId);
@@ -168,8 +157,9 @@ public class EntraAppProvisionerTests
         result.AppName.Should().Be($"{ServerName}-PublicClients");
         warnings.Should().BeEmpty();
 
-        capturedPublicClientUris.Should().ContainSingle();
-        capturedPublicClientUris[0].Should().BeEquivalentTo(
+        capturedUris.Should().ContainSingle();
+        var uris = capturedUris[0];
+        uris.Should().BeEquivalentTo(
             new[]
             {
                 $"ms-appx-web://Microsoft.AAD.BrokerPlugin/{AppClientId}",
@@ -183,78 +173,6 @@ public class EntraAppProvisionerTests
                      "on Windows, the localhost callbacks support MSAL.NET and Copilot CLI flows, " +
                      "and vscode.dev/redirect supports the VS Code web client. Silently " +
                      "adding/removing/reordering entries breaks one of those flows.");
-
-        capturedWebUris.Should().ContainSingle();
-        capturedWebUris[0].Should().BeEquivalentTo(
-            new[]
-            {
-                "https://admin.cloud.microsoft/?ref=tools/consent",
-            },
-            opt => opt.WithStrictOrdering(),
-            because: "Prod consent redirect URIs are required by the admin.cloud.microsoft " +
-                     "consent portal. Changing these URIs breaks the admin consent flow.");
-    }
-
-    [Fact]
-    public void GetConsentRedirectUris_UsesEnvVarOverride()
-    {
-        const string envKey = "A365_CONSENT_REDIRECT_URIS_PREPROD";
-        var prev = Environment.GetEnvironmentVariable(envKey);
-        try
-        {
-            Environment.SetEnvironmentVariable(envKey, "https://custom1.example.com/consent, https://custom2.example.com/consent");
-            var uris = EntraAppProvisioner.GetConsentRedirectUris("preprod");
-            uris.Should().BeEquivalentTo(
-                new[] { "https://custom1.example.com/consent", "https://custom2.example.com/consent" },
-                opt => opt.WithStrictOrdering(),
-                because: "Non-prod consent redirect URIs are read from A365_CONSENT_REDIRECT_URIS_{ENV} " +
-                         "to avoid leaking internal URLs in source code.");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(envKey, prev);
-        }
-    }
-
-    [Fact]
-    public void GetConsentRedirectUris_TrimsWhitespaceFromEnvironment()
-    {
-        const string envKey = "A365_CONSENT_REDIRECT_URIS_TEST";
-        var prev = Environment.GetEnvironmentVariable(envKey);
-        try
-        {
-            Environment.SetEnvironmentVariable(envKey, "https://trimmed.example.com/consent");
-            var uris = EntraAppProvisioner.GetConsentRedirectUris("  test  ");
-            uris.Should().BeEquivalentTo(
-                new[] { "https://trimmed.example.com/consent" },
-                because: "Environment values with leading/trailing whitespace (common in " +
-                         "shell/env var setups) must resolve to the correct env var key.");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(envKey, prev);
-        }
-    }
-
-    [Fact]
-    public void GetConsentRedirectUris_FallsToProdWhenNoEnvVar()
-    {
-        const string envKey = "A365_CONSENT_REDIRECT_URIS_PREPROD";
-        var prev = Environment.GetEnvironmentVariable(envKey);
-        try
-        {
-            Environment.SetEnvironmentVariable(envKey, null);
-            var uris = EntraAppProvisioner.GetConsentRedirectUris("preprod");
-            uris.Should().BeEquivalentTo(
-                new[] { "https://admin.cloud.microsoft/?ref=tools/consent" },
-                opt => opt.WithStrictOrdering(),
-                because: "When no env var override is set, all environments fall back to the " +
-                         "prod consent redirect URI.");
-        }
-        finally
-        {
-            Environment.SetEnvironmentVariable(envKey, prev);
-        }
     }
 
     [Fact]
@@ -276,16 +194,13 @@ public class EntraAppProvisionerTests
     }
 
     [Fact]
-    public async Task CreatePublicClientsAppAsync_WhenPublicClientRedirectUriUpdateReturnsFalse_AppendsWarning()
+    public async Task CreatePublicClientsAppAsync_WhenRedirectUriUpdateReturnsFalse_ReturnsIdsAndAppendsRetryWarning()
     {
         _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
         _graph.UpdateAppPublicClientRedirectUrisAsync(
                 TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(false));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
 
         var warnings = new List<string>();
         var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
@@ -293,26 +208,7 @@ public class EntraAppProvisionerTests
         result.ClientId.Should().Be(AppClientId);
         result.ObjectId.Should().Be(AppObjectId);
         result.AppName.Should().Be($"{ServerName}-PublicClients");
-        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set publicClient redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
-    }
-
-    [Fact]
-    public async Task CreatePublicClientsAppAsync_WhenWebRedirectUriUpdateReturnsFalse_AppendsWarning()
-    {
-        _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
-        _graph.UpdateAppPublicClientRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(false));
-
-        var warnings = new List<string>();
-        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
-
-        result.ClientId.Should().Be(AppClientId);
-        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set web redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
+        warnings.Should().ContainSingle().Which.Should().Be($"Failed to set redirect URIs on Public Clients app '{ServerName}-PublicClients' after retries.");
     }
 
     [Fact]
@@ -331,25 +227,5 @@ public class EntraAppProvisionerTests
         result.ObjectId.Should().Be(AppObjectId);
         result.AppName.Should().Be($"{ServerName}-PublicClients");
         warnings.Should().ContainSingle().Which.Should().Be("Failed to set redirect URIs on Public Clients app: Graph blew up");
-    }
-
-    [Fact]
-    public async Task CreatePublicClientsAppAsync_WhenWebRedirectUriUpdateThrows_ReturnsIdsAndAppendsExceptionWarning()
-    {
-        _graph.CreateEntraAppAsync(TenantId, Arg.Any<string>(), serviceTreeId: Arg.Any<string?>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<(string ObjectId, string ClientId)?>((AppObjectId, AppClientId)));
-        _graph.UpdateAppPublicClientRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(true));
-        _graph.UpdateAppRedirectUrisAsync(
-                TenantId, AppObjectId, Arg.Any<string[]>(), Arg.Any<CancellationToken>())
-            .Returns<Task<bool>>(_ => throw new InvalidOperationException("Graph consent update failed"));
-
-        var warnings = new List<string>();
-        var result = await _provisioner.CreatePublicClientsAppAsync(ServerName, TenantId, serviceTreeId: null, warnings);
-
-        result.ClientId.Should().Be(AppClientId);
-        result.ObjectId.Should().Be(AppObjectId);
-        warnings.Should().ContainSingle().Which.Should().Be("Failed to set redirect URIs on Public Clients app: Graph consent update failed");
     }
 }


### PR DESCRIPTION
## Summary
- Reverts PR #450 (`091d51d`) which added web consent redirect URIs to all Entra app registrations in the addmcpserver/publish flows
- Removes `GetConsentRedirectUris`, `SetWebConsentRedirectUrisAsync`, and consent URI appending in `RegisterCommandExecutor` and `PublishCommandExecutor`
- Removes associated tests in `EntraAppProvisionerTests`

## Test plan
- [ ] Verify `dotnet test tests.proj` passes
- [ ] Verify register and publish flows still create apps without consent redirect URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)