### PR TITLE
scope fix for m365copilot mcp

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopCommand.cs
@@ -827,6 +827,14 @@ public static class DevelopCommand
                         var audience = catalogEntry.TryGetProperty("audience", out var audienceElement) ? audienceElement.GetString() : null;
                         var publisher = catalogEntry.TryGetProperty("publisher", out var publisherElement) ? publisherElement.GetString() : null;
 
+                        // Override catalog scope/audience with static mapping when available.
+                        var (mappedScope, mappedAudience) = McpConstants.ServerScopeMappings.GetScopeAndAudience(existingServerName);
+                        if (!string.IsNullOrWhiteSpace(mappedScope))
+                        {
+                            scope = mappedScope;
+                            audience = McpConstants.WorkIQToolsProdAppId;
+                        }
+
                         var updatedServerObject = ManifestHelper.CreateCompleteServerObject(existingServerName, existingServerName, url, scope, audience, publisher);
                         updatedServers.Add(updatedServerObject);
                         updatedCount++;
@@ -896,6 +904,16 @@ public static class DevelopCommand
             var scope = string.Equals(scopeRaw, "null", StringComparison.OrdinalIgnoreCase) ? null : scopeRaw;
             var audience = catalogEntry.TryGetProperty("audience", out var audienceElement) ? audienceElement.GetString() : null;
             var publisher = catalogEntry.TryGetProperty("publisher", out var publisherElement) ? publisherElement.GetString() : null;
+
+            // Override catalog scope/audience with static mapping when available.
+            // This protects against stale catalog data where the catalog advertises V2
+            // scope/audience but the server still enforces a V1 scope.
+            var (mappedScope, mappedAudience) = McpConstants.ServerScopeMappings.GetScopeAndAudience(serverName);
+            if (!string.IsNullOrWhiteSpace(mappedScope))
+            {
+                scope = mappedScope;
+                audience = McpConstants.WorkIQToolsProdAppId;
+            }
 
             var serverObject = ManifestHelper.CreateCompleteServerObject(serverName, serverName, url, scope, audience, publisher);
             updatedServers.Add(serverObject);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/McpConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/McpConstants.cs
@@ -188,7 +188,10 @@ public static class McpConstants
                 ["MeMCPServer"] = ("McpServers.Me.All", "api://mcp-meserver"),
 
                 // Admin servers
-                ["mcp_Admin365_GraphTools"] = ("McpServers.Admin365.All", "api://mcp-admin365graphtools")
+                ["mcp_Admin365_GraphTools"] = ("McpServers.Admin365.All", "api://mcp-admin365graphtools"),
+
+                // Copilot servers
+                ["mcp_M365Copilot"] = ("McpServers.CopilotMCP.All", "api://mcp-m365copilot")
             };
 
         /// <summary>


### PR DESCRIPTION
Adds scope mapping for the mcp_M365Copilot server (McpServers.CopilotMCP.All to McpConstants.ServerScopeMappings

The V2 catalog endpoint returns incorrect scope metadata for mcp_M365Copilot, causing auth failures when connecting to the server