### PR TITLE
Add manual cleanup block for unpublish

### DIFF
--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -530,8 +530,9 @@ public static class DevelopMcpCommand
             logger.LogInformation("Successfully unpublished MCP server {ServerName} from environment {EnvId}", serverName, envId);
 
             // The platform removes the tenant publication but cannot delete Entra app registrations in the
-            // customer tenant, so it returns any it created for this server for the CLI to clean up here.
-            await CleanupEntraAppsAsync(logger, graphApiService, response.AppIdsToCleanup, serverName);
+            // customer tenant, so it returns any it created for this server (in ManualCleanupRequired) for
+            // the CLI to clean up here.
+            await CleanupEntraAppsAsync(logger, graphApiService, response.ManualCleanupRequired?.Apps, serverName);
 
         }, envIdOption, serverNameOption, dryRunOption, verboseOption);
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -7,6 +7,7 @@ using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Evaluate;
 using Microsoft.Extensions.Logging;
 using System.CommandLine;
+using System.Linq;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Commands;
 
@@ -551,7 +552,7 @@ public static class DevelopMcpCommand
     /// Best-effort deletion of the Entra app registrations the platform returned from an unpublish. Each
     /// delete is independent so one failure does not skip the rest, and every failure is logged with the
     /// app id so the user can remove it manually. When Graph is unavailable or the tenant cannot be
-    /// detected, the app ids are logged for manual cleanup instead.
+    /// detected, the apps are listed once for manual cleanup instead.
     /// </summary>
     private static async Task CleanupEntraAppsAsync(
         ILogger logger,
@@ -564,28 +565,19 @@ public static class DevelopMcpCommand
             return;
         }
 
-        if (graphApiService is null)
+        // Tenant detection shells out to az, so only attempt it when Graph is available.
+        var tenantId = graphApiService is null
+            ? null
+            : await TenantDetectionHelper.DetectTenantIdAsync(null, logger);
+
+        if (graphApiService is null || string.IsNullOrWhiteSpace(tenantId))
         {
-            foreach (var app in appsToCleanup)
-            {
-                logger.LogWarning(
-                    "Graph API is unavailable; cannot delete Entra app '{AppName}' (appId {AppId}) for server '{ServerName}'. Delete it manually in the Azure portal.",
-                    app.AppName ?? "<unknown>", app.AppId ?? "<unknown>", serverName);
-            }
-
-            return;
-        }
-
-        var tenantId = await TenantDetectionHelper.DetectTenantIdAsync(null, logger);
-        if (string.IsNullOrWhiteSpace(tenantId))
-        {
-            foreach (var app in appsToCleanup)
-            {
-                logger.LogWarning(
-                    "Could not detect the tenant; cannot delete Entra app '{AppName}' (appId {AppId}) for server '{ServerName}'. Delete it manually in the Azure portal.",
-                    app.AppName ?? "<unknown>", app.AppId ?? "<unknown>", serverName);
-            }
-
+            var appList = string.Join(
+                Environment.NewLine,
+                appsToCleanup.Select(app => $"  - {app.AppName ?? "<unknown>"} (appId {app.AppId ?? "<unknown>"})"));
+            logger.LogWarning(
+                "The platform could not automatically delete {Count} Entra app registration(s) for server '{ServerName}'. Delete them manually in the Azure portal:{NewLine}{AppList}",
+                appsToCleanup.Count, serverName, Environment.NewLine, appList);
             return;
         }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Helpers;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Evaluate;
@@ -37,7 +38,7 @@ public static class DevelopMcpCommand
         developMcpCommand.AddCommand(CreateListEnvironmentsSubcommand(logger, toolingService));
         developMcpCommand.AddCommand(CreateListServersSubcommand(logger, toolingService));
         developMcpCommand.AddCommand(CreatePublishSubcommand(logger, toolingService, graphApiService));
-        developMcpCommand.AddCommand(CreateUnpublishSubcommand(logger, toolingService));
+        developMcpCommand.AddCommand(CreateUnpublishSubcommand(logger, toolingService, graphApiService));
         developMcpCommand.AddCommand(CreateRegisterExternalMcpServerSubcommand(logger, toolingService, graphApiService));
 
         if (evaluationPipelineService is not null)
@@ -424,7 +425,8 @@ public static class DevelopMcpCommand
     /// </summary>
     private static Command CreateUnpublishSubcommand(
         ILogger logger, 
-        IAgent365ToolingService toolingService)
+        IAgent365ToolingService toolingService,
+        GraphApiService? graphApiService)
     {
         var command = new Command("unpublish", "Unpublish an MCP server from a Dataverse environment");
 
@@ -517,9 +519,9 @@ public static class DevelopMcpCommand
             }
 
             // Call service
-            var success = await toolingService.UnpublishServerAsync(envId, serverName);
+            var response = await toolingService.UnpublishServerAsync(envId, serverName);
 
-            if (!success)
+            if (response is null || !response.IsSuccess)
             {
                 logger.LogError("Failed to unpublish MCP server {ServerName} from environment {EnvId}", serverName, envId);
                 return;
@@ -527,9 +529,97 @@ public static class DevelopMcpCommand
 
             logger.LogInformation("Successfully unpublished MCP server {ServerName} from environment {EnvId}", serverName, envId);
 
+            // The platform removes the tenant publication but cannot delete Entra app registrations in the
+            // customer tenant, so it returns any it created for this server for the CLI to clean up here.
+            await CleanupEntraAppsAsync(logger, graphApiService, response.AppIdsToCleanup, serverName);
+
         }, envIdOption, serverNameOption, dryRunOption, verboseOption);
 
         return command;
+    }
+
+    /// <summary>
+    /// Best-effort deletion of the Entra app registrations the platform returned from an unpublish. Each
+    /// delete is independent so one failure does not skip the rest, and every failure is logged with the
+    /// app id so the user can remove it manually. When Graph is unavailable or the tenant cannot be
+    /// detected, the app ids are logged for manual cleanup instead.
+    /// </summary>
+    private static async Task CleanupEntraAppsAsync(
+        ILogger logger,
+        GraphApiService? graphApiService,
+        IReadOnlyList<McpServerAppEntry>? appsToCleanup,
+        string serverName)
+    {
+        if (appsToCleanup is null || appsToCleanup.Count == 0)
+        {
+            return;
+        }
+
+        if (graphApiService is null)
+        {
+            foreach (var app in appsToCleanup)
+            {
+                logger.LogWarning(
+                    "Graph API is unavailable; cannot delete Entra app '{AppName}' (appId {AppId}) for server '{ServerName}'. Delete it manually in the Azure portal.",
+                    app.AppName ?? "<unknown>", app.AppId ?? "<unknown>", serverName);
+            }
+
+            return;
+        }
+
+        var tenantId = await TenantDetectionHelper.DetectTenantIdAsync(null, logger);
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            foreach (var app in appsToCleanup)
+            {
+                logger.LogWarning(
+                    "Could not detect the tenant; cannot delete Entra app '{AppName}' (appId {AppId}) for server '{ServerName}'. Delete it manually in the Azure portal.",
+                    app.AppName ?? "<unknown>", app.AppId ?? "<unknown>", serverName);
+            }
+
+            return;
+        }
+
+        logger.LogInformation("Cleaning up Entra app registrations for unpublished server '{ServerName}'...", serverName);
+
+        foreach (var app in appsToCleanup)
+        {
+            if (string.IsNullOrWhiteSpace(app.AppId))
+            {
+                continue;
+            }
+
+            try
+            {
+                var objectId = await graphApiService.GetAppObjectIdByAppIdAsync(tenantId, app.AppId);
+                if (string.IsNullOrWhiteSpace(objectId))
+                {
+                    logger.LogWarning(
+                        "Entra app '{AppName}' (appId {AppId}) was not found; it may already be deleted.",
+                        app.AppName ?? "<unknown>", app.AppId);
+                    continue;
+                }
+
+                var deleted = await graphApiService.DeleteEntraAppAsync(tenantId, objectId);
+                if (deleted)
+                {
+                    logger.LogInformation("Deleted Entra app '{AppName}' (appId {AppId})", app.AppName ?? "<unknown>", app.AppId);
+                }
+                else
+                {
+                    logger.LogError(
+                        "Failed to delete Entra app '{AppName}' (appId {AppId}). Delete it manually in the Azure portal.",
+                        app.AppName ?? "<unknown>", app.AppId);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Exception deleting Entra app '{AppName}' (appId {AppId}). Delete it manually in the Azure portal.",
+                    app.AppName ?? "<unknown>", app.AppId);
+            }
+        }
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -456,9 +456,12 @@ public static class DevelopMcpCommand
         );
         command.AddOption(verboseOption);
 
-        command.SetHandler(async (envId, serverName, dryRun, verbose) =>
+        command.SetHandler(async (context) =>
         {
-            _ = verbose;
+            var envId = context.ParseResult.GetValueForOption(envIdOption);
+            var serverName = context.ParseResult.GetValueForOption(serverNameOption);
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+
             try
             {
                 // Validate and prompt for missing required arguments with security checks
@@ -468,6 +471,7 @@ public static class DevelopMcpCommand
                     if (string.IsNullOrWhiteSpace(envId))
                     {
                         logger.LogError("Environment ID is required");
+                        context.ExitCode = 1;
                         return;
                     }
                 }
@@ -478,6 +482,7 @@ public static class DevelopMcpCommand
                     if (envId == null)
                     {
                         logger.LogError("Invalid environment ID format");
+                        context.ExitCode = 1;
                         return;
                     }
                 }
@@ -488,6 +493,7 @@ public static class DevelopMcpCommand
                     if (string.IsNullOrWhiteSpace(serverName))
                     {
                         logger.LogError("Server name is required");
+                        context.ExitCode = 1;
                         return;
                     }
                 }
@@ -498,6 +504,7 @@ public static class DevelopMcpCommand
                     if (serverName == null)
                     {
                         logger.LogError("Invalid server name format");
+                        context.ExitCode = 1;
                         return;
                     }
                 }
@@ -505,6 +512,7 @@ public static class DevelopMcpCommand
             catch (ArgumentException ex)
             {
                 logger.LogError("Input validation failed: {Message}", ex.Message);
+                context.ExitCode = 1;
                 return;
             }
 
@@ -524,6 +532,7 @@ public static class DevelopMcpCommand
             if (response is null || !response.IsSuccess)
             {
                 logger.LogError("Failed to unpublish MCP server {ServerName} from environment {EnvId}", serverName, envId);
+                context.ExitCode = 1;
                 return;
             }
 
@@ -533,8 +542,7 @@ public static class DevelopMcpCommand
             // customer tenant, so it returns any it created for this server (in ManualCleanupRequired) for
             // the CLI to clean up here.
             await CleanupEntraAppsAsync(logger, graphApiService, response.ManualCleanupRequired?.Apps, serverName);
-
-        }, envIdOption, serverNameOption, dryRunOption, verboseOption);
+        });
 
         return command;
     }
@@ -587,6 +595,9 @@ public static class DevelopMcpCommand
         {
             if (string.IsNullOrWhiteSpace(app.AppId))
             {
+                logger.LogWarning(
+                    "The platform returned Entra app '{AppName}' for cleanup without an appId, so it cannot be deleted automatically. If it exists, delete it manually in the Azure portal.",
+                    app.AppName ?? "<unknown>");
                 continue;
             }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/McpServerAppEntry.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/McpServerAppEntry.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Models;
+
+/// <summary>
+/// An Entra app registration associated with a published MCP server that the CLI is responsible for
+/// deleting on unpublish. The platform cannot delete app registrations in the customer tenant, so it
+/// returns these entries and the CLI performs the deletion using the caller's Graph permissions.
+/// </summary>
+public class McpServerAppEntry
+{
+    /// <summary>
+    /// Friendly name of the app registration (for logging / manual cleanup guidance).
+    /// </summary>
+    [JsonPropertyName("AppName")]
+    public string? AppName { get; set; }
+
+    /// <summary>
+    /// The app (client) id of the Entra app registration. The CLI resolves the underlying application
+    /// object id from this before calling Graph's application delete.
+    /// </summary>
+    [JsonPropertyName("AppId")]
+    public string? AppId { get; set; }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/McpServerManualCleanup.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/McpServerManualCleanup.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Models;
+
+/// <summary>
+/// Describes resources the unpublish operation could not delete on the caller's behalf and that the
+/// caller must remove manually. Mirrors the platform's response contract so any client (not just this
+/// CLI) can discover the cleanup responsibility from the response body.
+/// </summary>
+public class McpServerManualCleanup
+{
+    /// <summary>
+    /// Human-readable explanation of why the listed resources were not deleted automatically and how
+    /// to remove them.
+    /// </summary>
+    [JsonPropertyName("Reason")]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// The Entra app registrations the caller must delete manually in their own tenant.
+    /// </summary>
+    [JsonPropertyName("Apps")]
+    public List<McpServerAppEntry>? Apps { get; set; }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/UnpublishMcpServerResponse.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/UnpublishMcpServerResponse.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Models;
+
+/// <summary>
+/// Response model for an MCP server unpublish operation.
+/// </summary>
+public class UnpublishMcpServerResponse
+{
+    /// <summary>
+    /// Status of the unpublish operation.
+    /// </summary>
+    [JsonPropertyName("Status")]
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Message from the API response.
+    /// </summary>
+    [JsonPropertyName("Message")]
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Entra app registrations the platform created for this server that the CLI must delete: the
+    /// platform's identity cannot delete app registrations in the customer tenant, so it returns them
+    /// here for the CLI to clean up. Currently the server's Public Clients app; empty/null when the
+    /// server had none (for example OOB Dataverse servers or legacy records).
+    /// </summary>
+    [JsonPropertyName("AppIdsToCleanup")]
+    public List<McpServerAppEntry>? AppIdsToCleanup { get; set; }
+
+    /// <summary>
+    /// Whether the operation was successful.
+    /// </summary>
+    [JsonIgnore]
+    public bool IsSuccess => Status?.Equals("Success", StringComparison.OrdinalIgnoreCase) ?? false;
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/UnpublishMcpServerResponse.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/UnpublishMcpServerResponse.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Models;
@@ -24,13 +23,12 @@ public class UnpublishMcpServerResponse
     public string? Message { get; set; }
 
     /// <summary>
-    /// Entra app registrations the platform created for this server that the CLI must delete: the
-    /// platform's identity cannot delete app registrations in the customer tenant, so it returns them
-    /// here for the CLI to clean up. Currently the server's Public Clients app; empty/null when the
-    /// server had none (for example OOB Dataverse servers or legacy records).
+    /// Resources the platform could not delete in the customer tenant and that the caller must remove
+    /// manually (with a reason and the affected app registrations). Null when there is nothing for the
+    /// caller to clean up (for example OOB Dataverse servers or legacy records).
     /// </summary>
-    [JsonPropertyName("AppIdsToCleanup")]
-    public List<McpServerAppEntry>? AppIdsToCleanup { get; set; }
+    [JsonPropertyName("ManualCleanupRequired")]
+    public McpServerManualCleanup? ManualCleanupRequired { get; set; }
 
     /// <summary>
     /// Whether the operation was successful.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -621,11 +621,22 @@ public class Agent365ToolingService : IAgent365ToolingService
             var unpublishResponse = JsonDeserializationHelper.DeserializeWithDoubleSerialization<UnpublishMcpServerResponse>(
                 responseContent, _logger);
 
-            return unpublishResponse ?? new UnpublishMcpServerResponse
+            // A non-empty body that fails to parse is not fatal to the unpublish itself, but it means we
+            // may have lost the ManualCleanupRequired block - so warn the user to check for leftovers rather
+            // than silently returning a clean success.
+            if (unpublishResponse is null)
             {
-                Status = "Success",
-                Message = $"Successfully unpublished {serverName}"
-            };
+                _logger.LogWarning(
+                    "The unpublish for {ServerName} succeeded but its response body could not be parsed, so any Entra app registrations the platform asked to be cleaned up may have been missed. Review the server's app registrations in the Azure portal and delete any leftovers manually.",
+                    serverName);
+                return new UnpublishMcpServerResponse
+                {
+                    Status = "Success",
+                    Message = $"Successfully unpublished {serverName}"
+                };
+            }
+
+            return unpublishResponse;
         }
         catch (Exception ex)
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -553,7 +553,7 @@ public class Agent365ToolingService : IAgent365ToolingService
     }
 
     /// <inheritdoc />
-    public async Task<bool> UnpublishServerAsync(
+    public async Task<UnpublishMcpServerResponse?> UnpublishServerAsync(
         string environmentId,
         string serverName,
         CancellationToken cancellationToken = default)
@@ -587,7 +587,7 @@ public class Agent365ToolingService : IAgent365ToolingService
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
-                return false;
+                return null;
             }
 
             // Create authenticated HTTP client
@@ -600,19 +600,37 @@ public class Agent365ToolingService : IAgent365ToolingService
             using var response = await httpClient.DeleteAsync(endpointUrl, cancellationToken);
 
             // Validate response using common helper
-            var (isSuccess, _) = await ValidateResponseAsync(response, "unpublish MCP server", cancellationToken);
+            var (isSuccess, responseContent) = await ValidateResponseAsync(response, "unpublish MCP server", cancellationToken);
             if (!isSuccess)
             {
-                return false;
+                return null;
             }
 
             _logger.LogDebug("Successfully unpublished MCP server");
-            return true;
+
+            // Allow for an empty/null body: the operation still succeeded, there is just nothing to clean up.
+            if (string.IsNullOrWhiteSpace(responseContent))
+            {
+                return new UnpublishMcpServerResponse
+                {
+                    Status = "Success",
+                    Message = $"Successfully unpublished {serverName}"
+                };
+            }
+
+            var unpublishResponse = JsonDeserializationHelper.DeserializeWithDoubleSerialization<UnpublishMcpServerResponse>(
+                responseContent, _logger);
+
+            return unpublishResponse ?? new UnpublishMcpServerResponse
+            {
+                Status = "Success",
+                Message = $"Successfully unpublished {serverName}"
+            };
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to unpublish MCP server {ServerName} from environment {EnvId}", serverName, environmentId);
-            return false;
+            return null;
         }
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -608,26 +608,19 @@ public class Agent365ToolingService : IAgent365ToolingService
 
             _logger.LogDebug("Successfully unpublished MCP server");
 
-            // Allow for an empty/null body: the operation still succeeded, there is just nothing to clean up.
-            if (string.IsNullOrWhiteSpace(responseContent))
-            {
-                return new UnpublishMcpServerResponse
-                {
-                    Status = "Success",
-                    Message = $"Successfully unpublished {serverName}"
-                };
-            }
+            var unpublishResponse = string.IsNullOrWhiteSpace(responseContent)
+                ? null
+                : JsonDeserializationHelper.DeserializeWithDoubleSerialization<UnpublishMcpServerResponse>(
+                    responseContent, _logger);
 
-            var unpublishResponse = JsonDeserializationHelper.DeserializeWithDoubleSerialization<UnpublishMcpServerResponse>(
-                responseContent, _logger);
-
-            // A non-empty body that fails to parse is not fatal to the unpublish itself, but it means we
-            // may have lost the ManualCleanupRequired block - so warn the user to check for leftovers rather
-            // than silently returning a clean success.
+            // The platform always returns a JSON body on a successful unpublish, so an empty body or one
+            // that fails to parse means we could not read the response - including any ManualCleanupRequired
+            // block. The unpublish itself still succeeded, so warn the user to check for leftover Entra app
+            // registrations rather than silently returning a clean success.
             if (unpublishResponse is null)
             {
                 _logger.LogWarning(
-                    "The unpublish for {ServerName} succeeded but its response body could not be parsed, so any Entra app registrations the platform asked to be cleaned up may have been missed. Review the server's app registrations in the Azure portal and delete any leftovers manually.",
+                    "The unpublish for {ServerName} succeeded but its response body was empty or could not be parsed, so any Entra app registrations the platform asked to be cleaned up may have been missed. Review the server's app registrations in the Azure portal and delete any leftovers manually.",
                     serverName);
                 return new UnpublishMcpServerResponse
                 {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -2270,42 +2270,6 @@ public class GraphApiService
     }
 
     /// <summary>
-    /// Looks up an application by its appId (clientId) and returns the object ID.
-    /// Retries up to 6 times with a 10-second delay to handle replication lag for newly created apps.
-    /// </summary>
-    public virtual async Task<string?> GetAppObjectIdByClientIdAsync(
-        string tenantId, string clientId, CancellationToken ct = default)
-    {
-        const int maxAttempts = 6;
-        const int delayMs = 10_000;
-
-        for (var attempt = 0; attempt < maxAttempts; attempt++)
-        {
-            var response = await GraphGetWithResponseAsync(tenantId, $"/v1.0/applications?$filter=appId eq '{clientId}'&$select=id", ct: ct);
-            if (response.IsSuccess && response.Json != null)
-            {
-                var values = response.Json.RootElement.GetProperty("value");
-                if (values.GetArrayLength() > 0)
-                {
-                    return values[0].GetProperty("id").GetString();
-                }
-            }
-            else
-            {
-                _logger.LogDebug("App {ClientId} query failed: {Code} {Reason} (attempt {Attempt}/{Max})", clientId, response.StatusCode, response.ReasonPhrase, attempt + 1, maxAttempts);
-            }
-
-            if (attempt < maxAttempts - 1)
-            {
-                _logger.LogDebug("App {ClientId} not found yet, retrying in {Delay}s (attempt {Attempt}/{Max})...", clientId, delayMs / 1000, attempt + 1, maxAttempts);
-                await Task.Delay(delayMs, ct);
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
     /// Finds an application's object ID by its display name.
     /// </summary>
     public virtual async Task<string?> GetAppObjectIdByDisplayNameAsync(

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -604,6 +604,30 @@ public class GraphApiService
     }
 
     /// <summary>
+    /// Resolves an application's object ID from its appId (client ID). Returns null when the application
+    /// cannot be found (for example it was already deleted). Virtual to allow substitution in unit tests.
+    /// </summary>
+    public virtual async Task<string?> GetAppObjectIdByAppIdAsync(
+        string tenantId, string appId, CancellationToken ct = default)
+    {
+        // Validate GUID format to prevent OData injection.
+        if (!Guid.TryParse(appId, out var validGuid))
+        {
+            _logger.LogWarning("Invalid appId format for application lookup: {AppId}", appId);
+            return null;
+        }
+
+        using var doc = await GraphGetAsync(
+            tenantId,
+            $"/v1.0/applications?$filter=appId eq '{validGuid:D}'&$select=id&$top=1",
+            ct);
+        if (doc == null) return null;
+        if (!doc.RootElement.TryGetProperty("value", out var value) || value.GetArrayLength() == 0) return null;
+        if (!value[0].TryGetProperty("id", out var id)) return null;
+        return id.GetString();
+    }
+
+    /// <summary>
     /// Looks up the display name of a service principal by its application ID.
     /// Returns null if the service principal is not found.
     /// Virtual to allow substitution in unit tests using NSubstitute.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IAgent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IAgent365ToolingService.cs
@@ -52,8 +52,11 @@ public interface IAgent365ToolingService
     /// <param name="environmentId">Dataverse environment ID</param>
     /// <param name="serverName">MCP server name to unpublish</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>True if successful, false otherwise</returns>
-    Task<bool> UnpublishServerAsync(
+    /// <returns>
+    /// The unpublish response (including any Entra app registrations the CLI must delete), or null when
+    /// the operation failed.
+    /// </returns>
+    Task<UnpublishMcpServerResponse?> UnpublishServerAsync(
         string environmentId,
         string serverName,
         CancellationToken cancellationToken = default);

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
@@ -72,7 +72,8 @@ public class DevelopMcpCommandRegressionTests
         _mockToolingService.ListServersAsync(Arg.Any<string>()).Returns(new DataverseMcpServersResponse());
         _mockToolingService.PublishServerAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<PublishMcpServerRequest>())
             .Returns(new PublishMcpServerResponse { Status = "Success" });
-        _mockToolingService.UnpublishServerAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        _mockToolingService.UnpublishServerAsync(Arg.Any<string>(), Arg.Any<string>())
+            .Returns(new UnpublishMcpServerResponse { Status = "Success" });
 
         var fullCommand = new List<string> { command };
         fullCommand.AddRange(args);
@@ -336,7 +337,8 @@ public class DevelopMcpCommandRegressionTests
         var testEnvId = "test-environment-456";
         var testServerName = "msdyn_TestServer";
 
-        _mockToolingService.UnpublishServerAsync(testEnvId, testServerName).Returns(true);
+        _mockToolingService.UnpublishServerAsync(testEnvId, testServerName)
+            .Returns(new UnpublishMcpServerResponse { Status = "Success" });
 
         // Act
         var result = await _command.InvokeAsync(new[] 
@@ -347,6 +349,56 @@ public class DevelopMcpCommandRegressionTests
         });
 
         // Assert
+        result.Should().Be(0);
+        await _mockToolingService.Received(1).UnpublishServerAsync(testEnvId, testServerName);
+    }
+
+    [Fact]
+    public async Task UnpublishCommand_WhenServiceReturnsNull_DoesNotThrow()
+    {
+        // A null response means the unpublish failed; the command must log and return cleanly.
+        var testEnvId = "test-environment-789";
+        var testServerName = "msdyn_TestServer";
+
+        _mockToolingService.UnpublishServerAsync(testEnvId, testServerName)
+            .Returns((UnpublishMcpServerResponse?)null);
+
+        var result = await _command.InvokeAsync(new[]
+        {
+            "unpublish",
+            "-e", testEnvId,
+            "-s", testServerName
+        });
+
+        result.Should().Be(0);
+        await _mockToolingService.Received(1).UnpublishServerAsync(testEnvId, testServerName);
+    }
+
+    [Fact]
+    public async Task UnpublishCommand_WithAppsToCleanup_NoGraphService_SucceedsWithoutThrow()
+    {
+        // The command is created without a GraphApiService (the default), so the returned apps cannot be
+        // deleted. The cleanup step must degrade gracefully (warn, no throw) rather than fail the command.
+        var testEnvId = "test-environment-abc";
+        var testServerName = "TestCustomServer";
+
+        _mockToolingService.UnpublishServerAsync(testEnvId, testServerName)
+            .Returns(new UnpublishMcpServerResponse
+            {
+                Status = "Success",
+                AppIdsToCleanup = new List<McpServerAppEntry>
+                {
+                    new() { AppName = $"{testServerName}-PublicClients", AppId = "11111111-1111-1111-1111-111111111111" },
+                },
+            });
+
+        var result = await _command.InvokeAsync(new[]
+        {
+            "unpublish",
+            "-e", testEnvId,
+            "-s", testServerName
+        });
+
         result.Should().Be(0);
         await _mockToolingService.Received(1).UnpublishServerAsync(testEnvId, testServerName);
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
@@ -354,9 +354,10 @@ public class DevelopMcpCommandRegressionTests
     }
 
     [Fact]
-    public async Task UnpublishCommand_WhenServiceReturnsNull_DoesNotThrow()
+    public async Task UnpublishCommand_WhenServiceReturnsNull_ReturnsNonZeroExitCode()
     {
-        // A null response means the unpublish failed; the command must log and return cleanly.
+        // A null response means the unpublish failed; the command must log the failure and surface it to
+        // the shell as a non-zero exit code (not swallow it as success).
         var testEnvId = "test-environment-789";
         var testServerName = "msdyn_TestServer";
 
@@ -370,7 +371,7 @@ public class DevelopMcpCommandRegressionTests
             "-s", testServerName
         });
 
-        result.Should().Be(0);
+        result.Should().Be(1);
         await _mockToolingService.Received(1).UnpublishServerAsync(testEnvId, testServerName);
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandRegressionTests.cs
@@ -386,9 +386,13 @@ public class DevelopMcpCommandRegressionTests
             .Returns(new UnpublishMcpServerResponse
             {
                 Status = "Success",
-                AppIdsToCleanup = new List<McpServerAppEntry>
+                ManualCleanupRequired = new McpServerManualCleanup
                 {
-                    new() { AppName = $"{testServerName}-PublicClients", AppId = "11111111-1111-1111-1111-111111111111" },
+                    Reason = "The platform cannot delete Entra app registrations in your tenant.",
+                    Apps = new List<McpServerAppEntry>
+                    {
+                        new() { AppName = $"{testServerName}-PublicClients", AppId = "11111111-1111-1111-1111-111111111111" },
+                    },
                 },
             });
 


### PR DESCRIPTION
### Summary
When you unpublish a custom MCP server, the platform removes the tenant publication (MOS title + MCC record) but cannot delete the Entra app registration it created for the server (the *-PublicClients app), because the platform's identity has no rights to delete app registrations in the customer tenant. Previously that app was left dangling after unpublish, with nothing telling the user it existed.

The platform now returns those apps on the unpublish response under a self-describing ManualCleanupRequired block. This PR teaches the CLI to consume that block and delete the apps on the user's behalf — mirroring the rollback the publish flow already does when a publish fails.

### What changed
UnpublishServerAsync now returns the parsed response (Task<UnpublishMcpServerResponse?> instead of Task<bool>), so the command layer can act on the returned apps. Returns null on failure.
New models mirroring the platform contract:

- UnpublishMcpServerResponse — Status, Message, ManualCleanupRequired, IsSuccess.
- McpServerManualCleanup — { Reason, Apps[] }.
- McpServerAppEntry — { AppName, AppId }.
- GraphApiService.GetAppObjectIdByAppIdAsync — resolves an app's object id from its app (client) id, since the platform returns the client id but Graph's delete needs the object id.
- develop mcp unpublish now takes the GraphApiService and, after a successful unpublish, deletes each returned app best-effort: each delete is independent, failures are logged with the app id, and the step degrades gracefully (warn, don't fail the command) when Graph or the tenant can't be resolved — falling back to a manual-cleanup message so the user still knows what to remove.

### Testing
CLI + test projects build clean (warnings-as-errors).
Full suite: 1923 passed / 0 failed / 12 skipped.
Added coverage: null-response path (unpublish failed → no throw) and the no-Graph-service cleanup path (degrades gracefully).