### PR TITLE
Add cloud-aware authority/graph endpoint resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,9 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- Repeated `publish --aiteammate` runs now preserve customized manifest names instead of restoring an overlong blueprint name.
+- Repeated `setup blueprint --agent-name` runs now reuse the stored valid client secret instead of creating duplicate credentials.
+- `a365 query-entra blueprint-scopes` and `inheritance` now report permission-grant read failures, and `a365 create-instance` now stops safely instead of continuing when existing grants cannot be read.
 - `setup requirements` now validates and repairs tenant-owned fallback CLI apps with the administrator bootstrap identity, preventing false "app not found" failures when the first-party CLI app is unavailable.
 - Cloud-specific Graph, authority, and Agent 365 Tools endpoint overrides now apply consistently across setup, consent, authentication, query, and create-instance flows for sovereign and custom clouds. (#478)
 - Setup no longer fails to detect the Agent 365 CLI application in tenants where it is not yet provisioned, and reports lookup errors instead of silently switching your configured client app (#489).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- Cloud-specific Agent 365 discover endpoint overrides now also select the messaging endpoint create and delete hosts unless explicit overrides are set.
 - Repeated `publish --aiteammate` runs now preserve customized manifest names instead of restoring an overlong blueprint name.
 - Repeated `setup blueprint --agent-name` runs now reuse the stored valid client secret instead of creating duplicate credentials.
 - `a365 query-entra blueprint-scopes` and `inheritance` now report permission-grant read failures, and `a365 create-instance` now stops safely instead of continuing when existing grants cannot be read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 **Option A — Entra portal** (no config files required):
 
 1. [Entra portal](https://entra.microsoft.com) > **App registrations** > select your **Blueprint** app > **API permissions**
-2. **Add a permission** > **APIs my organization uses** > search `9b975845-388f-4429-889e-eab1ef63949c`
+2. **Add a permission** > **APIs my organization uses** > search for the Observability app ID for your cloud:
+   - Commercial: `9b975845-388f-4429-889e-eab1ef63949c`
+   - GCC Moderate: `2c672ad5-b104-44ed-8069-bb68dd138546`
+   - GCC High: `009c6bd0-82e4-4466-95b3-4c996521f3d7`
+   - DoD: `a9e04047-c6a7-430b-a7ae-faf8f8eed1b7`
 3. **Delegated permissions** > select `Agent365.Observability.OtelWrite` > **Add permissions**
 4. Repeat step 2 > **Application permissions** > select `Agent365.Observability.OtelWrite` > **Add permissions**
 5. **Grant admin consent for \<tenant\>** > confirm
@@ -59,6 +63,8 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- Setup now requests the required Graph scopes and stops safely when existing blueprint discovery is inconclusive, preventing duplicate blueprints after CLI permission changes.
+- GCC Moderate, GCC High, and DoD setup now grant permissions to each cloud's Observability service instead of the commercial service.
 - Cloud-specific Agent 365 discover endpoint overrides now also select the messaging endpoint create and delete hosts unless explicit overrides are set.
 - Repeated `publish --aiteammate` runs now preserve customized manifest names instead of restoring an overlong blueprint name.
 - Repeated `setup blueprint --agent-name` runs now reuse the stored valid client secret instead of creating duplicate credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- `setup requirements` now validates and repairs tenant-owned fallback CLI apps with the administrator bootstrap identity, preventing false "app not found" failures when the first-party CLI app is unavailable.
 - Cloud-specific Graph, authority, and Agent 365 Tools endpoint overrides now apply consistently across setup, consent, authentication, query, and create-instance flows for sovereign and custom clouds. (#478)
 - Setup no longer fails to detect the Agent 365 CLI application in tenants where it is not yet provisioned, and reports lookup errors instead of silently switching your configured client app (#489).
 - The first-party Agent 365 CLI app now uses device code authentication when Windows Account Manager is unavailable, avoiding unsupported browser-response errors in WSL, macOS, and Linux (#489).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- Cloud-specific Graph, authority, and Agent 365 Tools overrides now apply across setup, consent, authentication, query, and create-instance flows. Arbitrary cloud names use normalized environment-scoped variables such as `A365_GRAPH_BASE_URL_GCC_HIGH`, and configured endpoints are normalized and validated
 - `setup all --authmode s2s` no longer prints spurious "Action Required" PowerShell steps when the agent identity already inherits its app roles from the blueprint, and now retries the grant automatically before falling back to manual steps (#460).
 - `a365 develop get-token` now falls back to device code when the Windows WAM broker rejects Exchange Graph scopes with `ApiContractViolation`, instead of failing with an opaque MSAL error.
 - `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically, and ends with a setup summary whose Action Required block surfaces the admin-consent URL for non-admins to hand off (#452).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
-- Cloud-specific Graph, authority, and Agent 365 Tools overrides now apply across setup, consent, authentication, query, and create-instance flows. Arbitrary cloud names use normalized environment-scoped variables such as `A365_GRAPH_BASE_URL_GCC_HIGH`, and configured endpoints are normalized and validated
+- Cloud-specific Graph, authority, and Agent 365 Tools endpoint overrides now apply consistently across setup, consent, authentication, query, and create-instance flows for sovereign and custom clouds. (#478)
 - `setup all --authmode s2s` no longer prints spurious "Action Required" PowerShell steps when the agent identity already inherits its app roles from the blueprint, and now retries the grant automatically before falling back to manual steps (#460).
 - `a365 develop get-token` now falls back to device code when the Windows WAM broker rejects Exchange Graph scopes with `ApiContractViolation`, instead of failing with an opaque MSAL error.
 - `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically, and ends with a setup summary whose Action Required block surfaces the admin-consent URL for non-admins to hand off (#452).

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/CreateInstanceCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/CreateInstanceCommand.cs
@@ -168,11 +168,12 @@ public class CreateInstanceCommand
                 if (!botApiGrantOk)
                     logger.LogWarning("Failed to create/update oauth2PermissionGrant for agent identity to Messaging Bot API.");
 
+                var observabilityApiAppId = ConfigConstants.GetObservabilityApiAppId(instanceConfig.Environment);
                 var observabilityApiResourceSpObjectId = await graphApiService.EnsureServicePrincipalForAppIdAsync(
                     instanceConfig.TenantId,
-                    ConfigConstants.ObservabilityApiAppId)
+                    observabilityApiAppId)
                     ?? throw new InvalidOperationException(
-                        $"Failed to resolve service principal for Observability API (appId {ConfigConstants.ObservabilityApiAppId}).");
+                        $"Failed to resolve service principal for Observability API (appId {observabilityApiAppId}).");
 
                 // Grant oauth2PermissionGrants: *agent identity SP* -> Observability API SP
                 var observabilityApiGrantOk = await graphApiService.CreateOrUpdateOauth2PermissionGrantAsync(

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopCommand.cs
@@ -146,7 +146,10 @@ public static class DevelopCommand
                 // Resolve az CLI login hint so WAM targets the correct account instead of
                 // defaulting to the first cached MSAL account (which may be stale).
                 var loginHint = await Services.Helpers.AzCliHelper.ResolveLoginHintAsync();
-                authToken = await authService.GetAccessTokenAsync(audience, userId: loginHint);
+                authToken = await authService.GetAccessTokenAsync(
+                    audience,
+                    userId: loginHint,
+                    authorityHost: ConfigConstants.GetAuthorityHost(environment));
 
                 if (string.IsNullOrWhiteSpace(authToken))
                 {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopSubcommands/AddPermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopSubcommands/AddPermissionsSubcommand.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Helpers;
+using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using System.CommandLine;
@@ -74,6 +75,10 @@ internal static class AddPermissionsSubcommand
                 var setupConfig = File.Exists(configFile.FullName)
                     ? await configService.LoadAsync(configFile.FullName)
                     : null;
+                graphApiService.ConfigureCloudEndpoints(setupConfig ?? new Agent365Config
+                {
+                    Environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod"
+                });
 
                 if (setupConfig == null && string.IsNullOrWhiteSpace(appId))
                 {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopSubcommands/GetTokenSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopSubcommands/GetTokenSubcommand.cs
@@ -139,7 +139,7 @@ internal static class GetTokenSubcommand
                 }
 
                 // Determine environment
-                var environment = setupConfig?.Environment ?? "prod";
+                var environment = ResolveEnvironment(setupConfig);
 
                 // Resolve resource app ID
                 string resourceAppId;
@@ -283,7 +283,10 @@ internal static class GetTokenSubcommand
                 forceRefresh,
                 clientAppId,
                 useInteractiveBrowser: !useDeviceCode,
-                userId: loginHint);
+                userId: loginHint,
+                authorityHost: ConfigConstants.GetAuthorityHost(
+                    ResolveEnvironment(setupConfig),
+                    setupConfig?.AuthorityHost));
 
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -394,7 +397,7 @@ internal static class GetTokenSubcommand
 
         logger.LogInformation("");
 
-        var tokenAtgAppId = ConfigConstants.GetAgent365ToolsResourceAppId(setupConfig?.Environment ?? "prod");
+        var tokenAtgAppId = ConfigConstants.GetAgent365ToolsResourceAppId(ResolveEnvironment(setupConfig));
         var scopesByAudience = await ManifestHelper.GetScopesByAudienceAsync(manifestPath, resolvedAtgAppId: tokenAtgAppId);
         var serverNamesByAudience = await ManifestHelper.GetServerNamesByAudienceAsync(manifestPath, resolvedAtgAppId: tokenAtgAppId);
 
@@ -454,6 +457,11 @@ internal static class GetTokenSubcommand
             return setupConfig.ClientAppId;
         throw new InvalidOperationException("No client application ID specified. Use --app-id or ensure ClientAppId is set in config.");
     }
+
+    private static string ResolveEnvironment(Agent365Config? setupConfig) =>
+        setupConfig?.Environment
+        ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT")
+        ?? "prod";
 
     private static async Task SaveAndReportTokenAsync(
         string token,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/PublishCommand.cs
@@ -221,6 +221,8 @@ public class PublishCommand
 
                 var updatedManifest = await UpdateManifestFileAsync(displayName, blueprintId, manifestPath);
                 var updatedAgenticUserManifest = await UpdateAgenticUserManifestTemplateFileAsync(blueprintId, agenticUserManifestPath);
+                var updatedManifestNode = JsonNode.Parse(updatedManifest);
+                var shortName = updatedManifestNode?["name"]?["short"]?.GetValue<string>();
 
                 if (dryRun)
                 {
@@ -238,12 +240,12 @@ public class PublishCommand
                 logger.LogInformation("Customize before packaging:");
                 logger.LogInformation("  version              - increment for republishing (e.g., 1.0.1), must be higher than previous");
 
-                if (string.IsNullOrWhiteSpace(displayName))
+                if (string.IsNullOrWhiteSpace(shortName))
                     logger.LogWarning("  name.short           - not set; edit manifest.json to provide a short name (30 chars max) before packaging");
-                else if (displayName.Length > 30)
-                    logger.LogWarning("  name.short           - EXCEEDS 30 chars ({Length}), currently: \"{Name}\" -- shorten before packaging", displayName.Length, displayName);
+                else if (shortName.Length > 30)
+                    logger.LogWarning("  name.short           - EXCEEDS 30 chars ({Length}), currently: \"{Name}\" -- shorten before packaging", shortName.Length, shortName);
                 else
-                    logger.LogInformation("  name.short           - 30 chars max, currently: \"{Name}\"", displayName);
+                    logger.LogInformation("  name.short           - 30 chars max, currently: \"{Name}\"", shortName);
 
                 logger.LogInformation("  name.full            - displayed in Microsoft 365");
                 logger.LogInformation("  description.short    - 1-2 sentences");
@@ -340,8 +342,8 @@ public class PublishCommand
                 node["name"] = nameObj;
             }
 
-            nameObj["short"] = displayName;
-            nameObj["full"] = displayName;
+            SetManifestNameDefault(nameObj, "short", "Your Agent Name", displayName);
+            SetManifestNameDefault(nameObj, "full", "Your Agent Full Name", displayName);
         }
 
         if (node["bots"] is JsonArray bots && bots.Count > 0 && bots[0] is JsonObject botObj)
@@ -357,6 +359,24 @@ public class PublishCommand
             ceObj["id"] = blueprintId;
 
         return node.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
+    }
+
+    private static void SetManifestNameDefault(
+        JsonObject name,
+        string propertyName,
+        string templateValue,
+        string displayName)
+    {
+        var currentValue = name[propertyName] is JsonValue valueNode &&
+            valueNode.TryGetValue<string>(out var value)
+                ? value
+                : null;
+
+        if (string.IsNullOrWhiteSpace(currentValue) ||
+            string.Equals(currentValue, templateValue, StringComparison.Ordinal))
+        {
+            name[propertyName] = displayName;
+        }
     }
 
     private static async Task<string> UpdateAgenticUserManifestTemplateFileAsync(string blueprintId, string agenticUserManifestPath)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/QueryEntraCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/QueryEntraCommand.cs
@@ -614,12 +614,14 @@ public class QueryEntraCommand
     /// </summary>
     private static string? GetWellKnownResourceName(string? resourceAppId)
     {
+        if (ConfigConstants.IsObservabilityApiAppId(resourceAppId))
+            return "Observability API";
+
         return resourceAppId switch
         {
             null or "" => null,
             AuthenticationConstants.MicrosoftGraphResourceAppId => "Microsoft Graph",
             ConfigConstants.MessagingBotApiAppId => "Messaging Bot API",
-            ConfigConstants.ObservabilityApiAppId => "Observability API",
             PowerPlatformConstants.PowerPlatformApiResourceAppId => "Power Platform API",
             "00000002-0000-0000-c000-000000000000" => "Azure Active Directory Graph",
             "797f4846-ba00-4fd7-ba43-dac1f8f63013" => "Azure Service Management",

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/QueryEntraCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/QueryEntraCommand.cs
@@ -27,7 +27,7 @@ public class QueryEntraCommand
 
         // Add subcommands for different query types
         command.AddCommand(CreateBlueprintScopesSubcommand(logger, configService, executor, graphApiService, blueprintService, resolver));
-        command.AddCommand(CreateInstanceScopesSubcommand(logger, configService, executor, resolver));
+        command.AddCommand(CreateInstanceScopesSubcommand(logger, configService, executor, graphApiService, resolver));
         command.AddCommand(CreateInheritanceSubcommand(logger, configService, graphApiService, blueprintService, resolver));
 
         return command;
@@ -82,6 +82,7 @@ public class QueryEntraCommand
                     context.ExitCode = 1;
                     return;
                 }
+                graphApiService.ConfigureCloudEndpoints(setupConfig);
 
                 if (string.IsNullOrEmpty(setupConfig.AgentBlueprintId))
                 {
@@ -258,6 +259,7 @@ public class QueryEntraCommand
                     context.ExitCode = 1;
                     return;
                 }
+                graphApiService.ConfigureCloudEndpoints(setupConfig);
 
                 if (string.IsNullOrEmpty(setupConfig.AgentBlueprintId))
                 {
@@ -365,6 +367,7 @@ public class QueryEntraCommand
         ILogger<QueryEntraCommand> logger,
         IConfigService configService,
         CommandExecutor executor,
+        GraphApiService graphApiService,
         IBootstrapConfigResolver? resolver = null)
     {
         var command = new Command("instance-scopes", "List configured scopes and consent status for the agent instance");
@@ -407,6 +410,7 @@ public class QueryEntraCommand
                     context.ExitCode = 1;
                     return;
                 }
+                graphApiService.ConfigureCloudEndpoints(instanceConfig);
 
                 // Check for agent identity (could be AgentBlueprintId or specific instance identity)
                 string? agenticAppId = null;
@@ -476,7 +480,7 @@ public class QueryEntraCommand
                 
                 // Use Microsoft Graph API through Azure CLI to get OAuth2 permission grants
                 var grantsResult = await executor.ExecuteAsync("az",
-                    $"rest --method GET --url \"https://graph.microsoft.com/v1.0/oauth2PermissionGrants?$filter=clientId eq '{agenticAppId}'\" --output json");
+                    $"rest --method GET --url \"{graphApiService.GraphBaseUrl}/v1.0/oauth2PermissionGrants?$filter=clientId eq '{agenticAppId}'\" --output json");
 
                 // Distinguish "API call failed" (can't read) from "API succeeded but returned no grants".
                 // Non-admin developers lack DelegatedPermissionGrant.Read.All and always get a failure here —
@@ -501,7 +505,7 @@ public class QueryEntraCommand
                                 
                                 // Get the resource display name using Graph API
                                 var resourceResult = await executor.ExecuteAsync("az", 
-                                    $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals/{resourceId}?$select=displayName,appId\" --output json");
+                                    $"rest --method GET --url \"{graphApiService.GraphBaseUrl}/v1.0/servicePrincipals/{resourceId}?$select=displayName,appId\" --output json");
                                 
                                 string resourceName = "Unknown Resource";
                                 string resourceAppId = "Unknown";

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
@@ -407,8 +407,7 @@ internal static class AllSubcommand
                 }
 
                 // Build SetupContext for non-DW blueprint and delegate to orchestrator.
-                if (!string.IsNullOrWhiteSpace(nonDwConfig.ClientAppId))
-                    graphApiService.CustomClientAppId = nonDwConfig.ClientAppId;
+                graphApiService.ConfigureCloudEndpoints(nonDwConfig);
 
                 var nonDwGeneratedConfigPath = Path.Combine(
                     config.DirectoryName ?? Environment.CurrentDirectory,
@@ -526,12 +525,7 @@ internal static class AllSubcommand
                     }
                 }
 
-                // Configure GraphApiService with custom client app ID if available
-                // This ensures inheritable permissions operations use the validated custom app
-                if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-                {
-                    graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-                }
+                graphApiService.ConfigureCloudEndpoints(setupConfig);
 
                 setupResults.PrerequisitesSkipped = skipRequirements;
                 setupResults.InfrastructureSkipped = true;
@@ -627,7 +621,7 @@ internal static class AllSubcommand
                 // Display verification URLs and setup summary
                 await SetupHelpers.DisplayVerificationInfoAsync(config, logger);
                 logger.LogInformation("");
-                SetupHelpers.DisplaySetupSummary(setupResults, logger);
+                SetupHelpers.DisplaySetupSummary(setupResults, logger, graphApiService.GraphBaseUrl);
             }
             catch (Agent365Exception ex)
             {
@@ -635,7 +629,7 @@ internal static class AllSubcommand
                 ExceptionHandler.HandleAgent365Exception(ex, logFilePath: logFilePath);
                 setupResults.Errors.Add(ex.Message);
                 logger.LogInformation("");
-                SetupHelpers.DisplaySetupSummary(setupResults, logger);
+                SetupHelpers.DisplaySetupSummary(setupResults, logger, graphApiService.GraphBaseUrl);
                 ExceptionHandler.ExitWithCleanup(1);
             }
             catch (FileNotFoundException fnfEx)
@@ -643,7 +637,7 @@ internal static class AllSubcommand
                 logger.LogError("Setup failed: {Message}", fnfEx.Message);
                 setupResults.Errors.Add(fnfEx.Message);
                 logger.LogInformation("");
-                SetupHelpers.DisplaySetupSummary(setupResults, logger);
+                SetupHelpers.DisplaySetupSummary(setupResults, logger, graphApiService.GraphBaseUrl);
                 ExceptionHandler.ExitWithCleanup(1);
             }
             catch (OperationCanceledException)
@@ -657,7 +651,7 @@ internal static class AllSubcommand
                 logger.LogError(ex, "Setup failed: {Message}", ex.Message);
                 setupResults.Errors.Add(ex.Message);
                 logger.LogInformation("");
-                SetupHelpers.DisplaySetupSummary(setupResults, logger);
+                SetupHelpers.DisplaySetupSummary(setupResults, logger, graphApiService.GraphBaseUrl);
                 throw;
             }
         });

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AzRestConsentRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AzRestConsentRunner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
@@ -65,7 +66,8 @@ internal static partial class AzRestConsentRunner
         string blueprintSpObjectId,
         IReadOnlyList<ResourcePermissionSpec> specs,
         ILogger logger,
-        CancellationToken ct)
+        CancellationToken ct,
+        string graphBaseUrl = GraphApiConstants.BaseUrl)
     {
         if (!GuidPattern().IsMatch(blueprintSpObjectId))
         {
@@ -99,6 +101,10 @@ internal static partial class AzRestConsentRunner
             }
         }
 
+        // Resolve the Graph base URL once so every az rest call targets the configured
+        // (sovereign / commercial) cloud endpoint rather than a hardcoded commercial host.
+        var baseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+
         logger.LogInformation("Granting delegated admin consent...");
 
         var allOk = true;
@@ -107,7 +113,7 @@ internal static partial class AzRestConsentRunner
             ct.ThrowIfCancellationRequested();
             try
             {
-                var ok = await GrantOneAsync(executor, blueprintSpObjectId, spec, logger, ct);
+                var ok = await GrantOneAsync(executor, blueprintSpObjectId, spec, baseUrl, logger, ct);
                 if (!ok) allOk = false;
             }
             catch (OperationCanceledException)
@@ -132,13 +138,14 @@ internal static partial class AzRestConsentRunner
         CommandExecutor executor,
         string blueprintSpObjectId,
         ResourcePermissionSpec spec,
+        string graphBaseUrl,
         ILogger logger,
         CancellationToken ct)
     {
         // 1. Resolve the resource SP object id.
         var resourceSpResult = await executor.ExecuteAsync(
             "az",
-            $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals?$filter=appId eq '{spec.ResourceAppId}'&$select=id\"",
+            $"rest --method GET --url \"{graphBaseUrl}/v1.0/servicePrincipals?$filter=appId eq '{spec.ResourceAppId}'&$select=id\"",
             captureOutput: true,
             suppressErrorLogging: true,
             cancellationToken: ct);
@@ -166,7 +173,7 @@ internal static partial class AzRestConsentRunner
         //    un-created. Filter on consentType to be precise.
         var grantQueryResult = await executor.ExecuteAsync(
             "az",
-            $"rest --method GET --url \"https://graph.microsoft.com/v1.0/oauth2PermissionGrants?$filter=clientId eq '{blueprintSpObjectId}' and resourceId eq '{resourceSpId}' and consentType eq 'AllPrincipals'\"",
+            $"rest --method GET --url \"{graphBaseUrl}/v1.0/oauth2PermissionGrants?$filter=clientId eq '{blueprintSpObjectId}' and resourceId eq '{resourceSpId}' and consentType eq 'AllPrincipals'\"",
             captureOutput: true,
             suppressErrorLogging: true,
             cancellationToken: ct);
@@ -200,7 +207,7 @@ internal static partial class AzRestConsentRunner
             var patched = await ExecuteAzRestWithBodyAsync(
                 executor,
                 method: "PATCH",
-                url: $"https://graph.microsoft.com/v1.0/oauth2PermissionGrants/{existingGrantId}",
+                url: $"{graphBaseUrl}/v1.0/oauth2PermissionGrants/{existingGrantId}",
                 bodyJson: patchBody,
                 logger: logger,
                 ct: ct);
@@ -224,7 +231,7 @@ internal static partial class AzRestConsentRunner
         var created = await ExecuteAzRestWithBodyAsync(
             executor,
             method: "POST",
-            url: "https://graph.microsoft.com/v1.0/oauth2PermissionGrants",
+            url: $"{graphBaseUrl}/v1.0/oauth2PermissionGrants",
             bodyJson: createBody,
             logger: logger,
             ct: ct);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AzRestS2SRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AzRestS2SRunner.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using System.Text.Json;
@@ -52,7 +53,8 @@ internal static partial class AzRestS2SRunner
         string blueprintSpObjectId,
         IReadOnlyList<ResourcePermissionSpec> specs,
         ILogger logger,
-        CancellationToken ct)
+        CancellationToken ct,
+        string graphBaseUrl = GraphApiConstants.BaseUrl)
     {
         if (!GuidPattern().IsMatch(blueprintSpObjectId))
         {
@@ -85,13 +87,17 @@ internal static partial class AzRestS2SRunner
             }
         }
 
+        // Resolve the Graph base URL once so every az rest call targets the configured
+        // (sovereign / commercial) cloud endpoint rather than a hardcoded commercial host.
+        var baseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+
         logger.LogInformation("Assigning S2S app roles...");
 
         var allOk = true;
 
         // Fetch the existing assignment list once at the top — every per-role idempotency
         // check then compares against this in-memory set, avoiding N+1 Graph round-trips.
-        var existingAssignments = await GetExistingAssignmentsAsync(executor, blueprintSpObjectId, logger, ct);
+        var existingAssignments = await GetExistingAssignmentsAsync(executor, blueprintSpObjectId, baseUrl, logger, ct);
         if (existingAssignments is null)
         {
             // The GET itself failed; that's a hard stop because we can't reason about
@@ -104,7 +110,7 @@ internal static partial class AzRestS2SRunner
             ct.ThrowIfCancellationRequested();
             try
             {
-                var ok = await AssignOneAsync(executor, blueprintSpObjectId, spec, existingAssignments, logger, ct);
+                var ok = await AssignOneAsync(executor, blueprintSpObjectId, spec, existingAssignments, baseUrl, logger, ct);
                 if (!ok) allOk = false;
             }
             catch (OperationCanceledException)
@@ -132,12 +138,13 @@ internal static partial class AzRestS2SRunner
         string blueprintSpObjectId,
         ResourcePermissionSpec spec,
         HashSet<(string ResourceId, string AppRoleId)> existingAssignments,
+        string graphBaseUrl,
         ILogger logger,
         CancellationToken ct)
     {
         var spResult = await executor.ExecuteAsync(
             "az",
-            $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals?$filter=appId eq '{spec.ResourceAppId}'&$select=id,appRoles\"",
+            $"rest --method GET --url \"{graphBaseUrl}/v1.0/servicePrincipals?$filter=appId eq '{spec.ResourceAppId}'&$select=id,appRoles\"",
             captureOutput: true,
             suppressErrorLogging: true,
             cancellationToken: ct);
@@ -182,7 +189,7 @@ internal static partial class AzRestS2SRunner
             var created = await ExecuteAzRestWithBodyAsync(
                 executor,
                 method: "POST",
-                url: $"https://graph.microsoft.com/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments",
+                url: $"{graphBaseUrl}/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments",
                 bodyJson: createBody,
                 logger: logger,
                 ct: ct);
@@ -212,12 +219,13 @@ internal static partial class AzRestS2SRunner
     private static async Task<HashSet<(string, string)>?> GetExistingAssignmentsAsync(
         CommandExecutor executor,
         string blueprintSpObjectId,
+        string graphBaseUrl,
         ILogger logger,
         CancellationToken ct)
     {
         var result = await executor.ExecuteAsync(
             "az",
-            $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments\"",
+            $"rest --method GET --url \"{graphBaseUrl}/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments\"",
             captureOutput: true,
             suppressErrorLogging: true,
             cancellationToken: ct);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
@@ -87,6 +87,13 @@ internal static class BatchPermissionsOrchestrator
         // Filter out specs with no scopes — they would produce empty OAuth2 grants (HTTP 400).
         // This can happen when the MCP manifest is missing or contains no required scopes.
         var effectiveSpecs = specs.Where(s => s.Scopes.Length > 0).ToList();
+        if (setupResults is not null)
+        {
+            setupResults.ObservabilityResourceAppId = effectiveSpecs
+                .FirstOrDefault(spec => ConfigConstants.IsObservabilityApiAppId(spec.ResourceAppId))
+                ?.ResourceAppId;
+        }
+
         if (effectiveSpecs.Count < specs.Count)
         {
             var skipped = specs.Count - effectiveSpecs.Count;
@@ -920,11 +927,23 @@ internal static class BatchPermissionsOrchestrator
     /// Updates config.ResourceConsents in-memory for each spec based on phase results.
     /// The caller is responsible for persisting the config via configService.SaveStateAsync.
     /// </summary>
-    private static void UpdateResourceConsents(
+    internal static void UpdateResourceConsents(
         Agent365Config config,
         IReadOnlyList<ResourcePermissionSpec> specs,
         Dictionary<string, (bool configured, bool alreadyExisted)> inheritedResults)
     {
+        var configuredObservabilityAppIds = specs
+            .Where(spec => ConfigConstants.IsObservabilityApiAppId(spec.ResourceAppId))
+            .Select(spec => spec.ResourceAppId)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        if (configuredObservabilityAppIds.Count > 0)
+        {
+            config.ResourceConsents.RemoveAll(resourceConsent =>
+                ConfigConstants.IsObservabilityApiAppId(resourceConsent.ResourceAppId) &&
+                !configuredObservabilityAppIds.Contains(resourceConsent.ResourceAppId));
+        }
+
         foreach (var spec in specs)
         {
             inheritedResults.TryGetValue(spec.ResourceAppId, out var inherited);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BatchPermissionsOrchestrator.cs
@@ -238,7 +238,7 @@ internal static class BatchPermissionsOrchestrator
                             {
                                 logger.LogDebug("S2S app role assignments could not be completed via the Graph API; falling back to az rest.");
                                 var (attempted, succeeded) = await AzRestS2SRunner.TryRunAsync(
-                                    commandExecutor, phase1Result.BlueprintSpObjectId, specs, logger, ct);
+                                    commandExecutor, phase1Result.BlueprintSpObjectId, specs, logger, ct, graph.GraphBaseUrl);
                                 if (attempted && succeeded)
                                 {
                                     logger.LogInformation("Application permissions granted.");
@@ -472,8 +472,12 @@ internal static class BatchPermissionsOrchestrator
     /// emit identical scope identifiers (e.g. <c>https://agent365.svc.cloud.microsoft/Tools.Execute</c>,
     /// not <c>api://{appId}/Tools.Execute</c>).
     /// </summary>
-    private static string BuildFullyQualifiedScope(string resourceAppId, string scope, bool isMcpAudience = false)
-        => SetupHelpers.BuildFullyQualifiedScope(resourceAppId, scope, isMcpAudience);
+    private static string BuildFullyQualifiedScope(
+        string resourceAppId, string scope, bool isMcpAudience = false,
+        string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
+        string? sharedMcpResourceAppId = null)
+        => SetupHelpers.BuildFullyQualifiedScope(
+            resourceAppId, scope, isMcpAudience, graphResourceUri, sharedMcpResourceAppId);
 
     /// <summary>
     /// Grants S2S app role assignments for all specs that carry <see cref="ResourcePermissionSpec.AppRoleScopes"/>.
@@ -656,16 +660,19 @@ internal static class BatchPermissionsOrchestrator
             ? specs.Where(s => resolvedSpAppIds.Contains(s.ResourceAppId)).ToList()
             : specs.ToList();
 
+        var sharedMcpResourceAppId = ConfigConstants.GetAgent365ToolsResourceAppId(config.Environment);
         var allScopes = specsForUrl
             .Where(s => s.Scopes is { Length: > 0 })
             .SelectMany(s => s.Scopes.Select(scope => BuildFullyQualifiedScope(
                 s.ResourceAppId, scope,
-                isMcpAudience: knownMcpAudienceAppIds?.Contains(s.ResourceAppId) ?? false)))
+                isMcpAudience: knownMcpAudienceAppIds?.Contains(s.ResourceAppId) ?? false,
+                graphResourceUri: graph.GraphBaseUrl,
+                sharedMcpResourceAppId: sharedMcpResourceAppId)))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         string? consentUrl = allScopes.Count > 0
-            ? SetupHelpers.BuildAdminConsentUrl(tenantId, blueprintAppId, allScopes)
+            ? SetupHelpers.BuildAdminConsentUrl(tenantId, blueprintAppId, allScopes, graph.AuthorityHost)
             : null;
 
         // No delegated scopes to consent at all — nothing to do. The caller still surfaces
@@ -728,7 +735,8 @@ internal static class BatchPermissionsOrchestrator
                             ct,
                             consentType: "AllPrincipals",
                             blueprintSpObjectId: phase1Result.BlueprintSpObjectId,
-                            resourceSpObjectId: resourceSpId);
+                            resourceSpObjectId: resourceSpId,
+                            graphBaseUrl: graph.GraphBaseUrl);
                     }
                     else
                     {
@@ -802,7 +810,8 @@ internal static class BatchPermissionsOrchestrator
                 // longer holds since PR #409 removed that scope from the CLI client app registration.
                 var found = await AdminConsentHelper.PollAdminConsentAsync(
                     commandExecutor, logger, blueprintAppId,
-                    "All permissions", timeoutSeconds: 180, intervalSeconds: 5, ct);
+                    "All permissions", timeoutSeconds: 180, intervalSeconds: 5, ct,
+                    graphBaseUrl: graph.GraphBaseUrl);
                 consentVerified = found;
                 // Browser was opened regardless — either the grant was directly observed (Verified)
                 // or the timeout elapsed without observing it (AssumedComplete). Either way, setup
@@ -877,7 +886,7 @@ internal static class BatchPermissionsOrchestrator
             else
             {
                 var (attempted, succeeded) = await AzRestConsentRunner.TryRunAsync(
-                    commandExecutor, p.BlueprintSpObjectId, originalSpecs, logger, ct);
+                    commandExecutor, p.BlueprintSpObjectId, originalSpecs, logger, ct, graph.GraphBaseUrl);
                 if (attempted && succeeded)
                 {
                     logger.LogInformation("Delegated admin consent granted.");
@@ -1054,7 +1063,7 @@ internal static class BatchPermissionsOrchestrator
                 "{Count} resource(s) require service principal provisioning. Auto-provisioning is disabled; steps will be listed in the setup summary.",
                 stillMissing.Count);
             foreach (var spec in stillMissing)
-                RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds);
+                RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds, graph.AuthorityHost);
             return;
         }
 
@@ -1102,7 +1111,7 @@ internal static class BatchPermissionsOrchestrator
                     logger.LogWarning(
                         "{Idx}. {Name} ({AppId}): skipping — resource app id is not a valid GUID.",
                         i + 1, spec.ResourceName, spec.ResourceAppId);
-                    RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds);
+                    RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds, graph.AuthorityHost);
                     continue;
                 }
 
@@ -1120,7 +1129,7 @@ internal static class BatchPermissionsOrchestrator
                     if (!shouldProvision)
                     {
                         logger.LogInformation("Skipped.");
-                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds);
+                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds, graph.AuthorityHost);
                         continue;
                     }
 
@@ -1136,7 +1145,7 @@ internal static class BatchPermissionsOrchestrator
                     {
                         var stderr = string.IsNullOrWhiteSpace(azResult.StandardError) ? azResult.StandardOutput : azResult.StandardError;
                         logger.LogWarning("Failed: {Error}", (stderr ?? string.Empty).Trim());
-                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds);
+                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds, graph.AuthorityHost);
                         continue;
                     }
 
@@ -1159,7 +1168,7 @@ internal static class BatchPermissionsOrchestrator
                         logger.LogWarning(
                             "az exited 0 but the output did not contain a service principal id. Output: {Output}",
                             (azResult.StandardOutput ?? string.Empty).Trim());
-                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds);
+                        RecordMissingSpAction(spec, tenantId, blueprintAppId, logger, setupResults, knownMcpAudienceAppIds, graph.AuthorityHost);
                     }
                 }
             }
@@ -1238,7 +1247,8 @@ internal static class BatchPermissionsOrchestrator
         string blueprintAppId,
         ILogger logger,
         SetupResults? setupResults,
-        IReadOnlyCollection<string>? knownMcpAudienceAppIds = null)
+        IReadOnlyCollection<string>? knownMcpAudienceAppIds = null,
+        string? authorityHost = null)
     {
         _ = logger; // intentionally unused — caller already emits a one-line inline marker
                     // ("Skipped." / "Failed: <error>" / "...invalid GUID...") immediately
@@ -1248,7 +1258,7 @@ internal static class BatchPermissionsOrchestrator
 
         var azCommand = BuildAzAdSpCreateCommand(spec.ResourceAppId);
         var isMcpAudience = knownMcpAudienceAppIds?.Contains(spec.ResourceAppId) ?? false;
-        var perSpConsentUrl = BuildPerSpBlueprintConsentUrl(tenantId, blueprintAppId, spec, isMcpAudience);
+        var perSpConsentUrl = BuildPerSpBlueprintConsentUrl(tenantId, blueprintAppId, spec, isMcpAudience, authorityHost);
 
         setupResults?.MissingSpActions.Add(new MissingSpAction(
             ResourceName: spec.ResourceName,
@@ -1270,14 +1280,16 @@ internal static class BatchPermissionsOrchestrator
         string tenantId,
         string blueprintAppId,
         ResourcePermissionSpec spec,
-        bool isMcpAudience = false)
+        bool isMcpAudience = false,
+        string? authorityHost = null)
     {
         var scopes = spec.Scopes ?? Array.Empty<string>();
         var fullyQualified = scopes
             .Select(s => $"{GetResourceUriForBlueprintConsent(spec.ResourceAppId, isMcpAudience)}/{s}");
         var scopeParam = string.Join("%20", fullyQualified.Select(Uri.EscapeDataString));
         var redirectEncoded = Uri.EscapeDataString(AuthenticationConstants.BlueprintConsentRedirectUri);
-        return $"https://login.microsoftonline.com/{tenantId}/v2.0/adminconsent" +
+        var consentBaseUrl = ConfigConstants.BuildAdminConsentEndpointUrl(authorityHost, tenantId);
+        return consentBaseUrl +
                $"?client_id={blueprintAppId}" +
                $"&scope={scopeParam}" +
                $"&redirect_uri={redirectEncoded}" +

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -638,6 +638,8 @@ internal static class BlueprintSubcommand
         logger.LogDebug("Blueprint created: {Name} (Object ID: {ObjectId}, App ID: {AppId})",
             setupConfig.AgentBlueprintDisplayName, blueprintObjectId, blueprintAppId);
 
+        RestoreExistingBlueprintSecret(setupConfig, generatedConfig, blueprintAppId, logger);
+
         // Update generated config with blueprint details, preserving all existing fields
         generatedConfig["agentBlueprintId"] = blueprintAppId;
         generatedConfig["agentBlueprintObjectId"] = blueprintObjectId;
@@ -787,6 +789,48 @@ internal static class BlueprintSubcommand
             FederatedCredentialError = blueprintResult.ficError,
             AdminConsentUrl = blueprintResult.adminConsentUrl
         };
+    }
+
+    internal static void RestoreExistingBlueprintSecret(
+        Agent365Config setupConfig,
+        JsonObject generatedConfig,
+        string? resolvedBlueprintId,
+        ILogger logger)
+    {
+        if (!string.IsNullOrWhiteSpace(setupConfig.AgentBlueprintClientSecret) ||
+            string.IsNullOrWhiteSpace(resolvedBlueprintId))
+        {
+            return;
+        }
+
+        var storedBlueprintId = generatedConfig["agentBlueprintId"] is JsonValue blueprintIdNode &&
+            blueprintIdNode.TryGetValue<string>(out var blueprintId)
+                ? blueprintId
+                : null;
+
+        if (!string.Equals(storedBlueprintId, resolvedBlueprintId, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug(
+                "Stored blueprint ID does not match the resolved blueprint; the stored client secret will not be reused.");
+            return;
+        }
+
+        var storedSecret = generatedConfig["agentBlueprintClientSecret"] is JsonValue secretNode &&
+            secretNode.TryGetValue<string>(out var secret)
+                ? secret
+                : null;
+
+        if (string.IsNullOrWhiteSpace(storedSecret))
+        {
+            return;
+        }
+
+        setupConfig.AgentBlueprintClientSecret = storedSecret;
+        setupConfig.AgentBlueprintClientSecretProtected =
+            generatedConfig["agentBlueprintClientSecretProtected"] is JsonValue protectedNode &&
+            protectedNode.TryGetValue<bool>(out var isProtected) &&
+            isProtected;
+        logger.LogDebug("Loaded the existing blueprint client secret from generated configuration.");
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -942,7 +942,11 @@ internal static class BlueprintSubcommand
         if (!string.IsNullOrWhiteSpace(displayName))
         {
             logger.LogDebug("Searching for existing blueprint by display name: {DisplayName}...", displayName);
-            var lookupResult = await blueprintLookupService.GetApplicationByDisplayNameAsync(tenantId, displayName, cancellationToken: ct);
+            var lookupResult = await blueprintLookupService.GetApplicationByDisplayNameAsync(
+                tenantId,
+                displayName,
+                preferredObjectId: setupConfig.AgentBlueprintObjectId,
+                cancellationToken: ct);
 
             if (lookupResult.Found)
             {
@@ -957,6 +961,17 @@ internal static class BlueprintSubcommand
                 existingAppId = lookupResult.AppId;
                 blueprintAlreadyExists = true;
                 requiresPersistence = lookupResult.RequiresPersistence;
+            }
+            else if (!string.IsNullOrWhiteSpace(lookupResult.ErrorMessage))
+            {
+                throw new SetupValidationException(
+                    "Could not determine whether the blueprint already exists.",
+                    errorDetails: [lookupResult.ErrorMessage],
+                    mitigationSteps:
+                    [
+                        "Confirm the CLI application has Microsoft Graph Application.Read.All consent.",
+                        "Sign in again, then retry setup."
+                    ]);
             }
         }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -111,7 +111,6 @@ internal static class BlueprintSubcommand
     }
     private const int ClientSecretValidationRetryDelayMs = 1000;
     private const int ClientSecretValidationTimeoutSeconds = 10;
-    private const string MicrosoftLoginOAuthTokenEndpoint = "https://login.microsoftonline.com/{0}/oauth2/v2.0/token";
 
     public static Command CreateCommand(
         ILogger logger,
@@ -354,14 +353,7 @@ internal static class BlueprintSubcommand
 
             // Configure GraphApiService with custom client app ID if available
             // This ensures inheritable permissions operations use the validated custom app
-            if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-            {
-                graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-            }
-
-            // Wire the sovereign/government cloud base URL from config so all Graph calls
-            // target the correct national cloud endpoint (commercial by default).
-            graphApiService.GraphBaseUrl = setupConfig.GraphBaseUrl;
+            graphApiService.ConfigureCloudEndpoints(setupConfig);
 
             // Handle --update-endpoint flag (--m365 is inferred for endpoint operations).
             if (!string.IsNullOrWhiteSpace(updateEndpoint))
@@ -560,13 +552,12 @@ internal static class BlueprintSubcommand
         // Create required services.
         // Pass the caller's logger so consent messages appear in the correct indent scope.
         var cleanLoggerFactory = LoggerFactoryHelper.CreateCleanLoggerFactory();
+        var delegatedGraphService = new GraphApiService(
+            cleanLoggerFactory.CreateLogger<GraphApiService>(), executor,
+            new AuthenticationService(cleanLoggerFactory.CreateLogger<AuthenticationService>()));
+        delegatedGraphService.ConfigureCloudEndpoints(setupConfig);
         var delegatedConsentService = new DelegatedConsentService(
-            logger,
-            new GraphApiService(
-                cleanLoggerFactory.CreateLogger<GraphApiService>(),
-                executor,
-                new AuthenticationService(cleanLoggerFactory.CreateLogger<AuthenticationService>()),
-                graphBaseUrl: setupConfig.GraphBaseUrl));
+            logger, delegatedGraphService);
 
         // Use DI-provided GraphApiService which already has MicrosoftGraphTokenProvider configured
         var graphService = graphApiService;
@@ -681,6 +672,7 @@ internal static class BlueprintSubcommand
                 setupConfig.AgentBlueprintClientSecret,
                 setupConfig.AgentBlueprintClientSecretProtected,
                 setupConfig.TenantId!,
+                graphService,
                 logger,
                 cancellationToken);
 
@@ -776,7 +768,7 @@ internal static class BlueprintSubcommand
                 GraphInheritablePermissionsError = blueprintResult.graphInheritablePermissionsError,
                 FederatedCredentialError = blueprintResult.ficError,
             };
-            SetupHelpers.DisplaySetupSummary(summary, logger);
+            SetupHelpers.DisplaySetupSummary(summary, logger, graphApiService.GraphBaseUrl);
         }
 
         return new BlueprintCreationResult
@@ -953,7 +945,8 @@ internal static class BlueprintSubcommand
                 {
                     using var spHttpClient = Services.Internal.HttpClientFactory.CreateAuthenticatedClient(spToken);
                     var spRetryHelper = new Services.Helpers.RetryHelper(logger);
-                    existingServicePrincipalId = await CreateServicePrincipalAsync(existingAppId, spHttpClient, spRetryHelper, logger, ct);
+                    existingServicePrincipalId = await CreateServicePrincipalAsync(
+                        existingAppId, spHttpClient, spRetryHelper, logger, graphApiService.GraphBaseUrl, ct);
                     if (!string.IsNullOrWhiteSpace(existingServicePrincipalId))
                     {
                         requiresPersistence = true;
@@ -976,7 +969,7 @@ internal static class BlueprintSubcommand
                             {
                                 if (spAuthDenied) return true;
                                 using var checkResp = await spHttpClient.GetAsync(
-                                    $"{Constants.GraphApiConstants.BaseUrl}/v1.0/oauth2PermissionGrants?$filter=clientId eq '{existingServicePrincipalId}'", token);
+                                    $"{graphApiService.GraphBaseUrl}/v1.0/oauth2PermissionGrants?$filter=clientId eq '{existingServicePrincipalId}'", token);
                                 if (checkResp.StatusCode == System.Net.HttpStatusCode.Forbidden)
                                 {
                                     spAuthDenied = true;
@@ -1090,7 +1083,7 @@ internal static class BlueprintSubcommand
                 {
                     sponsorUserId = me.Id;
                     logger.LogInformation("Current user: {DisplayName} <{UPN}>", me.DisplayName, me.UserPrincipalName);
-                    logger.LogDebug("Sponsor: {BaseUrl}/v1.0/users/{UserId}", Constants.GraphApiConstants.BaseUrl, sponsorUserId);
+                    logger.LogDebug("Sponsor: {BaseUrl}/v1.0/users/{UserId}", graphApiService.GraphBaseUrl, sponsorUserId);
                 }
             }
             catch (Exception ex)
@@ -1114,11 +1107,11 @@ internal static class BlueprintSubcommand
             {
                 appManifest["sponsors@odata.bind"] = new JsonArray
                 {
-                    $"{Constants.GraphApiConstants.BaseUrl}/v1.0/users/{sponsorUserId}"
+                    $"{graphApiService.GraphBaseUrl}/v1.0/users/{sponsorUserId}"
                 };
                 appManifest["owners@odata.bind"] = new JsonArray
                 {
-                    $"{Constants.GraphApiConstants.BaseUrl}/v1.0/users/{sponsorUserId}"
+                    $"{graphApiService.GraphBaseUrl}/v1.0/users/{sponsorUserId}"
                 };
             }
 
@@ -1134,7 +1127,9 @@ internal static class BlueprintSubcommand
             logger.LogDebug("Acquiring blueprint httpClient token — scope: AgentIdentityBlueprintPrincipal.Create, loginHint: {LoginHint}", blueprintLoginHint ?? "(none)");
             var graphToken = await AcquireMsalGraphTokenAsync(tenantId, setupConfig.ClientAppId, logger, ct,
                 scope: AuthenticationConstants.AgentIdentityBlueprintPrincipalCreateScope,
-                loginHint: blueprintLoginHint);
+                loginHint: blueprintLoginHint,
+                graphBaseUrl: graphApiService.GraphBaseUrl,
+                authorityHost: graphApiService.AuthorityHost);
             if (string.IsNullOrEmpty(graphToken))
             {
                 logger.LogError("Failed to extract access token from Graph client");
@@ -1146,7 +1141,7 @@ internal static class BlueprintSubcommand
             httpClient.DefaultRequestHeaders.Add("ConsistencyLevel", "eventual");
             httpClient.DefaultRequestHeaders.Add("OData-Version", "4.0"); // Required for @odata.type
 
-            var createAppUrl = $"{Constants.GraphApiConstants.BaseUrl}/beta/applications";
+            var createAppUrl = $"{graphApiService.GraphBaseUrl}/beta/applications";
 
             logger.LogInformation("Display Name: {DisplayName}", displayName);
             if (!string.IsNullOrEmpty(sponsorUserId))
@@ -1239,7 +1234,7 @@ internal static class BlueprintSubcommand
             var appAvailable = await retryHelper.ExecuteWithRetryAsync(
                 async ct =>
                 {
-                    var checkResp = await httpClient.GetAsync($"{Constants.GraphApiConstants.BaseUrl}/v1.0/applications/{objectId}", ct);
+                    var checkResp = await httpClient.GetAsync($"{graphApiService.GraphBaseUrl}/v1.0/applications/{objectId}", ct);
                     return checkResp.IsSuccessStatusCode;
                 },
                 result => !result,
@@ -1258,7 +1253,7 @@ internal static class BlueprintSubcommand
             // Update application with identifier URI and expose the access_agent_as_user scope
             // so callers can acquire tokens scoped to this blueprint via the OBO flow.
             var identifierUri = $"api://{appId}";
-            var patchAppUrl = $"{Constants.GraphApiConstants.BaseUrl}/v1.0/applications/{objectId}";
+            var patchAppUrl = $"{graphApiService.GraphBaseUrl}/v1.0/applications/{objectId}";
             var patchBody = new JsonObject
             {
                 ["identifierUris"] = new JsonArray { identifierUri },
@@ -1354,7 +1349,8 @@ internal static class BlueprintSubcommand
             // objectId. Retry with backoff until the appId index is replicated.
             logger.LogInformation("");
             logger.LogInformation("Creating blueprint service principal...");
-            string? servicePrincipalId = await CreateServicePrincipalAsync(appId, httpClient, retryHelper, logger, ct);
+            string? servicePrincipalId = await CreateServicePrincipalAsync(
+                appId, httpClient, retryHelper, logger, graphApiService.GraphBaseUrl, ct);
             if (string.IsNullOrWhiteSpace(servicePrincipalId))
             {
                 logger.LogError("Service principal creation failed after retries");
@@ -1465,9 +1461,10 @@ internal static class BlueprintSubcommand
         HttpClient httpClient,
         Services.Helpers.RetryHelper retryHelper,
         ILogger logger,
+        string graphBaseUrl,
         CancellationToken ct)
     {
-        var createSpUrl = $"{Constants.GraphApiConstants.BaseUrl}/v1.0/serviceprincipals/graph.agentIdentityBlueprintPrincipal";
+        var createSpUrl = $"{graphBaseUrl}/v1.0/serviceprincipals/graph.agentIdentityBlueprintPrincipal";
         var spManifestJson = new JsonObject { ["appId"] = appId }.ToJsonString();
         int forbiddenRetries = 0;
         const int maxForbiddenRetries = 3;
@@ -1598,7 +1595,7 @@ internal static class BlueprintSubcommand
                 {
                     var ownerPayload = new Dictionary<string, string>
                     {
-                        ["@odata.id"] = $"{Constants.GraphApiConstants.BaseUrl}/v1.0/users/{currentUserObjectId}"
+                        ["@odata.id"] = $"{graphApiService.GraphBaseUrl}/v1.0/users/{currentUserObjectId}"
                     };
 
                     var ownerResponse = await graphApiService.GraphPostWithResponseAsync(
@@ -1665,7 +1662,7 @@ internal static class BlueprintSubcommand
                         tenantId,
                         objectId,
                         credentialName,
-                        $"https://login.microsoftonline.com/{tenantId}/v2.0",
+                        $"{graphApiService.AuthorityHost}/{tenantId}/v2.0",
                         managedIdentityPrincipalId,
                         new List<string> { "api://AzureADTokenExchange" },
                         ct);
@@ -1907,7 +1904,8 @@ internal static class BlueprintSubcommand
         // Build the reference/handoff URL up front so it is available even if the orchestrator throws.
         var consentUrlGraph = SetupHelpers.BuildAdminConsentUrl(
             tenantId, appId,
-            applicationScopes.Select(s => $"{AuthenticationConstants.MicrosoftGraphResourceUri}/{s}"));
+            applicationScopes.Select(s => $"{graphApiService.GraphBaseUrl}/{s}"),
+            graphApiService.AuthorityHost);
 
         bool consentSuccess;
         bool inheritedConfigured;
@@ -1964,7 +1962,10 @@ internal static class BlueprintSubcommand
     /// rejected by the Agent Blueprint API. Defaults to .default (all consented permissions).
     /// Pass loginHint so WAM targets the az-logged-in user rather than the OS default account.
     /// </summary>
-    private static async Task<string?> AcquireMsalGraphTokenAsync(string tenantId, string clientAppId, ILogger logger, CancellationToken ct = default, string? scope = null, string? loginHint = null, string[]? additionalScopes = null)
+    private static async Task<string?> AcquireMsalGraphTokenAsync(
+        string tenantId, string clientAppId, ILogger logger, CancellationToken ct = default,
+        string? scope = null, string? loginHint = null, string[]? additionalScopes = null,
+        string? graphBaseUrl = null, string? authorityHost = null)
     {
         // Guard: MSAL will fail (and block for ~30s on WAM) with empty credentials.
         if (string.IsNullOrWhiteSpace(clientAppId) || string.IsNullOrWhiteSpace(tenantId))
@@ -1975,19 +1976,22 @@ internal static class BlueprintSubcommand
 
         try
         {
+            var resolvedGraphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+            var resolvedAuthorityHost = ConfigConstants.NormalizeAuthorityHost(authorityHost);
             var credential = new MsalBrowserCredential(
                 clientAppId,
                 tenantId,
                 redirectUri: null,  // Let MsalBrowserCredential use WAM on Windows
                 logger,
+                authority: $"{resolvedAuthorityHost}/{tenantId}",
                 loginHint: loginHint);
 
             var primaryScope = string.IsNullOrWhiteSpace(scope)
-                ? $"{Constants.GraphApiConstants.BaseUrl}/.default"
-                : $"{Constants.GraphApiConstants.BaseUrl}/{scope}";
+                ? $"{resolvedGraphBaseUrl}/.default"
+                : $"{resolvedGraphBaseUrl}/{scope}";
 
             var allScopes = additionalScopes?.Length > 0
-                ? new[] { primaryScope }.Concat(additionalScopes.Select(s => $"{Constants.GraphApiConstants.BaseUrl}/{s}")).ToArray()
+                ? new[] { primaryScope }.Concat(additionalScopes.Select(s => $"{resolvedGraphBaseUrl}/{s}")).ToArray()
                 : new[] { primaryScope };
 
             var tokenRequestContext = new TokenRequestContext(allScopes);
@@ -2039,7 +2043,9 @@ internal static class BlueprintSubcommand
         // Pass the caller's logger so messages appear in the correct indent scope.
         var interactiveAuth = new InteractiveGraphAuthService(
             logger,
-            setupConfig.ClientAppId);
+            setupConfig.ClientAppId,
+            graphBaseUrl: ConfigConstants.GetGraphBaseUrl(setupConfig.Environment, setupConfig.GraphBaseUrl),
+            authorityHost: ConfigConstants.GetAuthorityHost(setupConfig.Environment, setupConfig.AuthorityHost));
 
         try
         {
@@ -2103,7 +2109,9 @@ internal static class BlueprintSubcommand
                 setupConfig.ClientAppId ?? string.Empty,
                 logger, ct,
                 scope: AuthenticationConstants.AgentIdentityBlueprintReadWriteAllScope,
-                loginHint: loginHint);
+                loginHint: loginHint,
+                graphBaseUrl: graphService.GraphBaseUrl,
+                authorityHost: graphService.AuthorityHost);
 
             if (string.IsNullOrWhiteSpace(graphToken))
             {
@@ -2122,7 +2130,7 @@ internal static class BlueprintSubcommand
                 }
             };
 
-            var addPasswordUrl = $"{Constants.GraphApiConstants.BaseUrl}/v1.0/applications/{blueprintObjectId}/addPassword";
+            var addPasswordUrl = $"{graphService.GraphBaseUrl}/v1.0/applications/{blueprintObjectId}/addPassword";
             var secretBodyJson = secretBody.ToJsonString();
 
             // Retry on 404 (blueprint not yet visible on all replicas) and transient 403 (owner
@@ -2232,6 +2240,7 @@ internal static class BlueprintSubcommand
         string clientSecret,
         bool isProtected,
         string tenantId,
+        GraphApiService graphService,
         ILogger logger,
         CancellationToken ct = default)
     {
@@ -2245,7 +2254,7 @@ internal static class BlueprintSubcommand
         using var httpClient = new HttpClient();
         httpClient.Timeout = TimeSpan.FromSeconds(ClientSecretValidationTimeoutSeconds);
 
-        var tokenUrl = string.Format(MicrosoftLoginOAuthTokenEndpoint, tenantId);
+        var tokenUrl = ConfigConstants.BuildTokenEndpointUrl(graphService.AuthorityHost, tenantId);
 
         for (int attempt = 1; attempt <= ClientSecretValidationMaxRetries; attempt++)
         {
@@ -2255,7 +2264,7 @@ internal static class BlueprintSubcommand
                 {
                     ["client_id"] = clientId,
                     ["client_secret"] = plaintextSecret,
-                    ["scope"] = $"{Constants.GraphApiConstants.BaseUrl}/.default",
+                    ["scope"] = $"{graphService.GraphBaseUrl}/.default",
                     ["grant_type"] = "client_credentials"
                 });
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/CopilotStudioSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/CopilotStudioSubcommand.cs
@@ -99,10 +99,7 @@ internal static class CopilotStudioSubcommand
             }
 
             // Configure GraphApiService with custom client app ID if available
-            if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-            {
-                graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-            }
+            graphApiService.ConfigureCloudEndpoints(setupConfig);
 
             // Verify system requirements (PowerShell modules are required for Graph operations).
             // Skipped in dry-run: PowerShellModulesRequirementCheck can auto-install modules,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
@@ -217,7 +217,7 @@ internal static class NonDwBlueprintSetupOrchestrator
         if (roleCheck == Models.RoleCheckResult.DoesNotHaveRole)
         {
             ctx.Logger.LogWarning("Granting tenant-wide consent requires a tenant administrator. Setup will continue and may fail if these permissions are required at runtime.");
-            var url = Exceptions.ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId);
+            var url = Exceptions.ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId, ctx.GraphApiService.AuthorityHost);
             if (!string.IsNullOrWhiteSpace(url))
             {
                 ctx.Logger.LogInformation("Share the following URL with a tenant administrator so they can grant consent:");
@@ -416,7 +416,7 @@ internal static class NonDwBlueprintSetupOrchestrator
         // IsNonDwBlueprintFlow=true was set at the top of this method; DisplaySetupSummary reads that
         // flag directly to pick the non-DW step layout and action-required content.
         ctx.Logger.LogInformation("");
-        SetupHelpers.DisplaySetupSummary(ctx.Results, ctx.Logger);
+        SetupHelpers.DisplaySetupSummary(ctx.Results, ctx.Logger, ctx.GraphApiService.GraphBaseUrl);
 
         return ctx.Results.HasErrors ? 1 : 0;
     }
@@ -739,7 +739,7 @@ internal static class NonDwBlueprintSetupOrchestrator
         // Issue #460: Graph token lacks AppRoleAssignment.ReadWrite.All; retry via az rest (a GA's az token carries it) before PowerShell.
         ctx.Logger.LogDebug("S2S app role assignments on the agent identity could not be completed via the Graph API; falling back to az rest.");
         var (attempted, succeeded) = await AzRestS2SRunner.TryRunAsync(
-            ctx.Executor, agentIdentitySpObjectId, failedSpecs, ctx.Logger, ctx.CancellationToken);
+            ctx.Executor, agentIdentitySpObjectId, failedSpecs, ctx.Logger, ctx.CancellationToken, ctx.GraphApiService.GraphBaseUrl);
         if (attempted && succeeded)
         {
             using (ctx.Logger.Indent())

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
@@ -764,7 +764,11 @@ internal static class PermissionsSubcommand
 
         try
         {
-            var specs = new List<ResourcePermissionSpec>(SetupHelpers.GetFixedApiPermissionSpecs(setInheritable: true, isM365: true));
+            var specs = new List<ResourcePermissionSpec>(
+                SetupHelpers.GetFixedApiPermissionSpecs(
+                    setInheritable: true,
+                    isM365: true,
+                    setupConfig.Environment));
 
             var localResults = setupResults ?? new SetupResults();
             var (_, _, consentGranted, adminConsentUrl) = await BatchPermissionsOrchestrator.ConfigureAllPermissionsAsync(
@@ -838,11 +842,12 @@ internal static class PermissionsSubcommand
     {
         // Resource app IDs owned by standard setup subcommands — never remove these
         var envAtgAppId = ConfigConstants.GetAgent365ToolsResourceAppId(setupConfig.Environment);
+        var observabilityAppId = ConfigConstants.GetObservabilityApiAppId(setupConfig.Environment);
         var protectedIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             envAtgAppId,
             ConfigConstants.MessagingBotApiAppId,
-            ConfigConstants.ObservabilityApiAppId,
+            observabilityAppId,
             PowerPlatformConstants.PowerPlatformApiResourceAppId,
             AuthenticationConstants.MicrosoftGraphResourceAppId,
         };

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/PermissionsSubcommand.cs
@@ -196,11 +196,7 @@ internal static class PermissionsSubcommand
                 return;
             }
 
-            // Configure GraphApiService with custom client app ID if available
-            if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-            {
-                graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-            }
+            graphApiService.ConfigureCloudEndpoints(setupConfig);
 
             // Verify system requirements (PowerShell modules are required for Graph operations).
             // Skipped in dry-run: PowerShellModulesRequirementCheck can auto-install modules,
@@ -329,11 +325,7 @@ internal static class PermissionsSubcommand
                 return;
             }
 
-            // Configure GraphApiService with custom client app ID if available
-            if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-            {
-                graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-            }
+            graphApiService.ConfigureCloudEndpoints(setupConfig);
 
             // Verify system requirements (PowerShell modules are required for Graph operations).
             // Skipped in dry-run: PowerShellModulesRequirementCheck can auto-install modules,
@@ -513,11 +505,7 @@ internal static class PermissionsSubcommand
                 return;
             }
 
-            // Configure GraphApiService with custom client app ID if available
-            if (!string.IsNullOrWhiteSpace(setupConfig.ClientAppId))
-            {
-                graphApiService.CustomClientAppId = setupConfig.ClientAppId;
-            }
+            graphApiService.ConfigureCloudEndpoints(setupConfig);
 
             // Verify system requirements (PowerShell modules are required for Graph operations).
             // Skipped in dry-run: PowerShellModulesRequirementCheck can auto-install modules,
@@ -587,9 +575,12 @@ internal static class PermissionsSubcommand
                         StringComparison.OrdinalIgnoreCase);
                     if (isGraph)
                     {
-                        var fullyQualified = scopes.Select(s => $"{AuthenticationConstants.MicrosoftGraphResourceUri}/{s}");
+                        var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(setupConfig.Environment, setupConfig.GraphBaseUrl);
+                        var graphResourceUri = GraphApiConstants.GetResource(graphBaseUrl).TrimEnd('/');
+                        var authorityHost = ConfigConstants.GetAuthorityHost(setupConfig.Environment, setupConfig.AuthorityHost);
+                        var fullyQualified = scopes.Select(s => $"{graphResourceUri}/{s}");
                         var url = SetupHelpers.BuildAdminConsentUrl(
-                            setupConfig.TenantId, setupConfig.AgentBlueprintId!, fullyQualified);
+                            setupConfig.TenantId, setupConfig.AgentBlueprintId!, fullyQualified, authorityHost);
                         LogAdminConsentNextSteps(logger, url);
                     }
                     else

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
@@ -105,6 +105,7 @@ internal static class RequirementsSubcommand
                         return;
                     }
 
+                    graphApiService.ConfigureCloudEndpoints(configForChecks);
                     var configPassed = await RunRequirementChecksAsync(configChecks, configForChecks, logger, ct: ct);
                     allPassed = allPassed && configPassed;
                 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -54,7 +54,10 @@ internal static class SetupHelpers
     /// have no messaging surface so Bot scopes serve no purpose.
     /// </para>
     /// </summary>
-    internal static ResourcePermissionSpec[] GetFixedApiPermissionSpecs(bool setInheritable, bool isM365)
+    internal static ResourcePermissionSpec[] GetFixedApiPermissionSpecs(
+        bool setInheritable,
+        bool isM365,
+        string? environment = null)
     {
         var specs = new List<ResourcePermissionSpec>();
         if (isM365)
@@ -74,7 +77,7 @@ internal static class SetupHelpers
                 setInheritable));
         }
         specs.Add(new ResourcePermissionSpec(
-            ConfigConstants.ObservabilityApiAppId,
+            ConfigConstants.GetObservabilityApiAppId(environment),
             "Observability API",
             new[] { ConfigConstants.ObservabilityApiOtelWriteScope },
             setInheritable,
@@ -146,7 +149,7 @@ internal static class SetupHelpers
                     : "Agent 365 Tools",
                 kvp.Value,
                 SetInheritable: setInheritable)));
-        specs.AddRange(GetFixedApiPermissionSpecs(setInheritable, isM365));
+        specs.AddRange(GetFixedApiPermissionSpecs(setInheritable, isM365, config.Environment));
 
         foreach (var customPerm in config.CustomBlueprintPermissions ?? new List<CustomResourcePermission>())
         {
@@ -198,9 +201,23 @@ internal static class SetupHelpers
                 "az", "cloud show --query name -o tsv",
                 captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
             var cloudName = result.StandardOutput?.Trim();
+            if (string.Equals(cloudName, "AzureUSGovernment", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new SetupValidationException(
+                    "The Azure CLI cloud does not distinguish GCC Moderate, GCC High, and DoD.",
+                    mitigationSteps:
+                    [
+                        "Set A365_ENVIRONMENT to gcc, gcc-high, or dod for the target tenant, then retry setup."
+                    ]);
+            }
+
             return string.IsNullOrWhiteSpace(cloudName) ? "prod" : cloudName;
         }
         catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (SetupValidationException)
         {
             throw;
         }
@@ -427,11 +444,22 @@ internal static class SetupHelpers
     /// when additional APIs are required (e.g. dynamic MCP scopes, custom permissions).
     /// </summary>
     internal static readonly IReadOnlyList<(string ResourceName, string ResourceAppId, string Scope, string PermissionType)> NonDwAdminConsentSpecs =
-    [
-        ("Observability API",  ConfigConstants.ObservabilityApiAppId,                          ConfigConstants.ObservabilityApiOtelWriteScope,                     "Application"),
-        ("Observability API",  ConfigConstants.ObservabilityApiAppId,                          ConfigConstants.ObservabilityApiOtelWriteScope,                     "Delegated"),
-        ("Power Platform API", PowerPlatformConstants.PowerPlatformApiResourceAppId,           PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead,  "Delegated"),
-    ];
+        GetNonDwAdminConsentSpecs("prod");
+
+    internal static IReadOnlyList<(string ResourceName, string ResourceAppId, string Scope, string PermissionType)> GetNonDwAdminConsentSpecs(
+        string? environment)
+        => BuildNonDwAdminConsentSpecs(ConfigConstants.GetObservabilityApiAppId(environment));
+
+    private static IReadOnlyList<(string ResourceName, string ResourceAppId, string Scope, string PermissionType)> BuildNonDwAdminConsentSpecs(
+        string observabilityAppId)
+    {
+        return
+        [
+            ("Observability API",  observabilityAppId, ConfigConstants.ObservabilityApiOtelWriteScope,                    "Application"),
+            ("Observability API",  observabilityAppId, ConfigConstants.ObservabilityApiOtelWriteScope,                    "Delegated"),
+            ("Power Platform API", PowerPlatformConstants.PowerPlatformApiResourceAppId, PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead, "Delegated"),
+        ];
+    }
 
     /// <summary>
     /// Logs step-by-step instructions for a Global Administrator to grant admin consent
@@ -445,9 +473,11 @@ internal static class SetupHelpers
         ILogger logger,
         string blueprintId,
         IReadOnlyList<(string ResourceName, string ResourceAppId, string Scope, string PermissionType)>? specs = null,
-        string? tenantId = null)
+        string? tenantId = null,
+        string? environment = null)
     {
-        specs ??= NonDwAdminConsentSpecs;
+        specs ??= GetNonDwAdminConsentSpecs(
+            environment ?? Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod");
         var delegatedSpecs = specs.Where(s => s.PermissionType == "Delegated").ToList();
 
         var directLink = $"https://entra.microsoft.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/CallAnAPI/appId/{blueprintId}/isMSAApp~/false";
@@ -456,8 +486,12 @@ internal static class SetupHelpers
         logger.LogInformation("       1. Sign in as {Roles} and open:", AuthenticationConstants.DelegatedGrantRequiredRoles);
         logger.LogInformation("            {Link}", directLink);
         logger.LogInformation("       2. Add the following permissions (click 'Add a permission' for each):");
-        foreach (var group in delegatedSpecs.GroupBy(s => (s.ResourceName, s.Scope)))
-            logger.LogInformation("            - {ResourceName,-20}: {Scope} (Delegated)", group.Key.ResourceName, group.Key.Scope);
+        foreach (var group in delegatedSpecs.GroupBy(s => (s.ResourceName, s.ResourceAppId, s.Scope)))
+            logger.LogInformation(
+                "            - {ResourceName,-20}: {Scope} (Delegated, app ID: {ResourceAppId})",
+                group.Key.ResourceName,
+                group.Key.Scope,
+                group.Key.ResourceAppId);
         logger.LogInformation("       3. Click 'Grant admin consent for your organization' and confirm");
 
         logger.LogInformation("");
@@ -521,6 +555,8 @@ internal static class SetupHelpers
     public static void DisplaySetupSummary(SetupResults results, ILogger logger, string? graphBaseUrl = null)
     {
         var resolvedGraphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+        var observabilityResourceAppId =
+            results.ObservabilityResourceAppId ?? ConfigConstants.ObservabilityApiAppId;
         var isNonDw = results.IsNonDwBlueprintFlow;
         var isBlueprintOnly = results.IsBlueprintOnlyFlow;
         // Which row groups this run actually performs. Blueprint-only ('setup blueprint') stops after
@@ -864,7 +900,11 @@ internal static class SetupHelpers
                 if (isNonDw && string.IsNullOrWhiteSpace(consentUrl))
                 {
                     logger.LogInformation("  {N}. Permission Grants — must be granted by {Roles} in the Entra portal:", actionCount, AuthenticationConstants.DelegatedGrantRequiredRoles);
-                    LogNonDwAdminConsentInstructions(logger, adminCmdBlueprintId, tenantId: results.TenantId);
+                    LogNonDwAdminConsentInstructions(
+                        logger,
+                        adminCmdBlueprintId,
+                        specs: BuildNonDwAdminConsentSpecs(observabilityResourceAppId),
+                        tenantId: results.TenantId);
                 }
                 else
                 {
@@ -904,7 +944,7 @@ internal static class SetupHelpers
                     // Grant targets the agent identity SP directly (SP object ID, not an app ID).
                     var agentSpId = results.AgentIdentityId ?? "<agent-identity-sp-object-id>";
                     logger.LogInformation("       $agentSpId = '{AgentSpId}'", agentSpId);
-                    logger.LogInformation("       $obs = Get-MgServicePrincipal -Filter \"appId eq '{ObsApiAppId}'\"", ConfigConstants.ObservabilityApiAppId);
+                    logger.LogInformation("       $obs = Get-MgServicePrincipal -Filter \"appId eq '{ObsApiAppId}'\"", observabilityResourceAppId);
                     logger.LogInformation("       $rid = ($obs.AppRoles | Where-Object {{ $_.Value -eq '{ObsScope}' }}).Id", ConfigConstants.ObservabilityApiOtelWriteScope);
                     logger.LogInformation("       New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $agentSpId -PrincipalId $agentSpId -ResourceId $obs.Id -AppRoleId $rid");
                     logger.LogInformation("");
@@ -916,7 +956,7 @@ internal static class SetupHelpers
                 {
                     // DW: grant targets the blueprint SP (looked up by app ID).
                     logger.LogInformation("       $bp  = Get-MgServicePrincipal -Filter \"appId eq '{BlueprintAppId}'\"", blueprintAppId);
-                    logger.LogInformation("       $obs = Get-MgServicePrincipal -Filter \"appId eq '{ObsApiAppId}'\"", ConfigConstants.ObservabilityApiAppId);
+                    logger.LogInformation("       $obs = Get-MgServicePrincipal -Filter \"appId eq '{ObsApiAppId}'\"", observabilityResourceAppId);
                     logger.LogInformation("       $rid = ($obs.AppRoles | Where-Object {{ $_.Value -eq '{ObsScope}' }}).Id", ConfigConstants.ObservabilityApiOtelWriteScope);
                     logger.LogInformation("       New-MgServicePrincipalAppRoleAssignment -ServicePrincipalId $bp.Id -PrincipalId $bp.Id -ResourceId $obs.Id -AppRoleId $rid");
                     logger.LogInformation("");
@@ -939,7 +979,7 @@ internal static class SetupHelpers
                 logger.LogInformation("     $agentSpId = '{AgentSpId}'", results.AgentIdentityId ?? "<agent-identity-sp-id>");
                 logger.LogInformation("");
                 logger.LogInformation("     # Observability API");
-                logger.LogInformation("     $obsSp = Get-MgServicePrincipal -Filter \"appId eq '{ObsAppId}'\"", ConfigConstants.ObservabilityApiAppId);
+                logger.LogInformation("     $obsSp = Get-MgServicePrincipal -Filter \"appId eq '{ObsAppId}'\"", observabilityResourceAppId);
                 logger.LogInformation("     $body  = @{{ clientId = $agentSpId; consentType = 'AllPrincipals'; resourceId = $obsSp.Id; scope = '{ObsScope}' }} | ConvertTo-Json", ConfigConstants.ObservabilityApiOtelWriteScope);
                 logger.LogInformation("     Invoke-MgGraphRequest -Method POST -Uri '{GraphBaseUrl}/v1.0/oauth2PermissionGrants' -Body $body -ContentType 'application/json'", resolvedGraphBaseUrl);
                 logger.LogInformation("");
@@ -1125,11 +1165,12 @@ internal static class SetupHelpers
         var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(config.Environment, config.GraphBaseUrl);
         var graphResourceUri = graphBaseUrl;
         var authorityHost = ConfigConstants.GetAuthorityHost(config.Environment, config.AuthorityHost);
+        var observabilityResourceAppId = ConfigConstants.GetObservabilityApiAppId(config.Environment);
 
         var urls = BuildAdminConsentUrls(
             config.TenantId, config.AgentBlueprintId!, config.AgentApplicationScopes, mcpScopes,
             isM365, mcpScopesByAudience, mcpAudienceDisplayNames, graphResourceUri, authorityHost,
-            mcpResourceAppId);
+            mcpResourceAppId, observabilityResourceAppId);
 
         // Map resource names to App IDs for upsert into ResourceConsents. The fixed-name
         // entries cover Graph + Bot + Obs + PP + the WorkIQ shared MCP audience. V2
@@ -1142,7 +1183,7 @@ internal static class SetupHelpers
             ["Microsoft Graph"]   = AuthenticationConstants.MicrosoftGraphResourceAppId,
             ["Agent 365 Tools"]   = mcpResourceAppId,
             ["Messaging Bot API"] = ConfigConstants.MessagingBotApiAppId,
-            ["Observability API"] = ConfigConstants.ObservabilityApiAppId,
+            ["Observability API"] = observabilityResourceAppId,
             ["Power Platform API"] = PowerPlatformConstants.PowerPlatformApiResourceAppId,
         };
 
@@ -1248,8 +1289,8 @@ internal static class SetupHelpers
             return graphResourceUri;
         if (string.Equals(resourceAppId, ConfigConstants.MessagingBotApiAppId, StringComparison.OrdinalIgnoreCase))
             return ConfigConstants.MessagingBotApiIdentifierUri;
-        if (string.Equals(resourceAppId, ConfigConstants.ObservabilityApiAppId, StringComparison.OrdinalIgnoreCase))
-            return ConfigConstants.ObservabilityApiIdentifierUri;
+        if (ConfigConstants.IsObservabilityApiAppId(resourceAppId))
+            return ConfigConstants.BuildObservabilityApiIdentifierUri(resourceAppId);
         if (string.Equals(resourceAppId, PowerPlatformConstants.PowerPlatformApiResourceAppId, StringComparison.OrdinalIgnoreCase))
             return PowerPlatformConstants.PowerPlatformApiIdentifierUri;
         // WorkIQ Tools shared (issue #429): match by appId, not display name. V2 per-server
@@ -1326,7 +1367,8 @@ internal static class SetupHelpers
         IReadOnlyDictionary<string, List<string>>? mcpAudienceDisplayNames = null,
         string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
         string? authorityHost = null,
-        string? sharedMcpResourceAppId = null)
+        string? sharedMcpResourceAppId = null,
+        string? observabilityResourceAppId = null)
     {
         var urls = new List<(string, string)>();
 
@@ -1389,7 +1431,9 @@ internal static class SetupHelpers
         if (isM365)
             urls.Add(("Messaging Bot API", Build(tenantId, blueprintClientId, ConfigConstants.MessagingBotApiIdentifierUri, new[] { ConfigConstants.MessagingBotApiAdminConsentScope })));
 
-        urls.Add(("Observability API", Build(tenantId, blueprintClientId, ConfigConstants.ObservabilityApiIdentifierUri, new[] { ConfigConstants.ObservabilityApiOtelWriteScope })));
+        var observabilityIdentifierUri = ConfigConstants.BuildObservabilityApiIdentifierUri(
+            observabilityResourceAppId ?? ConfigConstants.ObservabilityApiAppId);
+        urls.Add(("Observability API", Build(tenantId, blueprintClientId, observabilityIdentifierUri, new[] { ConfigConstants.ObservabilityApiOtelWriteScope })));
         urls.Add(("Power Platform API", Build(tenantId, blueprintClientId, PowerPlatformConstants.PowerPlatformApiIdentifierUri, new[] { PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead })));
 
         return urls;
@@ -1415,7 +1459,8 @@ internal static class SetupHelpers
         IReadOnlyDictionary<string, string[]>? mcpScopesByAudience = null,
         string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
         string? authorityHost = null,
-        string? sharedMcpResourceAppId = null)
+        string? sharedMcpResourceAppId = null,
+        string? observabilityResourceAppId = null)
     {
         var allScopes = new List<string>();
         foreach (var s in graphScopes)
@@ -1448,7 +1493,8 @@ internal static class SetupHelpers
 
         if (isM365)
             allScopes.Add($"{ConfigConstants.MessagingBotApiIdentifierUri}/{ConfigConstants.MessagingBotApiAdminConsentScope}");
-        allScopes.Add($"{ConfigConstants.ObservabilityApiIdentifierUri}/{ConfigConstants.ObservabilityApiOtelWriteScope}");
+        allScopes.Add(
+            $"{ConfigConstants.BuildObservabilityApiIdentifierUri(observabilityResourceAppId ?? ConfigConstants.ObservabilityApiAppId)}/{ConfigConstants.ObservabilityApiOtelWriteScope}");
         allScopes.Add($"{PowerPlatformConstants.PowerPlatformApiIdentifierUri}/{PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead}");
         return BuildAdminConsentUrl(tenantId, blueprintClientId, allScopes, authorityHost);
     }
@@ -1482,10 +1528,11 @@ internal static class SetupHelpers
         var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(ctx.Config.Environment, ctx.Config.GraphBaseUrl);
         var graphResourceUri = graphBaseUrl;
         var authorityHost = ConfigConstants.GetAuthorityHost(ctx.Config.Environment, ctx.Config.AuthorityHost);
+        var observabilityResourceAppId = ConfigConstants.GetObservabilityApiAppId(ctx.Config.Environment);
         ctx.Results.CombinedConsentUrl = BuildCombinedConsentUrl(
             ctx.Config.TenantId!, ctx.Config.AgentBlueprintId!,
             graphScopes, mcpScopes, isM365, mcpScopesByAudience, graphResourceUri, authorityHost,
-            mcpResourceAppId);
+            mcpResourceAppId, observabilityResourceAppId);
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -459,8 +459,9 @@ internal static class SetupHelpers
     /// The DW vs non-DW branch is determined solely by <see cref="SetupResults.IsNonDwBlueprintFlow"/>,
     /// which both orchestrators set explicitly — there is no separate caller-supplied flag.
     /// </summary>
-    public static void DisplaySetupSummary(SetupResults results, ILogger logger)
+    public static void DisplaySetupSummary(SetupResults results, ILogger logger, string? graphBaseUrl = null)
     {
+        var resolvedGraphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
         var isNonDw = results.IsNonDwBlueprintFlow;
         var isBlueprintOnly = results.IsBlueprintOnlyFlow;
         // Which row groups this run actually performs. Blueprint-only ('setup blueprint') stops after
@@ -881,12 +882,12 @@ internal static class SetupHelpers
                 logger.LogInformation("     # Observability API");
                 logger.LogInformation("     $obsSp = Get-MgServicePrincipal -Filter \"appId eq '{ObsAppId}'\"", ConfigConstants.ObservabilityApiAppId);
                 logger.LogInformation("     $body  = @{{ clientId = $agentSpId; consentType = 'AllPrincipals'; resourceId = $obsSp.Id; scope = '{ObsScope}' }} | ConvertTo-Json", ConfigConstants.ObservabilityApiOtelWriteScope);
-                logger.LogInformation("     Invoke-MgGraphRequest -Method POST -Uri 'https://graph.microsoft.com/v1.0/oauth2PermissionGrants' -Body $body -ContentType 'application/json'");
+                logger.LogInformation("     Invoke-MgGraphRequest -Method POST -Uri '{GraphBaseUrl}/v1.0/oauth2PermissionGrants' -Body $body -ContentType 'application/json'", resolvedGraphBaseUrl);
                 logger.LogInformation("");
                 logger.LogInformation("     # Power Platform API");
                 logger.LogInformation("     $ppSp  = Get-MgServicePrincipal -Filter \"appId eq '{PpAppId}'\"", PowerPlatformConstants.PowerPlatformApiResourceAppId);
                 logger.LogInformation("     $body  = @{{ clientId = $agentSpId; consentType = 'AllPrincipals'; resourceId = $ppSp.Id; scope = '{PpScope}' }} | ConvertTo-Json", PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead);
-                logger.LogInformation("     Invoke-MgGraphRequest -Method POST -Uri 'https://graph.microsoft.com/v1.0/oauth2PermissionGrants' -Body $body -ContentType 'application/json'");
+                logger.LogInformation("     Invoke-MgGraphRequest -Method POST -Uri '{GraphBaseUrl}/v1.0/oauth2PermissionGrants' -Body $body -ContentType 'application/json'", resolvedGraphBaseUrl);
             }
             if (messagingEndpointManualRequired)
             {
@@ -1062,7 +1063,14 @@ internal static class SetupHelpers
         IReadOnlyDictionary<string, string[]>? mcpScopesByAudience = null,
         IReadOnlyDictionary<string, List<string>>? mcpAudienceDisplayNames = null)
     {
-        var urls = BuildAdminConsentUrls(config.TenantId, config.AgentBlueprintId!, config.AgentApplicationScopes, mcpScopes, isM365, mcpScopesByAudience, mcpAudienceDisplayNames);
+        var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(config.Environment, config.GraphBaseUrl);
+        var graphResourceUri = graphBaseUrl;
+        var authorityHost = ConfigConstants.GetAuthorityHost(config.Environment, config.AuthorityHost);
+
+        var urls = BuildAdminConsentUrls(
+            config.TenantId, config.AgentBlueprintId!, config.AgentApplicationScopes, mcpScopes,
+            isM365, mcpScopesByAudience, mcpAudienceDisplayNames, graphResourceUri, authorityHost,
+            mcpResourceAppId);
 
         // Map resource names to App IDs for upsert into ResourceConsents. The fixed-name
         // entries cover Graph + Bot + Obs + PP + the WorkIQ shared MCP audience. V2
@@ -1145,11 +1153,13 @@ internal static class SetupHelpers
     /// Each scope is individually Uri.EscapeDataString-encoded and joined with %20.
     /// A random GUID state parameter is generated for CSRF protection.
     /// </summary>
-    internal static string BuildAdminConsentUrl(string tenantId, string clientId, IEnumerable<string> fullyQualifiedScopes)
+    internal static string BuildAdminConsentUrl(
+        string tenantId, string clientId, IEnumerable<string> fullyQualifiedScopes, string? authorityHost = null)
     {
         var scopeParam = string.Join("%20", fullyQualifiedScopes.Select(Uri.EscapeDataString));
         var redirectEncoded = Uri.EscapeDataString(AuthenticationConstants.BlueprintConsentRedirectUri);
-        return $"https://login.microsoftonline.com/{tenantId}/v2.0/adminconsent?client_id={clientId}&scope={scopeParam}&redirect_uri={redirectEncoded}&state={Guid.NewGuid():N}";
+        var normalizedAuthorityHost = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        return $"{normalizedAuthorityHost}/{tenantId}/v2.0/adminconsent?client_id={clientId}&scope={scopeParam}&redirect_uri={redirectEncoded}&state={Guid.NewGuid():N}";
     }
 
     /// <summary>
@@ -1169,10 +1179,14 @@ internal static class SetupHelpers
     /// is a V2 MCP per-server audience (e.g. it sits in the ToolingManifest audience set
     /// or the call site is iterating <c>mcpScopesByAudience</c>). Default false preserves
     /// the safe api://{appId} fallback for any caller that has not been updated.</param>
-    internal static string GetResourceIdentifierUri(string resourceAppId, bool isMcpAudience = false)
+    internal static string GetResourceIdentifierUri(
+        string resourceAppId,
+        bool isMcpAudience = false,
+        string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
+        string? sharedMcpResourceAppId = null)
     {
         if (string.Equals(resourceAppId, AuthenticationConstants.MicrosoftGraphResourceAppId, StringComparison.OrdinalIgnoreCase))
-            return AuthenticationConstants.MicrosoftGraphResourceUri;
+            return graphResourceUri;
         if (string.Equals(resourceAppId, ConfigConstants.MessagingBotApiAppId, StringComparison.OrdinalIgnoreCase))
             return ConfigConstants.MessagingBotApiIdentifierUri;
         if (string.Equals(resourceAppId, ConfigConstants.ObservabilityApiAppId, StringComparison.OrdinalIgnoreCase))
@@ -1182,7 +1196,7 @@ internal static class SetupHelpers
         // WorkIQ Tools shared (issue #429): match by appId, not display name. V2 per-server
         // audiences are also named "Agent 365 Tools" so the old name-based check collapsed
         // them onto WorkIQ's URI and produced AADSTS650053.
-        if (IsAgent365ToolsResourceAppId(resourceAppId))
+        if (IsAgent365ToolsResourceAppId(resourceAppId, sharedMcpResourceAppId))
             return McpConstants.Agent365ToolsIdentifierUri;
 
         // V2 MCP per-server audiences (identifierUris=null, only bare appId in
@@ -1197,29 +1211,21 @@ internal static class SetupHelpers
 
     /// <summary>
     /// Returns true when the supplied resource appId is the WorkIQ Tools (Agent 365 Tools)
-    /// shared resource — either the hard-coded prod appId or an env-overridden value
-    /// pinned via <c>A365_MCP_APP_ID_&lt;env&gt;</c>. Used by
+    /// shared resource — either the hard-coded production appId or the explicitly resolved
+    /// cloud-specific appId. Used by
     /// <see cref="GetResourceIdentifierUri"/> to distinguish the WorkIQ shared audience
     /// (returns canonical https URI) from V2 MCP per-server audiences (returns bare appId
     /// GUID because per-server SPs have <c>identifierUris = null</c> and Entra rejects
     /// api://{appId} for them with AADSTS500011).
     /// </summary>
-    private static bool IsAgent365ToolsResourceAppId(string resourceAppId)
+    private static bool IsAgent365ToolsResourceAppId(string resourceAppId, string? sharedMcpResourceAppId = null)
     {
         if (string.IsNullOrWhiteSpace(resourceAppId)) return false;
         if (string.Equals(resourceAppId, McpConstants.WorkIQToolsProdAppId, StringComparison.OrdinalIgnoreCase))
             return true;
-        // Also accept any value the environment-aware resolver returns for known env keys.
-        // Cheaper than walking every possible env: only check the env on the running config
-        // when explicitly passed via env var. ConfigConstants.GetAgent365ToolsResourceAppId
-        // already short-circuits to the prod appId when no override is set.
-        foreach (var envKey in new[] { "prod", "preprod", "test", "dev" })
-        {
-            var resolved = ConfigConstants.GetAgent365ToolsResourceAppId(envKey);
-            if (string.Equals(resourceAppId, resolved, StringComparison.OrdinalIgnoreCase))
-                return true;
-        }
-        return false;
+
+        return !string.IsNullOrWhiteSpace(sharedMcpResourceAppId)
+            && string.Equals(resourceAppId, sharedMcpResourceAppId, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -1230,8 +1236,13 @@ internal static class SetupHelpers
     /// <param name="isMcpAudience">Forwarded to <see cref="GetResourceIdentifierUri"/>; pass
     /// true when the caller knows <paramref name="resourceAppId"/> is a V2 MCP per-server
     /// audience (e.g. found in the loaded ToolingManifest audience set). Default false.</param>
-    internal static string BuildFullyQualifiedScope(string resourceAppId, string scope, bool isMcpAudience = false)
-        => $"{GetResourceIdentifierUri(resourceAppId, isMcpAudience)}/{scope}";
+    internal static string BuildFullyQualifiedScope(
+        string resourceAppId,
+        string scope,
+        bool isMcpAudience = false,
+        string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
+        string? sharedMcpResourceAppId = null)
+        => $"{GetResourceIdentifierUri(resourceAppId, isMcpAudience, graphResourceUri, sharedMcpResourceAppId)}/{scope}";
 
     /// <summary>
     /// Builds per-resource admin consent URLs covering every resource stamped on the blueprint
@@ -1253,16 +1264,19 @@ internal static class SetupHelpers
         IEnumerable<string> mcpScopes,
         bool isM365 = true,
         IReadOnlyDictionary<string, string[]>? mcpScopesByAudience = null,
-        IReadOnlyDictionary<string, List<string>>? mcpAudienceDisplayNames = null)
+        IReadOnlyDictionary<string, List<string>>? mcpAudienceDisplayNames = null,
+        string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
+        string? authorityHost = null,
+        string? sharedMcpResourceAppId = null)
     {
         var urls = new List<(string, string)>();
 
-        static string Build(string tenant, string client, string resourceUri, IEnumerable<string> scopes)
-            => BuildAdminConsentUrl(tenant, client, scopes.Select(s => $"{resourceUri}/{s}"));
+        string Build(string tenant, string client, string resourceUri, IEnumerable<string> scopes)
+            => BuildAdminConsentUrl(tenant, client, scopes.Select(s => $"{resourceUri}/{s}"), authorityHost);
 
         var graphScopeList = graphScopes.ToList();
         if (graphScopeList.Count > 0)
-            urls.Add(("Microsoft Graph", Build(tenantId, blueprintClientId, AuthenticationConstants.MicrosoftGraphResourceUri, graphScopeList)));
+            urls.Add(("Microsoft Graph", Build(tenantId, blueprintClientId, graphResourceUri, graphScopeList)));
 
         // V2 per-server audiences (issue #429): when the caller passes a by-audience map,
         // emit one URL fragment per audience whose resource identifier is resolved by
@@ -1278,7 +1292,8 @@ internal static class SetupHelpers
                 if (scopes is null || scopes.Length == 0) continue;
                 // The loop iterates over manifest-derived MCP audiences; every key here is
                 // by definition an MCP per-server audience appId.
-                var resourceUri = GetResourceIdentifierUri(audienceAppId, isMcpAudience: true);
+                var resourceUri = GetResourceIdentifierUri(
+                    audienceAppId, isMcpAudience: true, sharedMcpResourceAppId: sharedMcpResourceAppId);
                 // Display name: WorkIQ shared audience keeps the legacy "Agent 365 Tools"
                 // label. Per-server audiences use the manifest McpServerName when supplied
                 // (e.g. "mcp_MailTools (16b1878d-...)") so the consent URL block matches the
@@ -1288,7 +1303,7 @@ internal static class SetupHelpers
                 // TryExtractAudienceAppIdFromResourceName for the PopulateAdminConsentUrls
                 // upsert path.
                 string resourceName;
-                if (IsAgent365ToolsResourceAppId(audienceAppId))
+                if (IsAgent365ToolsResourceAppId(audienceAppId, sharedMcpResourceAppId))
                 {
                     resourceName = "Agent 365 Tools";
                 }
@@ -1338,11 +1353,14 @@ internal static class SetupHelpers
         IEnumerable<string> graphScopes,
         IEnumerable<string> mcpScopes,
         bool isM365 = true,
-        IReadOnlyDictionary<string, string[]>? mcpScopesByAudience = null)
+        IReadOnlyDictionary<string, string[]>? mcpScopesByAudience = null,
+        string graphResourceUri = AuthenticationConstants.MicrosoftGraphResourceUri,
+        string? authorityHost = null,
+        string? sharedMcpResourceAppId = null)
     {
         var allScopes = new List<string>();
         foreach (var s in graphScopes)
-            allScopes.Add($"{AuthenticationConstants.MicrosoftGraphResourceUri}/{s}");
+            allScopes.Add($"{graphResourceUri}/{s}");
 
         // V2 per-server audiences (issue #429): when the caller passes a by-audience map,
         // emit per-audience scope URIs using GetResourceIdentifierUri so the WorkIQ
@@ -1357,7 +1375,8 @@ internal static class SetupHelpers
                 if (scopes is null) continue;
                 // The loop iterates over manifest-derived MCP audiences; every key here is
                 // by definition an MCP per-server audience appId.
-                var resourceUri = GetResourceIdentifierUri(audienceAppId, isMcpAudience: true);
+                var resourceUri = GetResourceIdentifierUri(
+                    audienceAppId, isMcpAudience: true, sharedMcpResourceAppId: sharedMcpResourceAppId);
                 foreach (var s in scopes)
                     allScopes.Add($"{resourceUri}/{s}");
             }
@@ -1372,7 +1391,7 @@ internal static class SetupHelpers
             allScopes.Add($"{ConfigConstants.MessagingBotApiIdentifierUri}/{ConfigConstants.MessagingBotApiAdminConsentScope}");
         allScopes.Add($"{ConfigConstants.ObservabilityApiIdentifierUri}/{ConfigConstants.ObservabilityApiOtelWriteScope}");
         allScopes.Add($"{PowerPlatformConstants.PowerPlatformApiIdentifierUri}/{PowerPlatformConstants.PermissionNames.ConnectivityConnectionsRead}");
-        return BuildAdminConsentUrl(tenantId, blueprintClientId, allScopes);
+        return BuildAdminConsentUrl(tenantId, blueprintClientId, allScopes, authorityHost);
     }
 
     /// <summary>
@@ -1401,9 +1420,13 @@ internal static class SetupHelpers
         var consentResourceNames = PopulateAdminConsentUrls(ctx.Config, mcpResourceAppId, mcpScopes, isM365, mcpScopesByAudience, mcpAudienceDisplayNames);
         ctx.Results.ConsentUrlsSavedToPath = ctx.GeneratedConfigPath;
         ctx.Results.ConsentResourceNames.AddRange(consentResourceNames);
+        var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(ctx.Config.Environment, ctx.Config.GraphBaseUrl);
+        var graphResourceUri = graphBaseUrl;
+        var authorityHost = ConfigConstants.GetAuthorityHost(ctx.Config.Environment, ctx.Config.AuthorityHost);
         ctx.Results.CombinedConsentUrl = BuildCombinedConsentUrl(
             ctx.Config.TenantId!, ctx.Config.AgentBlueprintId!,
-            graphScopes, mcpScopes, isM365, mcpScopesByAudience);
+            graphScopes, mcpScopes, isM365, mcpScopesByAudience, graphResourceUri, authorityHost,
+            mcpResourceAppId);
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupResults.cs
@@ -16,6 +16,7 @@ public class SetupResults
     public string? BlueprintDisplayName { get; set; }
     public bool McpPermissionsConfigured { get; set; }
     public bool BotApiPermissionsConfigured { get; set; }
+    public string? ObservabilityResourceAppId { get; set; }
     public bool MessagingEndpointRegistered { get; set; }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
@@ -260,16 +260,11 @@ public static class AuthenticationConstants
         .ToArray();
 
     /// <summary>
-    /// Explicit delegated scopes passed to EnsureGraphHeadersAsync for permission-grant operations.
-    /// Intentionally empty: the operations that previously needed explicit scopes here
-    /// (DelegatedPermissionGrant.ReadWrite.All for oauth2 grant CRUD,
-    /// AgentIdentityBlueprint.UpdateAuthProperties.All for inheritable permissions) are now
-    /// covered by the AgentIdentityBlueprint.ReadWrite.All umbrella in RequiredClientAppPermissions.
-    /// An empty array causes EnsureGraphHeadersAsync to route through the standard token path
-    /// (GetGraphAccessTokenAsync / AuthenticationService), which already carries all required scopes.
-    /// Validated end-to-end across all 4 setup variants (PR #409).
+    /// Delegated scopes requested for permission and blueprint-resource operations.
+    /// These calls include application and service-principal reads, so they must not fall back to
+    /// the custom app's default User.Read token.
     /// </summary>
-    public static readonly string[] RequiredPermissionGrantScopes = [];
+    public static readonly string[] RequiredPermissionGrantScopes = BlueprintOperationScopes.ToArray();
 
     /// <summary>
     /// Additional scopes for S2S app role assignment calls in BatchPermissionsOrchestrator.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
@@ -84,12 +84,27 @@ public static class ConfigConstants
     public const string MessagingBotApiIdentifierUri = "https://botapi.skype.com";
 
     /// <summary>
-    /// Observability API App ID
+    /// Commercial Observability API App ID
     /// </summary>
     public const string ObservabilityApiAppId = "9b975845-388f-4429-889e-eab1ef63949c";
 
     /// <summary>
-    /// Observability API identifier URI (uses api:// scheme — no public https URI registered).
+    /// GCC Moderate Observability API App ID
+    /// </summary>
+    public const string GccObservabilityApiAppId = "2c672ad5-b104-44ed-8069-bb68dd138546";
+
+    /// <summary>
+    /// GCC High Observability API App ID
+    /// </summary>
+    public const string GccHighObservabilityApiAppId = "009c6bd0-82e4-4466-95b3-4c996521f3d7";
+
+    /// <summary>
+    /// DoD Observability API App ID
+    /// </summary>
+    public const string DodObservabilityApiAppId = "a9e04047-c6a7-430b-a7ae-faf8f8eed1b7";
+
+    /// <summary>
+    /// Commercial Observability API identifier URI.
     /// </summary>
     public const string ObservabilityApiIdentifierUri = "api://9b975845-388f-4429-889e-eab1ef63949c";
 
@@ -178,6 +193,38 @@ public static class ConfigConstants
     public static string GetAgent365ToolsResourceAppId(string environment)
         => GetEnvironmentScopedSetting("A365_MCP_APP_ID", environment)
             ?? McpConstants.WorkIQToolsProdAppId;
+
+    /// <summary>
+    /// Returns the Observability resource Application ID for the selected cloud.
+    /// </summary>
+    public static string GetObservabilityApiAppId(string? environment)
+        => NormalizeEnvironmentKey(environment) switch
+        {
+            "GCC" or "GCC_MODERATE" => GccObservabilityApiAppId,
+            "GCC_HIGH" => GccHighObservabilityApiAppId,
+            "DOD" => DodObservabilityApiAppId,
+            "AZUREUSGOVERNMENT" => throw new ArgumentException(
+                "AzureUSGovernment does not distinguish GCC Moderate, GCC High, and DoD. " +
+                "Set the environment to gcc, gcc-high, or dod.",
+                nameof(environment)),
+            _ => ObservabilityApiAppId,
+        };
+
+    /// <summary>
+    /// Returns the Observability resource identifier URI for the selected cloud.
+    /// </summary>
+    public static string GetObservabilityApiIdentifierUri(string? environment)
+        => BuildObservabilityApiIdentifierUri(GetObservabilityApiAppId(environment));
+
+    internal static string BuildObservabilityApiIdentifierUri(string appId)
+        => $"api://{appId}";
+
+    internal static bool IsObservabilityApiAppId(string? appId)
+        => appId is not null &&
+           (appId.Equals(ObservabilityApiAppId, StringComparison.OrdinalIgnoreCase) ||
+            appId.Equals(GccObservabilityApiAppId, StringComparison.OrdinalIgnoreCase) ||
+            appId.Equals(GccHighObservabilityApiAppId, StringComparison.OrdinalIgnoreCase) ||
+            appId.Equals(DodObservabilityApiAppId, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Returns the authority host for the selected cloud environment.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
@@ -11,6 +11,10 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Constants;
 /// </summary>
 public static class ConfigConstants
 {
+    private const string ProductionAgent365ToolsOrigin = "https://agent365.svc.cloud.microsoft";
+    internal const string CreateAgentBlueprintPath = "/agents/botManagement/createAgentBlueprint";
+    internal const string DeleteAgentBlueprintPath = "/agents/botManagement/deleteAgentBlueprint";
+
     /// <summary>
     /// Commercial-cloud OAuth authority host. Used as the fallback when no cloud-specific
     /// override is configured.
@@ -62,12 +66,12 @@ public static class ConfigConstants
     /// <summary>
     /// Production Agent 365 Tools Create endpoint URL
     /// </summary>
-    public const string ProductionCreateEndpointUrl = "https://agent365.svc.cloud.microsoft/agents/botManagement/createAgentBlueprint";
+    public const string ProductionCreateEndpointUrl = ProductionAgent365ToolsOrigin + CreateAgentBlueprintPath;
 
     /// <summary>
     /// Production Agent 365 Tools Delete endpoint URL
     /// </summary>
-    public const string ProductionDeleteEndpointUrl = "https://agent365.svc.cloud.microsoft/agents/botManagement/deleteAgentBlueprint";
+    public const string ProductionDeleteEndpointUrl = ProductionAgent365ToolsOrigin + DeleteAgentBlueprintPath;
 
     /// <summary>
     /// Messaging Bot API App ID
@@ -160,18 +164,13 @@ public static class ConfigConstants
     /// Get Discover endpoint URL based on environment
     /// </summary>
     public static string GetDiscoverEndpointUrl(string environment)
-    {
-        // Check for custom endpoint in environment variable first
-        var customEndpoint = GetEnvironmentScopedSetting("A365_DISCOVER_ENDPOINT", environment);
-        if (!string.IsNullOrEmpty(customEndpoint))
-            return customEndpoint;
+        => ResolveDiscoverEndpointUri(environment).AbsoluteUri;
 
-        // Default to production endpoint
-        return environment?.ToLower() switch
-        {
-            _ => ProductionDiscoverEndpointUrl
-        };
-    }
+    internal static string GetAgent365ToolsOrigin(string environment)
+        => ResolveDiscoverEndpointUri(environment).GetLeftPart(UriPartial.Authority);
+
+    internal static string BuildAgent365ToolsEndpointUrl(string environment, string endpointPath)
+        => $"{GetAgent365ToolsOrigin(environment)}{endpointPath}";
 
     /// <summary>
     /// environment-aware Agent 365 Tools resource Application ID
@@ -229,18 +228,19 @@ public static class ConfigConstants
     }
 
     private static string? GetEnvironmentScopedSetting(string prefix, string? environment)
-        => Environment.GetEnvironmentVariable($"{prefix}_{NormalizeEnvironmentKey(environment)}") is { } value
+        => GetEnvironmentScopedValue(prefix, environment) is { } value
             && !string.IsNullOrWhiteSpace(value)
                 ? value.Trim()
                 : null;
 
+    private static string? GetEnvironmentScopedValue(string prefix, string? environment)
+        => Environment.GetEnvironmentVariable($"{prefix}_{NormalizeEnvironmentKey(environment)}");
+
     private static string NormalizeHttpsOrigin(string? value, string fallback, string settingName)
     {
         var candidate = string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
-        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) ||
-            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
-            !string.IsNullOrEmpty(uri.UserInfo) ||
-            !string.IsNullOrEmpty(uri.Query) ||
+        var uri = ParseHttpsUri(candidate, settingName);
+        if (!string.IsNullOrEmpty(uri.Query) ||
             !string.IsNullOrEmpty(uri.Fragment) ||
             uri.AbsolutePath != "/")
         {
@@ -249,5 +249,34 @@ public static class ConfigConstants
         }
 
         return uri.GetLeftPart(UriPartial.Authority);
+    }
+
+    private static Uri ResolveDiscoverEndpointUri(string environment)
+    {
+        var configuredEndpoint = GetEnvironmentScopedValue("A365_DISCOVER_ENDPOINT", environment);
+        var candidate = configuredEndpoint is null
+            ? ProductionDiscoverEndpointUrl
+            : configuredEndpoint.Trim();
+        var uri = ParseHttpsUri(candidate, "Agent 365 Tools discover endpoint");
+        if (!string.IsNullOrEmpty(uri.Query) || !string.IsNullOrEmpty(uri.Fragment))
+        {
+            throw new ArgumentException(
+                "Agent 365 Tools discover endpoint must not contain a query or fragment.");
+        }
+
+        return uri;
+    }
+
+    private static Uri ParseHttpsUri(string value, string settingName)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            !string.IsNullOrEmpty(uri.UserInfo))
+        {
+            throw new ArgumentException(
+                $"{settingName} must be an absolute HTTPS URL without user info.");
+        }
+
+        return uri;
     }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/ConfigConstants.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Constants;
 
@@ -10,6 +11,14 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Constants;
 /// </summary>
 public static class ConfigConstants
 {
+    /// <summary>
+    /// Commercial-cloud OAuth authority host. Used as the fallback when no cloud-specific
+    /// override is configured.
+    /// </summary>
+    public const string DefaultAuthorityHost = "https://login.microsoftonline.com";
+    private const string AuthorityHostEnvVar = "A365_AUTHORITY_HOST";
+    private const string GraphBaseUrlEnvVar = "A365_GRAPH_BASE_URL";
+
     /// <summary>
     /// Default static configuration file name (user-managed, version-controlled)
     /// </summary>
@@ -153,7 +162,7 @@ public static class ConfigConstants
     public static string GetDiscoverEndpointUrl(string environment)
     {
         // Check for custom endpoint in environment variable first
-        var customEndpoint = Environment.GetEnvironmentVariable($"A365_DISCOVER_ENDPOINT_{environment?.ToUpper()}");
+        var customEndpoint = GetEnvironmentScopedSetting("A365_DISCOVER_ENDPOINT", environment);
         if (!string.IsNullOrEmpty(customEndpoint))
             return customEndpoint;
 
@@ -167,13 +176,78 @@ public static class ConfigConstants
     /// <summary>
     /// environment-aware Agent 365 Tools resource Application ID
     /// </summary>
-public static string GetAgent365ToolsResourceAppId(string environment)
-{
-    // Check for custom app ID in environment variable first
-    var customAppId = Environment.GetEnvironmentVariable($"A365_MCP_APP_ID_{environment?.ToUpperInvariant()}");
-    if (!string.IsNullOrEmpty(customAppId))
-        return customAppId;
+    public static string GetAgent365ToolsResourceAppId(string environment)
+        => GetEnvironmentScopedSetting("A365_MCP_APP_ID", environment)
+            ?? McpConstants.WorkIQToolsProdAppId;
 
-    return McpConstants.WorkIQToolsProdAppId;
-}
+    /// <summary>
+    /// Returns the authority host for the selected cloud environment.
+    /// </summary>
+    public static string GetAuthorityHost(string environment, string? configAuthorityHost = null)
+        => NormalizeAuthorityHost(GetEnvironmentScopedSetting(AuthorityHostEnvVar, environment) ?? configAuthorityHost);
+
+    /// <summary>
+    /// Returns the Graph base URL for the selected cloud environment.
+    /// </summary>
+    public static string GetGraphBaseUrl(string environment, string? configGraphBaseUrl = null)
+        => NormalizeGraphBaseUrl(GetEnvironmentScopedSetting(GraphBaseUrlEnvVar, environment) ?? configGraphBaseUrl);
+
+    /// <summary>
+    /// Composes an OAuth2 admin-consent endpoint from an already-resolved authority host.
+    /// </summary>
+    public static string BuildAdminConsentEndpointUrl(string? authorityHost, string tenantId)
+        => $"{NormalizeAuthorityHost(authorityHost)}/{tenantId}/v2.0/adminconsent";
+
+    /// <summary>
+    /// Returns the OAuth2 token endpoint URL for the given tenant and environment.
+    /// </summary>
+    public static string GetTokenEndpointUrl(string tenantId, string environment, string? configAuthorityHost = null)
+        => BuildTokenEndpointUrl(GetAuthorityHost(environment, configAuthorityHost), tenantId);
+
+    /// <summary>
+    /// Composes an OAuth2 token endpoint from an already-resolved authority host.
+    /// </summary>
+    public static string BuildTokenEndpointUrl(string? authorityHost, string tenantId)
+        => $"{NormalizeAuthorityHost(authorityHost)}/{tenantId}/oauth2/v2.0/token";
+
+    internal static string NormalizeAuthorityHost(string? authorityHost)
+        => NormalizeHttpsOrigin(authorityHost, DefaultAuthorityHost, "Authority host");
+
+    internal static string NormalizeGraphBaseUrl(string? graphBaseUrl)
+        => NormalizeHttpsOrigin(graphBaseUrl, GraphApiConstants.BaseUrl, "Graph base URL");
+
+    /// <summary>
+    /// Normalizes an environment key so arbitrary cloud names can map to env vars.
+    /// </summary>
+    public static string NormalizeEnvironmentKey(string? environment)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+            return "PROD";
+
+        var normalized = Regex.Replace(environment.Trim(), "[^A-Za-z0-9]", "_").ToUpperInvariant();
+        return string.IsNullOrWhiteSpace(normalized) ? "PROD" : normalized;
+    }
+
+    private static string? GetEnvironmentScopedSetting(string prefix, string? environment)
+        => Environment.GetEnvironmentVariable($"{prefix}_{NormalizeEnvironmentKey(environment)}") is { } value
+            && !string.IsNullOrWhiteSpace(value)
+                ? value.Trim()
+                : null;
+
+    private static string NormalizeHttpsOrigin(string? value, string fallback, string settingName)
+    {
+        var candidate = string.IsNullOrWhiteSpace(value) ? fallback : value.Trim();
+        if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) ||
+            !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ||
+            !string.IsNullOrEmpty(uri.UserInfo) ||
+            !string.IsNullOrEmpty(uri.Query) ||
+            !string.IsNullOrEmpty(uri.Fragment) ||
+            uri.AbsolutePath != "/")
+        {
+            throw new ArgumentException(
+                $"{settingName} must be an HTTPS origin without a path, query, fragment, or user info.");
+        }
+
+        return uri.GetLeftPart(UriPartial.Authority);
+    }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
@@ -83,9 +83,9 @@ public sealed class ClientAppValidationException : Agent365Exception
     /// Creates exception for missing admin consent.
     /// Includes a direct admin consent URL that a Global Administrator can open to grant consent.
     /// </summary>
-    public static ClientAppValidationException MissingAdminConsent(string clientAppId, string? tenantId = null)
+    public static ClientAppValidationException MissingAdminConsent(string clientAppId, string? tenantId = null, string? authorityHost = null)
     {
-        var consentUrl = BuildAdminConsentUrl(clientAppId, tenantId);
+        var consentUrl = BuildAdminConsentUrl(clientAppId, tenantId, authorityHost);
         var consentInstruction = consentUrl != null
             ? $"Share this URL with a Global Administrator to grant consent:\n  {consentUrl}"
             : "Grant admin consent at: Azure Portal > App registrations > Your app > API permissions.";
@@ -116,16 +116,19 @@ public sealed class ClientAppValidationException : Agent365Exception
     /// Builds the admin consent URL for the given client app and tenant.
     /// A Global Administrator can open this URL to grant tenant-wide (AllPrincipals) consent.
     /// </summary>
-    public static string? BuildAdminConsentUrl(string clientAppId, string? tenantId)
+    public static string? BuildAdminConsentUrl(string clientAppId, string? tenantId, string? authorityHost = null)
     {
         if (string.IsNullOrWhiteSpace(clientAppId) || string.IsNullOrWhiteSpace(tenantId))
             return null;
 
-        // Standard native-app redirect URI accepted by Entra ID for admin consent flows
-        const string redirectUri = "https://login.microsoftonline.com/common/oauth2/nativeclient";
+        // Standard native-app redirect URI accepted by Entra ID for admin consent flows.
+        // Authority host defaults to commercial cloud; callers pass a cloud-resolved host
+        // (e.g. GraphApiService.AuthorityHost) so sovereign tenants get a matching consent URL.
+        var host = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        var redirectUri = $"{host}/common/oauth2/nativeclient";
         var clientIdEncoded = Uri.EscapeDataString(clientAppId);
         var redirectUriEncoded = Uri.EscapeDataString(redirectUri);
-        return $"https://login.microsoftonline.com/{tenantId}/adminconsent?client_id={clientIdEncoded}&redirect_uri={redirectUriEncoded}";
+        return $"{host}/{tenantId}/adminconsent?client_id={clientIdEncoded}&redirect_uri={redirectUriEncoded}";
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Helpers/ProjectSettingsSyncHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Helpers/ProjectSettingsSyncHelper.cs
@@ -19,8 +19,6 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Helpers;
 /// </summary>
 public static class ProjectSettingsSyncHelper
 {
-    private const string DEFAULT_AUTHORITY_ENDPOINT = "https://login.microsoftonline.com";
-    private const string DEFAULT_USER_AUTHORIZATION_SCOPE = "https://graph.microsoft.com/.default";
     // Messaging Bot API Application GUID
     private const string DEFAULT_SERVICE_CONNECTION_SCOPE = $"{ConfigConstants.MessagingBotApiAppId}/.default";
 
@@ -459,7 +457,8 @@ public static class ProjectSettingsSyncHelper
 
         var agenticSettings = RequireObj(agentic, "Settings");
         agenticSettings["AlternateBlueprintConnectionName"] = "ServiceConnection";
-        var uaScopes = new JsonArray(DEFAULT_USER_AUTHORIZATION_SCOPE);
+        var userAuthorizationScope = GetUserAuthorizationScope(pkgConfig);
+        var uaScopes = new JsonArray(userAuthorizationScope);
         agenticSettings["Scopes"] = uaScopes;
         
         // -- Connections --
@@ -470,7 +469,7 @@ public static class ProjectSettingsSyncHelper
         
         if (!string.IsNullOrWhiteSpace(pkgConfig.TenantId))
         {
-            var authority = $"{DEFAULT_AUTHORITY_ENDPOINT}/{pkgConfig.TenantId}";
+            var authority = $"{ConfigConstants.GetAuthorityHost(pkgConfig.Environment, pkgConfig.AuthorityHost)}/{pkgConfig.TenantId}";
             svcSettings["AuthorityEndpoint"] = authority;
         }
 
@@ -579,7 +578,7 @@ public static class ProjectSettingsSyncHelper
         Set("AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__ALT_BLUEPRINT_NAME",
             "SERVICE_CONNECTION");
         Set("AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__SCOPES",
-            DEFAULT_USER_AUTHORIZATION_SCOPE);
+            GetUserAuthorizationScope(pkgConfig));
 
         // --- ConnectionsMap[0] ---
         Set("CONNECTIONSMAP__0__SERVICEURL", "*");
@@ -651,7 +650,7 @@ public static class ProjectSettingsSyncHelper
 
         // --- AgenticAuthentication Options ---
         Set("agentic_altBlueprintConnectionName", "service_connection");
-        Set("agentic_scopes", DEFAULT_USER_AUTHORIZATION_SCOPE);
+        Set("agentic_scopes", GetUserAuthorizationScope(pkgConfig));
         Set("agentic_connectionName", "AgenticAuthConnection");
 
         // --- Agent365 Observability ---
@@ -693,5 +692,11 @@ public static class ProjectSettingsSyncHelper
             return $"\"{escaped}\"";
         }
         return value;
+    }
+
+    private static string GetUserAuthorizationScope(Agent365Config pkgConfig)
+    {
+        var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(pkgConfig.Environment, pkgConfig.GraphBaseUrl);
+        return $"{graphBaseUrl}/.default";
     }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
@@ -125,9 +125,9 @@ public class Agent365Config
     public string TenantId { get; init; } = string.Empty;
 
     /// <summary>
-    /// Target environment for Agent 365 services (test, preprod, prod).
-    /// Controls which endpoints are used for Teams Graph API, Agent 365 Tools, etc.
-    /// Default: preprod
+    /// Target Agent 365 environment or cloud key.
+    /// Supported production cloud keys include prod, gcc, gcc-high, and dod.
+    /// Controls service endpoints, resource application IDs, and authentication audiences.
     /// </summary>
     [JsonPropertyName("environment")]
     public string Environment { get; init; } = "prod";
@@ -539,7 +539,7 @@ public class Agent365Config
     {
         var botResources = ResourceConsents
             .Where(rc => rc.ResourceAppId.Equals(ConfigConstants.MessagingBotApiAppId, StringComparison.OrdinalIgnoreCase) ||
-                         rc.ResourceAppId.Equals(ConfigConstants.ObservabilityApiAppId, StringComparison.OrdinalIgnoreCase) ||
+                         ConfigConstants.IsObservabilityApiAppId(rc.ResourceAppId) ||
                          rc.ResourceAppId.Equals(PowerPlatformConstants.PowerPlatformApiResourceAppId, StringComparison.OrdinalIgnoreCase))
             .Where(rc => rc.InheritablePermissionsConfigured.HasValue)
             .ToList();

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
@@ -140,14 +140,17 @@ public class Agent365Config
     public string MessagingEndpoint { get; init; } = string.Empty;
 
     /// <summary>
-    /// Base URL for Microsoft Graph API.
-    /// Override this to target sovereign / government clouds:
-    ///   GCC High / DoD : "https://graph.microsoft.us"
-    ///   China (21Vianet): "https://microsoftgraph.chinacloudapi.cn"
-    /// Defaults to "https://graph.microsoft.com" when omitted.
+    /// Base URL for Microsoft Graph API. Defaults to the commercial cloud endpoint.
     /// </summary>
     [JsonPropertyName("graphBaseUrl")]
     public string GraphBaseUrl { get; init; } = Constants.GraphApiConstants.BaseUrl;
+
+    /// <summary>
+    /// OAuth authority host for the selected cloud. Pair this with <see cref="GraphBaseUrl"/>
+    /// so authentication and Graph data-plane calls target the same environment.
+    /// </summary>
+    [JsonPropertyName("authorityHost")]
+    public string? AuthorityHost { get; init; }
 
     #endregion
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
@@ -334,6 +334,7 @@ class Program
 
             // Default to "prod". Override with A365_ENVIRONMENT env var or a365.config.json.
             string environment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT") ?? "prod";
+            string? authorityHost = null;
 
             var configFilePath = ConfigService.GetConfigFilePath();
             if (configFilePath != null)
@@ -350,6 +351,8 @@ class Program
                             environment = envValue;
                         }
                     }
+                    if (doc.RootElement.TryGetProperty("authorityHost", out var authorityProp))
+                        authorityHost = authorityProp.GetString();
 
                     logger.LogDebug("Resolved environment from config: {Environment}", environment);
                 }
@@ -359,7 +362,7 @@ class Program
                 }
             }
 
-            return new Agent365ToolingService(configService, authService, logger, environment);
+            return new Agent365ToolingService(configService, authService, logger, environment, authorityHost);
         });
 
         // Add Azure validators (individual validators for composition)
@@ -442,4 +445,3 @@ class Program
             .Replace("_", "-");
     }
 }
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
@@ -399,8 +399,22 @@ public sealed class A365CreateInstanceRunner
                 _logger.LogInformation("Granting permissions to agent identity across {Count} resource(s)", requiredPermissions.Count);
 
                 // Get existing oauth2PermissionGrants on the agent identity
-                var existingGrants = await _graphService.GetOauth2PermissionGrantsAsync(
-                    tenantId, agenticSpObjectId, cancellationToken);
+                List<(string resourceId, string scope, string consentType)> existingGrants;
+                try
+                {
+                    existingGrants = await _graphService.GetOauth2PermissionGrantsAsync(
+                        tenantId,
+                        agenticSpObjectId,
+                        cancellationToken);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogError(
+                        ex,
+                        "Failed to read existing OAuth2 permission grants for agent identity {ServicePrincipalId}; no grant changes were attempted.",
+                        agenticSpObjectId);
+                    return false;
+                }
 
                 // Build a lookup: resourceSpObjectId -> set of already-granted scopes
                 var existingScopesByResource = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
@@ -162,6 +162,7 @@ public sealed class A365CreateInstanceRunner
         if (!string.IsNullOrWhiteSpace(configuredClientAppId))
             _graphService.CustomClientAppId = configuredClientAppId;
         var mcpResourceAppId = ConfigConstants.GetAgent365ToolsResourceAppId(environment);
+        var observabilityResourceAppId = ConfigConstants.GetObservabilityApiAppId(environment);
 
         var usageLocation = GetConfig("agentUserUsageLocation");
 
@@ -342,7 +343,7 @@ public sealed class A365CreateInstanceRunner
                             "McpServers.Mail.All",
                             "McpServersMetadata.Read.All"
                         }),
-                    [ConfigConstants.ObservabilityApiAppId] = (
+                    [observabilityResourceAppId] = (
                         "Observability API",
                         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/A365CreateInstanceRunner.cs
@@ -148,6 +148,21 @@ public sealed class A365CreateInstanceRunner
             _logger.LogInformation("Using environment from config: {Env}", environment);
         }
 
+        // Wire the sovereign/government cloud endpoints so all Graph calls and client-credential
+        // token acquisition target the correct national cloud (commercial by default).
+        var configuredGraphBaseUrl = GetConfig("graphBaseUrl");
+        _graphService.GraphBaseUrl = ConfigConstants.GetGraphBaseUrl(
+            environment,
+            string.IsNullOrWhiteSpace(configuredGraphBaseUrl) ? null : configuredGraphBaseUrl);
+        var configuredAuthorityHost = GetConfig("authorityHost");
+        _graphService.AuthorityHost = ConfigConstants.GetAuthorityHost(
+            environment,
+            string.IsNullOrWhiteSpace(configuredAuthorityHost) ? null : configuredAuthorityHost);
+        var configuredClientAppId = GetConfig("clientAppId");
+        if (!string.IsNullOrWhiteSpace(configuredClientAppId))
+            _graphService.CustomClientAppId = configuredClientAppId;
+        var mcpResourceAppId = ConfigConstants.GetAgent365ToolsResourceAppId(environment);
+
         var usageLocation = GetConfig("agentUserUsageLocation");
 
         await SaveInstanceAsync(generatedConfigPath, instance, cancellationToken);
@@ -320,7 +335,7 @@ public sealed class A365CreateInstanceRunner
                     [AuthenticationConstants.MicrosoftGraphResourceAppId] = (
                         "Microsoft Graph",
                         new HashSet<string>(ConfigConstants.DefaultAgentIdentityScopes, StringComparer.OrdinalIgnoreCase)),
-                    [McpConstants.WorkIQToolsProdAppId] = (
+                    [mcpResourceAppId] = (
                         "Work IQ Tools",
                         new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                         {
@@ -657,7 +672,7 @@ public sealed class A365CreateInstanceRunner
                 : correlationId;
 
             using var httpClient = HttpClientFactory.CreateAuthenticatedClient(correlationId: effectiveCorrelationId);
-            var tokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+            var tokenEndpoint = ConfigConstants.BuildTokenEndpointUrl(_graphService.AuthorityHost, tenantId);
             
             var requestBody = new FormUrlEncodedContent(new[]
             {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -20,6 +20,7 @@ public class Agent365ToolingService : IAgent365ToolingService
     private readonly AuthenticationService _authService;
     private readonly ILogger<Agent365ToolingService> _logger;
     private readonly string _environment;
+    private readonly string _authorityHost;
 
     /// <inheritdoc />
     public string Environment => _environment;
@@ -28,12 +29,14 @@ public class Agent365ToolingService : IAgent365ToolingService
         IConfigService configService,
         AuthenticationService authService,
         ILogger<Agent365ToolingService> logger,
-        string environment = "prod")
+        string environment = "prod",
+        string? authorityHost = null)
     {
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
         _authService = authService ?? throw new ArgumentNullException(nameof(authService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _environment = environment ?? "prod";
+        _authorityHost = ConfigConstants.GetAuthorityHost(_environment, authorityHost);
     }
 
     /// <summary>
@@ -343,7 +346,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
             
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint, ct: cancellationToken);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, ct: cancellationToken, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -422,7 +426,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
             
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint, ct: cancellationToken);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, ct: cancellationToken, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -496,7 +501,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
             
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint, ct: cancellationToken);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, ct: cancellationToken, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -583,7 +589,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
             
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint, ct: cancellationToken);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, ct: cancellationToken, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -628,7 +635,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             var endpointUrl = BuildLogRegisterUrl(_environment);
             var audience = ConfigConstants.GetAgent365ToolsResourceAppId(_environment);
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogDebug("Skipping telemetry: failed to acquire token");
@@ -666,7 +674,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             var endpointUrl = BuildLogEvaluateUrl(_environment);
             var audience = ConfigConstants.GetAgent365ToolsResourceAppId(_environment);
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogDebug("Skipping telemetry: failed to acquire token");
@@ -721,7 +730,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
 
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -801,7 +811,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
 
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -873,7 +884,8 @@ public class Agent365ToolingService : IAgent365ToolingService
             _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
 
             var loginHint = await AzCliHelper.ResolveLoginHintAsync();
-            var authToken = await _authService.GetAccessTokenAsync(audience, userId: loginHint);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience, userId: loginHint, authorityHost: _authorityHost);
             if (string.IsNullOrWhiteSpace(authToken))
             {
                 _logger.LogError("Failed to acquire authentication token");
@@ -905,4 +917,3 @@ public class Agent365ToolingService : IAgent365ToolingService
         }
     }
 }
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/AgentBlueprintService.cs
@@ -547,7 +547,18 @@ public class AgentBlueprintService
                      ?? new List<string>();
         if (appIds.Count == 0) return result;
 
-        var blueprintSpObjectId = await _graphApiService.LookupServicePrincipalByAppIdAsync(tenantId, blueprintAppId, ct, requiredScopes);
+        var blueprintLookup = await _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+            tenantId,
+            blueprintAppId,
+            ct,
+            GraphAuthenticationMode.Ambient);
+        if (!blueprintLookup.IsSuccess)
+        {
+            throw new InvalidOperationException(
+                $"Microsoft Graph could not look up the blueprint service principal for app ID '{blueprintAppId}': {blueprintLookup.FailureReason}");
+        }
+
+        var blueprintSpObjectId = blueprintLookup.ServicePrincipalId;
         if (string.IsNullOrWhiteSpace(blueprintSpObjectId))
         {
             _logger.LogWarning("Blueprint service principal not found for app ID {BlueprintAppId} — cannot enumerate granted permissions.", blueprintAppId);
@@ -556,10 +567,12 @@ public class AgentBlueprintService
 
         // One bulk fetch each — by resource SP object ID, not by app ID, so we'll need a resolution table.
         var delegatedByResourceSpId = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-        var allGrants = await _graphApiService.GetOauth2PermissionGrantsAsync(tenantId, blueprintSpObjectId, ct);
+        var allGrants = await _graphApiService.GetOauth2PermissionGrantsAsync(
+            tenantId,
+            blueprintSpObjectId,
+            ct);
         foreach (var (resourceSpId, scope, _) in allGrants)
         {
-            if (string.IsNullOrWhiteSpace(resourceSpId)) continue;
             if (!delegatedByResourceSpId.TryGetValue(resourceSpId, out var list))
             {
                 list = new List<string>();
@@ -571,31 +584,75 @@ public class AgentBlueprintService
         }
 
         var appRoleIdsByResourceSpId = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-        using (var assignmentsDoc = await _graphApiService.GraphGetAsync(
-            tenantId, $"/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments", ct, scopes: requiredScopes))
+        var assignmentsResponse = await _graphApiService.GraphGetWithResponseAsync(
+            tenantId,
+            $"/v1.0/servicePrincipals/{blueprintSpObjectId}/appRoleAssignments",
+            ct: ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+        using (var assignmentsDoc = assignmentsResponse.Json)
         {
-            if (assignmentsDoc != null &&
-                assignmentsDoc.RootElement.TryGetProperty("value", out var assignmentsArr) &&
-                assignmentsArr.ValueKind == JsonValueKind.Array)
+            if (!assignmentsResponse.IsSuccess)
             {
-                foreach (var assignment in assignmentsArr.EnumerateArray())
+                var status = assignmentsResponse.StatusCode > 0
+                    ? $"HTTP {assignmentsResponse.StatusCode} {assignmentsResponse.ReasonPhrase}".TrimEnd()
+                    : assignmentsResponse.ReasonPhrase;
+                throw new InvalidOperationException(
+                    $"Microsoft Graph could not read app role assignments for blueprint service principal '{blueprintSpObjectId}': {status}.");
+            }
+
+            if (assignmentsDoc is null ||
+                assignmentsDoc.RootElement.ValueKind != JsonValueKind.Object ||
+                !assignmentsDoc.RootElement.TryGetProperty("value", out var assignmentsArr) ||
+                assignmentsArr.ValueKind != JsonValueKind.Array)
+            {
+                throw new InvalidOperationException(
+                    $"Microsoft Graph returned an invalid app role assignments response for blueprint service principal '{blueprintSpObjectId}'.");
+            }
+
+            foreach (var assignment in assignmentsArr.EnumerateArray())
+            {
+                if (assignment.ValueKind != JsonValueKind.Object ||
+                    !assignment.TryGetProperty("resourceId", out var resourceIdElement) ||
+                    resourceIdElement.ValueKind != JsonValueKind.String ||
+                    !assignment.TryGetProperty("appRoleId", out var appRoleIdElement) ||
+                    appRoleIdElement.ValueKind != JsonValueKind.String)
                 {
-                    var resId = assignment.TryGetProperty("resourceId", out var r) ? r.GetString() : null;
-                    var roleId = assignment.TryGetProperty("appRoleId", out var ar) ? ar.GetString() : null;
-                    if (string.IsNullOrWhiteSpace(resId) || string.IsNullOrWhiteSpace(roleId)) continue;
-                    if (!appRoleIdsByResourceSpId.TryGetValue(resId, out var list))
-                    {
-                        list = new List<string>();
-                        appRoleIdsByResourceSpId[resId] = list;
-                    }
-                    list.Add(roleId);
+                    throw new InvalidOperationException(
+                        $"Microsoft Graph returned an invalid app role assignment for blueprint service principal '{blueprintSpObjectId}'.");
                 }
+
+                var resourceId = resourceIdElement.GetString()!;
+                var appRoleId = appRoleIdElement.GetString()!;
+                if (!Guid.TryParse(resourceId, out _) ||
+                    !Guid.TryParse(appRoleId, out _))
+                {
+                    throw new InvalidOperationException(
+                        $"Microsoft Graph returned an invalid app role assignment for blueprint service principal '{blueprintSpObjectId}'.");
+                }
+
+                if (!appRoleIdsByResourceSpId.TryGetValue(resourceId, out var list))
+                {
+                    list = new List<string>();
+                    appRoleIdsByResourceSpId[resourceId] = list;
+                }
+                list.Add(appRoleId);
             }
         }
 
         foreach (var resourceAppId in appIds)
         {
-            var resourceSpId = await _graphApiService.LookupServicePrincipalByAppIdAsync(tenantId, resourceAppId, ct, requiredScopes);
+            var resourceLookup = await _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                tenantId,
+                resourceAppId,
+                ct,
+                GraphAuthenticationMode.Ambient);
+            if (!resourceLookup.IsSuccess)
+            {
+                throw new InvalidOperationException(
+                    $"Microsoft Graph could not look up the resource service principal for app ID '{resourceAppId}': {resourceLookup.FailureReason}");
+            }
+
+            var resourceSpId = resourceLookup.ServicePrincipalId;
             if (string.IsNullOrWhiteSpace(resourceSpId))
             {
                 _logger.LogDebug("Resource SP not found for app ID {ResourceAppId} — granted permissions cannot be enumerated.", resourceAppId);
@@ -613,18 +670,56 @@ public class AgentBlueprintService
                 // role IDs fall back to a "<role-id>" placeholder so the operator can still see them.
                 var roleIdSet = new HashSet<string>(roleIds, StringComparer.OrdinalIgnoreCase);
                 var nameById = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                using var resourceSpDoc = await _graphApiService.GraphGetAsync(
-                    tenantId, $"/v1.0/servicePrincipals/{resourceSpId}?$select=appRoles", ct, scopes: requiredScopes);
-                if (resourceSpDoc != null &&
-                    resourceSpDoc.RootElement.TryGetProperty("appRoles", out var rolesEl) &&
-                    rolesEl.ValueKind == JsonValueKind.Array)
+                var roleMetadataResponse = await _graphApiService.GraphGetWithResponseAsync(
+                    tenantId,
+                    $"/v1.0/servicePrincipals/{resourceSpId}?$select=appRoles",
+                    ct: ct,
+                    authenticationMode: GraphAuthenticationMode.Ambient);
+                using var resourceSpDoc = roleMetadataResponse.Json;
+                if (!roleMetadataResponse.IsSuccess)
                 {
-                    foreach (var role in rolesEl.EnumerateArray())
+                    var status = roleMetadataResponse.StatusCode > 0
+                        ? $"HTTP {roleMetadataResponse.StatusCode} {roleMetadataResponse.ReasonPhrase}".TrimEnd()
+                        : roleMetadataResponse.ReasonPhrase;
+                    throw new InvalidOperationException(
+                        $"Microsoft Graph could not read app role metadata for resource service principal '{resourceSpId}': {status}.");
+                }
+
+                if (resourceSpDoc is null ||
+                    resourceSpDoc.RootElement.ValueKind != JsonValueKind.Object ||
+                    !resourceSpDoc.RootElement.TryGetProperty("appRoles", out var rolesEl) ||
+                    rolesEl.ValueKind != JsonValueKind.Array)
+                {
+                    throw new InvalidOperationException(
+                        $"Microsoft Graph returned invalid app role metadata for resource service principal '{resourceSpId}'.");
+                }
+
+                foreach (var role in rolesEl.EnumerateArray())
+                {
+                    if (role.ValueKind != JsonValueKind.Object ||
+                        !role.TryGetProperty("id", out var idElement) ||
+                        idElement.ValueKind != JsonValueKind.String ||
+                        !role.TryGetProperty("value", out var valueElement) ||
+                        (valueElement.ValueKind != JsonValueKind.String &&
+                         valueElement.ValueKind != JsonValueKind.Null))
                     {
-                        var id = role.TryGetProperty("id", out var idEl) ? idEl.GetString() : null;
-                        var name = role.TryGetProperty("value", out var valEl) ? valEl.GetString() : null;
-                        if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(name))
-                            nameById[id] = name;
+                        throw new InvalidOperationException(
+                            $"Microsoft Graph returned invalid app role metadata for resource service principal '{resourceSpId}'.");
+                    }
+
+                    var roleId = idElement.GetString()!;
+                    if (!Guid.TryParse(roleId, out _))
+                    {
+                        throw new InvalidOperationException(
+                            $"Microsoft Graph returned invalid app role metadata for resource service principal '{resourceSpId}'.");
+                    }
+
+                    var roleValue = valueElement.ValueKind == JsonValueKind.String
+                        ? valueElement.GetString()
+                        : null;
+                    if (!string.IsNullOrWhiteSpace(roleValue))
+                    {
+                        nameById[roleId] = roleValue;
                     }
                 }
                 appRoleNames = roleIdSet

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/AuthenticationService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/AuthenticationService.cs
@@ -27,7 +27,8 @@ public interface IAuthenticationService
         IEnumerable<string>? scopes = null,
         bool useInteractiveBrowser = true,
         string? userId = null,
-        CancellationToken ct = default);
+        CancellationToken ct = default,
+        string? authorityHost = null);
 
     Task<string?> ResolveLoginHintFromCacheAsync();
 
@@ -118,14 +119,18 @@ public class AuthenticationService : IAuthenticationService
         IEnumerable<string>? scopes = null,
         bool useInteractiveBrowser = true,
         string? userId = null,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? authorityHost = null)
     {
         // Access tokens are no longer cached to disk by this service. Token persistence and
         // silent re-acquisition are delegated entirely to the OS-protected MSAL persistent cache
         // (managed by MsalBrowserCredential). When forceRefresh is requested, the underlying
         // credential is configured to bypass MSAL's silent cache and acquire a fresh token.
         _logger.LogDebug("Authentication required for Agent 365 Tools");
-        var token = await AuthenticateInteractivelyAsync(resourceUrl, tenantId, clientId, scopes, useInteractiveBrowser, loginHint: userId, forceRefresh: forceRefresh, ct: ct);
+        var token = await AuthenticateInteractivelyAsync(
+            resourceUrl, tenantId, clientId, scopes, useInteractiveBrowser,
+            loginHint: userId, forceRefresh: forceRefresh, ct: ct,
+            authorityHost: authorityHost);
 
         // Self-heal: validate the tid claim in the returned JWT against the requested tenant.
         // WAM may silently select a cached work account from a different tenant when multiple
@@ -147,7 +152,10 @@ public class AuthenticationService : IAuthenticationService
                 await ClearMsalCacheAsync();
                 // Retry once with the same parameters — MSAL disk cache is now empty so WAM
                 // gets a clean slate and will either pick the correct account or prompt.
-                token = await AuthenticateInteractivelyAsync(resourceUrl, tenantId, clientId, scopes, useInteractiveBrowser, loginHint: userId, forceRefresh: forceRefresh, ct: ct);
+                token = await AuthenticateInteractivelyAsync(
+                    resourceUrl, tenantId, clientId, scopes, useInteractiveBrowser,
+                    loginHint: userId, forceRefresh: forceRefresh, ct: ct,
+                    authorityHost: authorityHost);
                 var retryTid = JwtHelper.TryDecodeClaim(token.AccessToken, "tid");
                 if (!string.IsNullOrWhiteSpace(retryTid) &&
                     !string.Equals(retryTid, tenantId, StringComparison.OrdinalIgnoreCase))
@@ -195,7 +203,8 @@ public class AuthenticationService : IAuthenticationService
         bool useInteractiveBrowser = false,
         string? loginHint = null,
         bool forceRefresh = false,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        string? authorityHost = null)
     {
         // Declare variables outside try block so they're available in catch for logging
         string effectiveTenantId = tenantId ?? "unknown";
@@ -274,14 +283,16 @@ public class AuthenticationService : IAuthenticationService
                 // Use MsalBrowserCredential which handles WAM on Windows and browser on other platforms
                 _logger.LogDebug("Using interactive authentication (browser/WAM)...");
 
-                credential = CreateBrowserCredential(effectiveClientId, effectiveTenantId, loginHint: loginHint, forceRefresh: forceRefresh);
+                credential = CreateBrowserCredentialForAuthority(
+                    effectiveClientId, effectiveTenantId, authorityHost, loginHint, forceRefresh);
             }
             else
             {
                 // Device code flow - works in all environments including SSH/remote sessions
                 _logger.LogDebug("Using device code authentication...");
                 _logger.LogDebug("Please sign in with your Microsoft account");
-                credential = CreateDeviceCodeCredential(effectiveClientId, effectiveTenantId);
+                credential = CreateDeviceCodeCredentialForAuthority(
+                    effectiveClientId, effectiveTenantId, authorityHost);
             }
 
             var tokenRequestContext = new TokenRequestContext(scopes);
@@ -295,7 +306,8 @@ public class AuthenticationService : IAuthenticationService
                 _logger.LogWarning("Browser authentication is not supported on this platform, falling back to device code flow...");
                 _logger.LogDebug("Using device code authentication...");
                 _logger.LogDebug("Please sign in with your Microsoft account");
-                var deviceCodeCredential = CreateDeviceCodeCredential(effectiveClientId, effectiveTenantId);
+                var deviceCodeCredential = CreateDeviceCodeCredentialForAuthority(
+                    effectiveClientId, effectiveTenantId, authorityHost);
                 tokenResult = await deviceCodeCredential.GetTokenAsync(tokenRequestContext, ct);
             }
             _logger.LogDebug("Authentication successful!");
@@ -368,6 +380,7 @@ public class AuthenticationService : IAuthenticationService
     /// <param name="clientId">Optional client ID for authentication. If not provided, uses PowerShell client ID</param>
     /// <param name="userId">Optional UPN/email to pre-select the account for WAM and silent acquisition.
     /// When provided, WAM will target this identity instead of the first cached account.</param>
+    /// <param name="authorityHost">Optional OAuth authority host for sovereign cloud authentication.</param>
     /// <returns>Access token with the requested scopes</returns>
     public async Task<string> GetAccessTokenWithScopesAsync(
         string resourceAppId,
@@ -376,7 +389,8 @@ public class AuthenticationService : IAuthenticationService
         bool forceRefresh = false,
         string? clientId = null,
         bool useInteractiveBrowser = true,
-        string? userId = null)
+        string? userId = null,
+        string? authorityHost = null)
     {
         if (string.IsNullOrWhiteSpace(resourceAppId))
             throw new ArgumentException("Resource App ID cannot be empty", nameof(resourceAppId));
@@ -388,7 +402,15 @@ public class AuthenticationService : IAuthenticationService
             resourceAppId, string.Join(", ", scopes));
 
         // Delegate to the consolidated GetAccessTokenAsync method
-        return await GetAccessTokenAsync(resourceAppId, tenantId, forceRefresh, clientId, scopes, useInteractiveBrowser, userId);
+        return await GetAccessTokenAsync(
+            resourceAppId,
+            tenantId,
+            forceRefresh,
+            clientId,
+            scopes,
+            useInteractiveBrowser,
+            userId,
+            authorityHost: authorityHost);
     }
 
     /// <summary>
@@ -545,6 +567,18 @@ public class AuthenticationService : IAuthenticationService
     protected virtual TokenCredential CreateBrowserCredential(string clientId, string tenantId, string? loginHint = null, bool forceRefresh = false)
         => new MsalBrowserCredential(clientId, tenantId, redirectUri: null, _logger, loginHint: loginHint, forceRefresh: forceRefresh);
 
+    private TokenCredential CreateBrowserCredentialForAuthority(
+        string clientId, string tenantId, string? authorityHost, string? loginHint, bool forceRefresh)
+    {
+        var host = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        if (string.Equals(host, ConfigConstants.DefaultAuthorityHost, StringComparison.OrdinalIgnoreCase))
+            return CreateBrowserCredential(clientId, tenantId, loginHint, forceRefresh);
+
+        return new MsalBrowserCredential(
+            clientId, tenantId, redirectUri: null, _logger, authority: $"{host}/{tenantId}",
+            loginHint: loginHint, forceRefresh: forceRefresh);
+    }
+
     /// <summary>
     /// Creates a DeviceCodeCredential configured for interactive device code authentication.
     /// This flow works in all environments including SSH, remote sessions, and platforms where
@@ -552,12 +586,26 @@ public class AuthenticationService : IAuthenticationService
     /// Protected virtual to allow substitution in tests.
     /// </summary>
     protected virtual TokenCredential CreateDeviceCodeCredential(string clientId, string tenantId)
+        => CreateDeviceCodeCredentialCore(clientId, tenantId, AzureAuthorityHosts.AzurePublicCloud);
+
+    private TokenCredential CreateDeviceCodeCredentialForAuthority(
+        string clientId, string tenantId, string? authorityHost)
+    {
+        var host = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        if (string.Equals(host, ConfigConstants.DefaultAuthorityHost, StringComparison.OrdinalIgnoreCase))
+            return CreateDeviceCodeCredential(clientId, tenantId);
+
+        return CreateDeviceCodeCredentialCore(clientId, tenantId, new Uri(host));
+    }
+
+    private DeviceCodeCredential CreateDeviceCodeCredentialCore(
+        string clientId, string tenantId, Uri authorityHost)
     {
         return new DeviceCodeCredential(new DeviceCodeCredentialOptions
         {
             TenantId = tenantId,
             ClientId = clientId,
-            AuthorityHost = AzureAuthorityHosts.AzurePublicCloud,
+            AuthorityHost = authorityHost,
             TokenCachePersistenceOptions = new TokenCachePersistenceOptions
             {
                 Name = AuthenticationConstants.ApplicationName

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/BlueprintLookupService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/BlueprintLookupService.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Text.Json;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Extensions.Logging;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 
@@ -102,6 +103,7 @@ public class BlueprintLookupService
         string tenantId,
         string displayName,
         string signInAudience = "AzureADMultipleOrgs",
+        string? preferredObjectId = null,
         CancellationToken cancellationToken = default)
     {
         try
@@ -112,18 +114,37 @@ public class BlueprintLookupService
             var escapedDisplayName = displayName.Replace("'", "''");
             var filter = $"displayName eq '{escapedDisplayName}' and signInAudience eq '{signInAudience}'";
 
-            var doc = await _graphApiService.GraphGetAsync(
+            var response = await _graphApiService.GraphGetWithResponseAsync(
                 tenantId,
                 $"/beta/applications?$filter={Uri.EscapeDataString(filter)}",
-                cancellationToken);
+                scopes: [AuthenticationConstants.ApplicationReadAllScope],
+                ct: cancellationToken);
 
-            if (doc == null)
+            if (!response.IsSuccess)
             {
-                _logger.LogDebug("No blueprints found with displayName: {DisplayName}", displayName);
+                response.Json?.Dispose();
+                var errorMessage = $"Graph application lookup failed with HTTP {response.StatusCode} {response.ReasonPhrase}.";
+                _logger.LogDebug(
+                    "Blueprint lookup by displayName failed with HTTP {StatusCode} {ReasonPhrase}: {Body}",
+                    response.StatusCode,
+                    response.ReasonPhrase,
+                    response.Body);
                 return new BlueprintLookupResult
                 {
                     Found = false,
-                    LookupMethod = "displayName"
+                    LookupMethod = "displayName",
+                    ErrorMessage = errorMessage
+                };
+            }
+
+            using var doc = response.Json;
+            if (doc == null)
+            {
+                return new BlueprintLookupResult
+                {
+                    Found = false,
+                    LookupMethod = "displayName",
+                    ErrorMessage = "Graph application lookup returned an empty response."
                 };
             }
 
@@ -138,17 +159,44 @@ public class BlueprintLookupService
                 };
             }
 
-            // Take first match (if multiple exist, log warning)
-            var firstMatch = valueElement[0];
-            var objectId = firstMatch.GetProperty("id").GetString();
-            var appId = firstMatch.GetProperty("appId").GetString();
-            var foundDisplayName = firstMatch.GetProperty("displayName").GetString();
-
-            if (valueElement.GetArrayLength() > 1)
+            JsonElement? selectedMatch = null;
+            if (!string.IsNullOrWhiteSpace(preferredObjectId))
             {
-                _logger.LogWarning("Multiple blueprints found with displayName '{DisplayName}'. Using first match: {ObjectId}", 
-                    displayName, objectId);
+                foreach (var candidate in valueElement.EnumerateArray())
+                {
+                    if (string.Equals(
+                            candidate.GetProperty("id").GetString(),
+                            preferredObjectId,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        selectedMatch = candidate;
+                        break;
+                    }
+                }
             }
+
+            if (selectedMatch is null && valueElement.GetArrayLength() == 1)
+            {
+                selectedMatch = valueElement[0];
+            }
+
+            if (selectedMatch is null)
+            {
+                var errorMessage = string.IsNullOrWhiteSpace(preferredObjectId)
+                    ? $"Multiple blueprints were found with display name '{displayName}'."
+                    : $"Multiple blueprints were found with display name '{displayName}', but none matched the stored object ID '{preferredObjectId}'.";
+                _logger.LogWarning("{ErrorMessage}", errorMessage);
+                return new BlueprintLookupResult
+                {
+                    Found = false,
+                    LookupMethod = "displayName",
+                    ErrorMessage = errorMessage
+                };
+            }
+
+            var objectId = selectedMatch.Value.GetProperty("id").GetString();
+            var appId = selectedMatch.Value.GetProperty("appId").GetString();
+            var foundDisplayName = selectedMatch.Value.GetProperty("displayName").GetString();
 
             _logger.LogDebug("Found blueprint: {DisplayName} (ObjectId: {ObjectId}, AppId: {AppId})", 
                 foundDisplayName, objectId, appId);
@@ -162,6 +210,10 @@ public class BlueprintLookupService
                 LookupMethod = "displayName",
                 RequiresPersistence = true
             };
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/BootstrapConfigResolver.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/BootstrapConfigResolver.cs
@@ -239,7 +239,7 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         }
     }
 
-    private async Task<string> GetBootstrapEnvironmentAsync()
+    private async Task<string> GetBootstrapEnvironmentAsync(CancellationToken ct)
     {
         var configuredEnvironment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT");
         if (!string.IsNullOrWhiteSpace(configuredEnvironment))
@@ -249,7 +249,7 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         {
             var result = await _executor.ExecuteAsync(
                 "az", "cloud show --query name -o tsv",
-                captureOutput: true, suppressErrorLogging: true);
+                captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
             var cloudName = result.StandardOutput?.Trim();
             return string.IsNullOrWhiteSpace(cloudName) ? "prod" : cloudName;
         }
@@ -271,7 +271,7 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         if (tenantId is null)
             return null;
 
-        var environment = await GetBootstrapEnvironmentAsync();
+        var environment = await GetBootstrapEnvironmentAsync(ct);
         _graphApiService?.ConfigureCloudEndpoints(new Agent365Config { Environment = environment });
 
         var clientAppId = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
@@ -320,7 +320,7 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
             return null;
         }
 
-        var environment = await GetBootstrapEnvironmentAsync();
+        var environment = await GetBootstrapEnvironmentAsync(ct);
         _graphApiService?.ConfigureCloudEndpoints(new Agent365Config { Environment = environment });
 
         // Step 2: Resolve client app ID — prefer local a365.config.json when tenant matches.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/BootstrapConfigResolver.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/BootstrapConfigResolver.cs
@@ -146,6 +146,9 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         {
             ["tenantId"] = config.TenantId,
             ["clientAppId"] = config.ClientAppId,
+            ["environment"] = config.Environment,
+            ["graphBaseUrl"] = config.GraphBaseUrl,
+            ["authorityHost"] = config.AuthorityHost,
             ["agentIdentityDisplayName"] = config.AgentIdentityDisplayName,
             ["agentBlueprintDisplayName"] = config.AgentBlueprintDisplayName,
             ["agentDescription"] = config.AgentDescription,
@@ -236,6 +239,27 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         }
     }
 
+    private async Task<string> GetBootstrapEnvironmentAsync()
+    {
+        var configuredEnvironment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT");
+        if (!string.IsNullOrWhiteSpace(configuredEnvironment))
+            return configuredEnvironment;
+
+        try
+        {
+            var result = await _executor.ExecuteAsync(
+                "az", "cloud show --query name -o tsv",
+                captureOutput: true, suppressErrorLogging: true);
+            var cloudName = result.StandardOutput?.Trim();
+            return string.IsNullOrWhiteSpace(cloudName) ? "prod" : cloudName;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to resolve current Azure CLI cloud; using the default environment.");
+            return "prod";
+        }
+    }
+
     // ── Private helpers ────────────────────────────────────────────────────────
 
     private async Task<Agent365Config?> BuildBootstrapConfigAsync(
@@ -246,6 +270,9 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         var tenantId = await SetupHelpers.ResolveBootstrapTenantIdAsync(tenantIdFlag, _executor, _logger);
         if (tenantId is null)
             return null;
+
+        var environment = await GetBootstrapEnvironmentAsync();
+        _graphApiService?.ConfigureCloudEndpoints(new Agent365Config { Environment = environment });
 
         var clientAppId = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
             tenantId, _graphApiService, _logger, ct);
@@ -259,6 +286,9 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         {
             TenantId = tenantId,
             ClientAppId = clientAppId,
+            Environment = environment,
+            GraphBaseUrl = _graphApiService?.GraphBaseUrl ?? ConfigConstants.GetGraphBaseUrl(environment),
+            AuthorityHost = _graphApiService?.AuthorityHost ?? ConfigConstants.GetAuthorityHost(environment),
             AgentIdentityDisplayName = $"{agentName} Identity",
             AgentBlueprintDisplayName = $"{agentName} Blueprint",
             AgentDescription = agentName,
@@ -289,6 +319,9 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
             _logger.LogError("Could not detect tenant ID. Sign in with 'az login' or pass --tenant-id.");
             return null;
         }
+
+        var environment = await GetBootstrapEnvironmentAsync();
+        _graphApiService?.ConfigureCloudEndpoints(new Agent365Config { Environment = environment });
 
         // Step 2: Resolve client app ID — prefer local a365.config.json when tenant matches.
         var resolvedClientAppId = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
@@ -379,6 +412,9 @@ internal sealed class BootstrapConfigResolver : IBootstrapConfigResolver
         {
             TenantId = tenantId,
             ClientAppId = resolvedClientAppId,
+            Environment = environment,
+            GraphBaseUrl = _graphApiService?.GraphBaseUrl ?? ConfigConstants.GetGraphBaseUrl(environment),
+            AuthorityHost = _graphApiService?.AuthorityHost ?? ConfigConstants.GetAuthorityHost(environment),
             AgentIdentityDisplayName = $"{agentName} Identity",
             AgentBlueprintDisplayName = blueprintDisplayName,
             AgentDescription = agentName,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -889,6 +889,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             // Best-effort: also extend the existing oauth2PermissionGrant so consent takes effect immediately
             await TryExtendConsentGrantScopesAsync(clientAppId, missingPermissions, tenantId, ct);
 
+            // Tokens issued before the permission update cannot carry the newly consented scopes.
+            await _graphApiService.ClearTokenCacheAsync();
+
             return true;
         }
         catch (Exception ex)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -465,7 +465,10 @@ public sealed class ClientAppValidator : IClientAppValidator
             _logger.LogDebug("Checking redirect URIs for client app {ClientAppId}", clientAppId);
 
             using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient", ct);
+                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (appDoc == null)
             {
@@ -522,7 +525,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 new JsonObject { ["publicClient"] = new JsonObject { ["redirectUris"] = urisArray } },
-                ct);
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (!patchSuccess)
             {
@@ -614,7 +619,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 patchPayload,
-                ct);
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (!patchSuccess)
             {
@@ -698,7 +705,10 @@ public sealed class ClientAppValidator : IClientAppValidator
             _logger.LogDebug("Checking 'Allow public client flows' for client app {ClientAppId}", clientAppId);
 
             using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient", ct);
+                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (appDoc == null)
             {
@@ -740,7 +750,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 new { isFallbackPublicClient = true },
-                ct);
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (!patchSuccess)
             {
@@ -861,7 +873,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
                 $"/v1.0/applications/{appInfo.ObjectId}",
                 new JsonObject { ["requiredResourceAccess"] = updatedResourceAccess },
-                ct);
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (!patchSuccess)
             {
@@ -899,7 +913,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         {
             // Look up the service principal for the client app
             using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
+                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (spDoc == null) return;
 
@@ -909,7 +926,10 @@ public sealed class ClientAppValidator : IClientAppValidator
 
             // Find the oauth2PermissionGrant that targets Microsoft Graph
             using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
+                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (grantsDoc == null) return;
 
@@ -920,7 +940,10 @@ public sealed class ClientAppValidator : IClientAppValidator
             // Look up the Microsoft Graph service principal ID to match against resourceId
             string? graphSpObjectId = null;
             using var graphSpDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/servicePrincipals?$filter=appId eq '{AuthenticationConstants.MicrosoftGraphResourceAppId}'&$select=id", ct);
+                $"/v1.0/servicePrincipals?$filter=appId eq '{AuthenticationConstants.MicrosoftGraphResourceAppId}'&$select=id",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (graphSpDoc != null)
             {
@@ -961,7 +984,9 @@ public sealed class ClientAppValidator : IClientAppValidator
                         ["consentType"] = "AllPrincipals",
                         ["principalId"] = null
                     },
-                    ct);
+                    ct,
+                    scopes: null,
+                    authenticationMode: GraphAuthenticationMode.Ambient);
 
                 if (patchSuccess)
                 {
@@ -1072,7 +1097,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient", ct);
+                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (appDoc == null) return new List<string>();
 
@@ -1112,7 +1140,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient", ct);
+                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (appDoc == null) return false;
 
@@ -1149,7 +1180,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,optionalClaims", ct);
+                $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,optionalClaims",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (appDoc == null) return (false, null, null);
 
@@ -1204,7 +1238,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
+                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
             if (spDoc == null) return false;
 
             var spJson = JsonNode.Parse(spDoc.RootElement.GetRawText());
@@ -1212,7 +1249,10 @@ public sealed class ClientAppValidator : IClientAppValidator
             if (string.IsNullOrWhiteSpace(spObjectId)) return false;
 
             using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
+                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
             if (grantsDoc == null) return false;
 
             var grantsJson = JsonNode.Parse(grantsDoc.RootElement.GetRawText());
@@ -1259,7 +1299,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
+                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
             if (spDoc == null) return;
 
             var spJson = JsonNode.Parse(spDoc.RootElement.GetRawText());
@@ -1267,7 +1310,10 @@ public sealed class ClientAppValidator : IClientAppValidator
             if (string.IsNullOrWhiteSpace(spObjectId)) return;
 
             using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
+                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
             if (grantsDoc == null) return;
 
             var grantsJson = JsonNode.Parse(grantsDoc.RootElement.GetRawText());
@@ -1302,7 +1348,9 @@ public sealed class ClientAppValidator : IClientAppValidator
                         ["principalId"] = null,
                         ["scope"] = scope
                     },
-                    ct);
+                    ct,
+                    scopes: null,
+                    authenticationMode: GraphAuthenticationMode.Ambient);
 
                 if (patchSuccess)
                     _logger.LogInformation("Consent grant upgraded to AllPrincipals — all tenant users can now authenticate without individual consent prompts.");
@@ -1324,7 +1372,9 @@ public sealed class ClientAppValidator : IClientAppValidator
 
         const string path = "/v1.0/applications?$filter=appId eq '{0}'&$select=id,appId,displayName,requiredResourceAccess";
         var graphResponse = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-            string.Format(path, clientAppId), ct: ct);
+            string.Format(path, clientAppId),
+            ct: ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
 
         if (graphResponse == null || !graphResponse.IsSuccess)
         {
@@ -1334,27 +1384,72 @@ public sealed class ClientAppValidator : IClientAppValidator
             if (graphResponse?.StatusCode != 401)
             {
                 _logger.LogDebug("Graph app query failed with {StatusCode} — not retrying", graphResponse?.StatusCode);
-                return null;
+                throw ClientAppValidationException.ValidationFailed(
+                    "Unable to verify the client app registration",
+                    [$"Microsoft Graph application lookup failed: HTTP {graphResponse?.StatusCode ?? 0} {graphResponse?.ReasonPhrase ?? "Unknown"}."],
+                    clientAppId);
             }
 
             _logger.LogDebug("Graph app query returned 401 — retrying with fresh token (possible CAE revocation)");
             graphResponse = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-                string.Format(path, clientAppId), forceRefresh: true, ct: ct);
+                string.Format(path, clientAppId),
+                forceRefresh: true,
+                ct: ct,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (!graphResponse.IsSuccess)
-                throw ClientAppValidationException.TokenRevoked(clientAppId);
+            {
+                if (graphResponse.StatusCode == 401)
+                    throw ClientAppValidationException.TokenRevoked(clientAppId);
+
+                throw ClientAppValidationException.ValidationFailed(
+                    "Unable to verify the client app registration",
+                    [$"Microsoft Graph application lookup failed after token refresh: HTTP {graphResponse.StatusCode} {graphResponse.ReasonPhrase}."],
+                    clientAppId);
+            }
         }
 
         using var doc = graphResponse.Json;
-        if (doc == null) return null;
+        if (doc is null)
+        {
+            throw ClientAppValidationException.ValidationFailed(
+                "Unable to verify the client app registration",
+                ["Microsoft Graph application lookup returned an empty response body."],
+                clientAppId);
+        }
 
-        var response = JsonNode.Parse(doc.RootElement.GetRawText());
-        var apps = response?["value"]?.AsArray();
-        if (apps == null || apps.Count == 0) return null;
+        if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+            !doc.RootElement.TryGetProperty("value", out var appsElement) ||
+            appsElement.ValueKind != JsonValueKind.Array)
+        {
+            throw ClientAppValidationException.ValidationFailed(
+                "Unable to verify the client app registration",
+                ["Microsoft Graph application lookup returned an invalid response."],
+                clientAppId);
+        }
 
-        var app = apps[0]!.AsObject();
+        if (appsElement.GetArrayLength() == 0) return null;
+
+        var firstApp = appsElement[0];
+        if (firstApp.ValueKind != JsonValueKind.Object ||
+            !firstApp.TryGetProperty("id", out var objectIdElement) ||
+            objectIdElement.ValueKind != JsonValueKind.String ||
+            !Guid.TryParse(objectIdElement.GetString(), out var objectId) ||
+            !firstApp.TryGetProperty("appId", out var appIdElement) ||
+            appIdElement.ValueKind != JsonValueKind.String ||
+            !Guid.TryParse(appIdElement.GetString(), out var returnedAppId) ||
+            !Guid.TryParse(clientAppId, out var expectedAppId) ||
+            returnedAppId != expectedAppId)
+        {
+            throw ClientAppValidationException.ValidationFailed(
+                "Unable to verify the client app registration",
+                ["Microsoft Graph application lookup returned an invalid application record."],
+                clientAppId);
+        }
+
+        var app = JsonNode.Parse(firstApp.GetRawText())!.AsObject();
         return new ClientAppInfo(
-            app["id"]?.GetValue<string>() ?? string.Empty,
+            objectId.ToString("D"),
             app["displayName"]?.GetValue<string>() ?? string.Empty,
             app["requiredResourceAccess"]?.AsArray());
     }
@@ -1440,7 +1535,9 @@ public sealed class ClientAppValidator : IClientAppValidator
         {
             using var doc = await _graphApiService.GraphGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{AuthenticationConstants.MicrosoftGraphResourceAppId}'&$select=id,oauth2PermissionScopes",
-                ct);
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (doc == null)
             {
@@ -1499,7 +1596,10 @@ public sealed class ClientAppValidator : IClientAppValidator
         {
             // Get service principal for the app
             using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
-                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
+                $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id",
+                ct,
+                scopes: null,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
             if (spDoc == null)
             {
@@ -1530,7 +1630,9 @@ public sealed class ClientAppValidator : IClientAppValidator
             // "permissions not consented" prompt for non-admin developers who can never read
             // the grants table by design).
             var grantsResp = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct: ct);
+                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'",
+                ct: ct,
+                authenticationMode: GraphAuthenticationMode.Ambient);
             using var grantsDoc = grantsResp.Json;
 
             if (grantsResp.StatusCode == 403)
@@ -1587,7 +1689,10 @@ public sealed class ClientAppValidator : IClientAppValidator
 
         // Get service principal for the app
         using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
-            $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id,appId", ct);
+            $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id,appId",
+            ct,
+            scopes: null,
+            authenticationMode: GraphAuthenticationMode.Ambient);
 
         if (spDoc == null)
         {
@@ -1618,7 +1723,9 @@ public sealed class ClientAppValidator : IClientAppValidator
         // (token acquisition, network, 5xx) — the user-facing message differs and lumping them
         // together would either misattribute the cause or hide real failures.
         var grantsResp = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-            $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct: ct);
+            $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'",
+            ct: ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
         using var grantsDoc = grantsResp.Json;
 
         if (grantsResp.StatusCode == 403)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -165,7 +165,7 @@ public sealed class ClientAppValidator : IClientAppValidator
                         missingDetails.Add("OAuth2 consent grant must be upgraded from per-user (Principal) to tenant-wide (AllPrincipals)");
                     if (needsWidsClaim)
                         missingDetails.Add("'wids' optional claim missing on access tokens — without it, role detection always returns Unknown and the AllPrincipals grant phase silently skips, leaving the agent blueprint with no permissions granted on its service principal");
-                    var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId);
+                    var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId, _graphApiService.AuthorityHost);
                     var steps = new List<string>
                     {
                         "Next Steps — Global Administrator action required:",
@@ -289,7 +289,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             // Step 4: Verify admin consent (requires AllPrincipals grant)
             if (!await ValidateAdminConsentAsync(clientAppId, tenantId, ct))
             {
-                throw ClientAppValidationException.MissingAdminConsent(clientAppId, tenantId);
+                throw ClientAppValidationException.MissingAdminConsent(clientAppId, tenantId, _graphApiService.AuthorityHost);
             }
 
             // Step 5: Verify and fix redirect URIs
@@ -1570,7 +1570,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             }
 
             // Print the admin consent URL so the user (or their admin) can fix this immediately
-            var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId);
+            var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(clientAppId, tenantId, _graphApiService.AuthorityHost);
             if (consentUrl != null)
             {
                 _logger.LogInformation("To grant tenant-wide admin consent, share this URL with a Global Administrator:");

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/DelegatedConsentService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/DelegatedConsentService.cs
@@ -120,8 +120,10 @@ public sealed class DelegatedConsentService
                     var result = await EnsureScopeOnGrantAsync(httpClient, grant, TargetScope, cancellationToken);
                     if (result == ScopeGrantResult.NeedsAdminConsent)
                     {
-                        var scopeUri = Uri.EscapeDataString($"{AuthenticationConstants.MicrosoftGraphResourceUri}/{TargetScope}");
-                        var consentUrl = $"https://login.microsoftonline.com/{tenantId}/v2.0/adminconsent?client_id={callingAppId}&scope={scopeUri}";
+                        var graphResourceUri = GraphApiConstants.GetResource(_graphService.GraphBaseUrl).TrimEnd('/');
+                        var scopeUri = Uri.EscapeDataString($"{graphResourceUri}/{TargetScope}");
+                        var consentBaseUrl = ConfigConstants.BuildAdminConsentEndpointUrl(_graphService.AuthorityHost, tenantId);
+                        var consentUrl = $"{consentBaseUrl}?client_id={callingAppId}&scope={scopeUri}";
                         _logger.LogError(
                             "The existing permission grant could not be updated to include '{Scope}'. " +
                             "An administrator ({Roles}) must grant admin consent. " +
@@ -192,7 +194,7 @@ public sealed class DelegatedConsentService
 
             // Create new service principal
             _logger.LogDebug("Creating service principal for app {AppId}", appId);
-            var createSpUrl = $"{GraphApiConstants.BaseUrl}/v1.0/servicePrincipals";
+            var createSpUrl = $"{_graphService.GraphBaseUrl}/v1.0/servicePrincipals";
             var createBody = new
             {
                 appId = appId
@@ -350,7 +352,7 @@ public sealed class DelegatedConsentService
     {
         try
         {
-            var url = $"{GraphApiConstants.BaseUrl}/v1.0/servicePrincipals?$filter=appId eq '{appId}'";
+            var url = $"{_graphService.GraphBaseUrl}/v1.0/servicePrincipals?$filter=appId eq '{appId}'";
             using var response = await httpClient.GetAsync(url, cancellationToken);
 
             if (!response.IsSuccessStatusCode)
@@ -391,7 +393,7 @@ public sealed class DelegatedConsentService
         try
         {
             var filter = $"clientId eq '{clientId}' and resourceId eq '{resourceId}' and consentType eq '{AllPrincipalsConsentType}'";
-            var url = $"{GraphApiConstants.BaseUrl}/v1.0/oauth2PermissionGrants?$filter={Uri.EscapeDataString(filter)}";
+            var url = $"{_graphService.GraphBaseUrl}/v1.0/oauth2PermissionGrants?$filter={Uri.EscapeDataString(filter)}";
 
             using var response = await httpClient.GetAsync(url, cancellationToken);
 
@@ -458,7 +460,7 @@ public sealed class DelegatedConsentService
             _logger.LogDebug("    Updating grant {GrantId} to include scope: {Scope}", grantId, scopeToAdd);
 
             // Update the grant
-            var updateUrl = $"{GraphApiConstants.BaseUrl}/v1.0/oauth2PermissionGrants/{grantId}";
+            var updateUrl = $"{_graphService.GraphBaseUrl}/v1.0/oauth2PermissionGrants/{grantId}";
             var updateBody = new
             {
                 scope = newScope
@@ -509,7 +511,7 @@ public sealed class DelegatedConsentService
     {
         try
         {
-            var createUrl = $"{GraphApiConstants.BaseUrl}/v1.0/oauth2PermissionGrants";
+            var createUrl = $"{_graphService.GraphBaseUrl}/v1.0/oauth2PermissionGrants";
             var createBody = new
             {
                 clientId = clientId,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -1321,7 +1321,10 @@ public class GraphApiService
     /// <param name="tenantId">Azure AD tenant ID</param>
     /// <param name="clientSpObjectId">Object ID of the service principal to check grants for</param>
     /// <param name="ct">Cancellation token</param>
-    /// <returns>List of grants with their scope strings and consent types, or empty list on failure</returns>
+    /// <returns>List of grants with their scope strings and consent types.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Microsoft Graph could not return a valid permission-grants response.
+    /// </exception>
     public virtual async Task<List<(string resourceId, string scope, string consentType)>> GetOauth2PermissionGrantsAsync(
         string tenantId,
         string clientSpObjectId,
@@ -1329,22 +1332,58 @@ public class GraphApiService
     {
         var grants = new List<(string resourceId, string scope, string consentType)>();
 
-        using var doc = await GraphGetAsync(
+        var response = await GraphGetWithResponseAsync(
             tenantId,
             $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{clientSpObjectId}'",
-            ct);
+            ct: ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+        using var doc = response.Json;
 
-        if (doc == null) return grants;
-
-        if (doc.RootElement.TryGetProperty("value", out var arr))
+        if (!response.IsSuccess)
         {
-            foreach (var grant in arr.EnumerateArray())
+            var status = response.StatusCode > 0
+                ? $"HTTP {response.StatusCode} {response.ReasonPhrase}".TrimEnd()
+                : response.ReasonPhrase;
+            throw new InvalidOperationException(
+                string.IsNullOrWhiteSpace(status)
+                    ? $"Microsoft Graph could not read OAuth2 permission grants for service principal '{clientSpObjectId}'."
+                    : $"Microsoft Graph could not read OAuth2 permission grants for service principal '{clientSpObjectId}': {status}.");
+        }
+
+        if (doc is null ||
+            doc.RootElement.ValueKind != JsonValueKind.Object ||
+            !doc.RootElement.TryGetProperty("value", out var arr) ||
+            arr.ValueKind != JsonValueKind.Array)
+        {
+            throw new InvalidOperationException(
+                $"Microsoft Graph returned an invalid OAuth2 permission grants response for service principal '{clientSpObjectId}'.");
+        }
+
+        foreach (var grant in arr.EnumerateArray())
+        {
+            if (grant.ValueKind != JsonValueKind.Object ||
+                !grant.TryGetProperty("resourceId", out var rid) ||
+                rid.ValueKind != JsonValueKind.String ||
+                !grant.TryGetProperty("scope", out var scopeElement) ||
+                scopeElement.ValueKind != JsonValueKind.String ||
+                !grant.TryGetProperty("consentType", out var consentTypeElement) ||
+                consentTypeElement.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(consentTypeElement.GetString()))
             {
-                var resourceId = grant.TryGetProperty("resourceId", out var rid) ? rid.GetString() ?? "" : "";
-                var scope = grant.TryGetProperty("scope", out var s) ? s.GetString() ?? "" : "";
-                var consentType = grant.TryGetProperty("consentType", out var ct2) ? ct2.GetString() ?? "" : "";
-                grants.Add((resourceId, scope, consentType));
+                throw new InvalidOperationException(
+                    $"Microsoft Graph returned an invalid OAuth2 permission grant for service principal '{clientSpObjectId}'.");
             }
+
+            var resourceId = rid.GetString()!;
+            if (!Guid.TryParse(resourceId, out _))
+            {
+                throw new InvalidOperationException(
+                    $"Microsoft Graph returned an invalid OAuth2 permission grant for service principal '{clientSpObjectId}'.");
+            }
+
+            var scope = scopeElement.GetString()!;
+            var consentType = consentTypeElement.GetString()!;
+            grants.Add((resourceId, scope, consentType));
         }
 
         return grants;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -275,9 +275,9 @@ public class GraphApiService
         //    that need claims from the custom-app JWT (e.g. CheckDirectoryRoleAsync) must guard
         //    for both `_tokenProvider == null` and an empty `CustomClientAppId` themselves.
         //
-        // 4. GraphAuthenticationMode.Ambient: the caller is probing whether a client app exists.
-        //    Authenticating as that app would make its own absence unverifiable, so the resolved
-        //    client app and requested scopes are ignored and the bootstrap path below is used.
+        // 4. GraphAuthenticationMode.Ambient: the caller is diagnosing or repairing a client app.
+        //    Authenticating as that app would make an underconfigured registration unable to
+        //    authorize its own repair, so the resolved app and requested scopes are ignored.
         //
         // All paths go through MSAL — no az CLI subprocess involved.
 
@@ -395,9 +395,36 @@ public class GraphApiService
     /// Executes a GET request to Microsoft Graph API.
     /// Virtual to allow mocking in unit tests using Moq.
     /// </summary>
-    public virtual async Task<JsonDocument?> GraphGetAsync(string tenantId, string relativePath, CancellationToken ct = default, IEnumerable<string>? scopes = null)
+    public virtual Task<JsonDocument?> GraphGetAsync(
+        string tenantId,
+        string relativePath,
+        CancellationToken ct = default,
+        IEnumerable<string>? scopes = null)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct)) return null;
+        return GraphGetAsync(
+            tenantId,
+            relativePath,
+            ct,
+            scopes,
+            GraphAuthenticationMode.ResolvedClientApp);
+    }
+
+    /// <summary>
+    /// Executes a GET request to Microsoft Graph API using the selected authentication identity.
+    /// </summary>
+    public virtual async Task<JsonDocument?> GraphGetAsync(
+        string tenantId,
+        string relativePath,
+        CancellationToken ct,
+        IEnumerable<string>? scopes,
+        GraphAuthenticationMode authenticationMode)
+    {
+        if (!await EnsureGraphHeadersAsync(
+                tenantId,
+                scopes: scopes,
+                ct: ct,
+                authenticationMode: authenticationMode))
+            return null;
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
         try
         {
@@ -585,9 +612,39 @@ public class GraphApiService
     /// Executes a PATCH request to Microsoft Graph API.
     /// Virtual to allow mocking in unit tests using Moq.
     /// </summary>
-    public virtual async Task<bool> GraphPatchAsync(string tenantId, string relativePath, object payload, CancellationToken ct = default, IEnumerable<string>? scopes = null)
+    public virtual Task<bool> GraphPatchAsync(
+        string tenantId,
+        string relativePath,
+        object payload,
+        CancellationToken ct = default,
+        IEnumerable<string>? scopes = null)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct)) return false;
+        return GraphPatchAsync(
+            tenantId,
+            relativePath,
+            payload,
+            ct,
+            scopes,
+            GraphAuthenticationMode.ResolvedClientApp);
+    }
+
+    /// <summary>
+    /// Executes a PATCH request to Microsoft Graph API using the selected authentication identity.
+    /// </summary>
+    public virtual async Task<bool> GraphPatchAsync(
+        string tenantId,
+        string relativePath,
+        object payload,
+        CancellationToken ct,
+        IEnumerable<string>? scopes,
+        GraphAuthenticationMode authenticationMode)
+    {
+        if (!await EnsureGraphHeadersAsync(
+                tenantId,
+                scopes: scopes,
+                ct: ct,
+                authenticationMode: authenticationMode))
+            return false;
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         try

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -183,7 +183,11 @@ public class GraphApiService
     /// can invalidate after an operation that makes cached tokens stale — most commonly after adding
     /// the <c>wids</c> optional claim to the client app registration.
     /// </summary>
-    public virtual Task ClearTokenCacheAsync() => _authService.ClearTokenCacheAsync();
+    public virtual async Task ClearTokenCacheAsync()
+    {
+        _tokenProvider?.ClearTokenCache();
+        await _authService.ClearTokenCacheAsync();
+    }
 
     /// <summary>
     /// Acquires an access token for Microsoft Graph API via MSAL (WAM on Windows,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -27,6 +27,11 @@ public class GraphApiService
     private readonly IAuthenticationService _authService;
     private readonly RetryHelper _retryHelper;
     private string _graphBaseUrl;
+    private string _authorityHost = ConfigConstants.DefaultAuthorityHost;
+    private string? GraphBaseUrlOverride =>
+        string.Equals(_graphBaseUrl, GraphApiConstants.BaseUrl, StringComparison.OrdinalIgnoreCase) ? null : _graphBaseUrl;
+    private string? AuthorityHostOverride =>
+        string.Equals(_authorityHost, ConfigConstants.DefaultAuthorityHost, StringComparison.OrdinalIgnoreCase) ? null : _authorityHost;
 
     // Login hint resolved once per GraphApiService instance.
     // Used to direct MSAL/WAM to the correct identity, preventing the Windows default
@@ -62,7 +67,29 @@ public class GraphApiService
     public string GraphBaseUrl
     {
         get => _graphBaseUrl;
-        set => _graphBaseUrl = string.IsNullOrWhiteSpace(value) ? GraphApiConstants.BaseUrl : value;
+        set => _graphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(value);
+    }
+
+    /// <summary>
+    /// OAuth authority host used for token acquisition.
+    /// </summary>
+    public string AuthorityHost
+    {
+        get => _authorityHost;
+        set => _authorityHost = ConfigConstants.NormalizeAuthorityHost(value);
+    }
+
+    /// <summary>
+    /// Applies cloud endpoints and the custom client app from a loaded project config.
+    /// </summary>
+    public void ConfigureCloudEndpoints(Agent365Config config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        GraphBaseUrl = ConfigConstants.GetGraphBaseUrl(config.Environment, config.GraphBaseUrl);
+        AuthorityHost = ConfigConstants.GetAuthorityHost(config.Environment, config.AuthorityHost);
+        if (!string.IsNullOrWhiteSpace(config.ClientAppId))
+            CustomClientAppId = config.ClientAppId;
     }
 
     // Lightweight wrapper to surface HTTP status, reason and body to callers
@@ -88,7 +115,7 @@ public class GraphApiService
         _retryHelper = retryHelper ?? new RetryHelper(_logger);
         // Default: try az CLI first (if present), fall back to JWT cache in AuthenticationService.
         _loginHintResolver = loginHintResolver ?? (() => ResolveLoginHintWithFallbackAsync(authService));
-        _graphBaseUrl = string.IsNullOrWhiteSpace(graphBaseUrl) ? GraphApiConstants.BaseUrl : graphBaseUrl;
+        _graphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
         _agentRegistryRetryDelay = agentRegistryRetryDelay ?? TimeSpan.FromSeconds(30);
     }
 
@@ -146,7 +173,9 @@ public class GraphApiService
         {
             var resource = GraphApiConstants.GetResource(_graphBaseUrl);
             var loginHint = await _loginHintResolver();
-            var token = await _authService.GetAccessTokenAsync(resource, tenantId, forceRefresh: forceRefresh, userId: loginHint, ct: ct);
+            var token = await _authService.GetAccessTokenAsync(
+                resource, tenantId, forceRefresh: forceRefresh, userId: loginHint, ct: ct,
+                authorityHost: AuthorityHostOverride);
             if (!string.IsNullOrWhiteSpace(token))
             {
                 _logger.LogDebug("Graph API access token acquired successfully");
@@ -210,7 +239,9 @@ public class GraphApiService
                 "Acquiring Graph token via token provider (clientId: {AppId}, scopes: {Scopes})",
                 CustomClientAppId, string.Join(", ", effectiveScopes));
             var loginHint = await ResolveLoginHintAsync();
-            token = await _tokenProvider.GetMgGraphAccessTokenAsync(tenantId, effectiveScopes, false, CustomClientAppId, ct, loginHint, forceRefresh);
+            token = await _tokenProvider.GetMgGraphAccessTokenAsync(
+                tenantId, effectiveScopes, false, CustomClientAppId, ct, loginHint, forceRefresh,
+                GraphBaseUrlOverride, AuthorityHostOverride);
 
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -1177,7 +1208,7 @@ public class GraphApiService
                 clientAppId: CustomClientAppId,
                 ct: ct,
                 loginHint: loginHint,
-                forceRefresh: false);
+                forceRefresh: false, graphBaseUrl: GraphBaseUrlOverride, authorityHost: AuthorityHostOverride);
             if (string.IsNullOrWhiteSpace(token))
                 return Models.RoleCheckResult.Unknown;
 
@@ -1377,7 +1408,7 @@ public class GraphApiService
         // Use .default so the token includes all permissions consented on the "Agent 365 CLI" app,
         // including AgentRegistration.ReadWrite.All, without enumerating scopes explicitly.
         IEnumerable<string>? registrationScopes = _tokenProvider != null
-            ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
+            ? [$"{_graphBaseUrl}/.default"]
             : null;
 
         var now = DateTimeOffset.UtcNow.ToString("o");
@@ -1493,10 +1524,10 @@ public class GraphApiService
         // Use .default so the token includes all permissions consented on the "Agent 365 CLI" app,
         // including AgentRegistration.ReadWrite.All, without enumerating scopes explicitly.
         IEnumerable<string>? scopes = _tokenProvider != null
-            ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
+            ? [$"{_graphBaseUrl}/.default"]
             : null;
 
-        _logger.LogInformation("DELETE https://graph.microsoft.com{Path}/{RegistrationId}", AgentRegistrationsPath, registrationId);
+        _logger.LogInformation("DELETE {GraphBaseUrl}{Path}/{RegistrationId}", _graphBaseUrl, AgentRegistrationsPath, registrationId);
 
         return await GraphDeleteAsync(
             tenantId,
@@ -1519,11 +1550,11 @@ public class GraphApiService
         CancellationToken ct = default)
     {
         IEnumerable<string>? scopes = _tokenProvider != null
-            ? [$"{Constants.AuthenticationConstants.MicrosoftGraphResourceUri}/.default"]
+            ? [$"{_graphBaseUrl}/.default"]
             : null;
 
         var path = $"{AgentRegistrationsPath}/{Uri.EscapeDataString(registrationId)}";
-        _logger.LogDebug("GET https://graph.microsoft.com{Path}", path);
+        _logger.LogDebug("GET {GraphBaseUrl}{Path}", _graphBaseUrl, path);
 
         try
         {
@@ -1558,7 +1589,7 @@ public class GraphApiService
             ? [Constants.AuthenticationConstants.AgentInstanceReadWriteAllScope]
             : null;
 
-        _logger.LogInformation("DELETE https://graph.microsoft.com/beta/agentRegistry/agentInstances/{InstanceId}", instanceId);
+        _logger.LogInformation("DELETE {GraphBaseUrl}/beta/agentRegistry/agentInstances/{InstanceId}", _graphBaseUrl, instanceId);
 
         return await GraphDeleteAsync(
             tenantId,
@@ -1588,7 +1619,7 @@ public class GraphApiService
             _logger.LogDebug("Acquiring blueprint access token via client credentials (CorrelationId: {Id})", effectiveCorrelationId);
 
             using var httpClient = HttpClientFactory.CreateAuthenticatedClient(correlationId: effectiveCorrelationId);
-            var tokenEndpoint = $"https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token";
+            var tokenEndpoint = ConfigConstants.BuildTokenEndpointUrl(_authorityHost, tenantId);
 
             const int maxRetries = 12;
             const int baseDelaySeconds = 5;
@@ -1600,7 +1631,7 @@ public class GraphApiService
                 {
                     new KeyValuePair<string, string>("client_id", clientId),
                     new KeyValuePair<string, string>("client_secret", clientSecret),
-                    new KeyValuePair<string, string>("scope", "https://graph.microsoft.com/.default"),
+                    new KeyValuePair<string, string>("scope", $"{_graphBaseUrl}/.default"),
                     new KeyValuePair<string, string>("grant_type", "client_credentials"),
                 });
 
@@ -1690,7 +1721,8 @@ public class GraphApiService
             {
                 var loginHint = await ResolveLoginHintAsync();
                 var previewToken = await _tokenProvider.GetMgGraphAccessTokenAsync(
-                    tenantId, scopes, false, CustomClientAppId, ct, loginHint);
+                    tenantId, scopes, false, CustomClientAppId, ct, loginHint,
+                    graphBaseUrl: GraphBaseUrlOverride, authorityHost: AuthorityHostOverride);
                 if (!string.IsNullOrWhiteSpace(previewToken))
                 {
                     var scp = TryDecodeTokenClaim(previewToken, "scp");
@@ -1717,15 +1749,15 @@ public class GraphApiService
             {
                 body["sponsors@odata.bind"] = new JsonArray
                 {
-                    $"https://graph.microsoft.com/v1.0/users/{currentUserId}"
+                    $"{_graphBaseUrl}/v1.0/users/{currentUserId}"
                 };
                 body["owners@odata.bind"] = new JsonArray
                 {
-                    $"https://graph.microsoft.com/v1.0/users/{currentUserId}"
+                    $"{_graphBaseUrl}/v1.0/users/{currentUserId}"
                 };
             }
 
-            _logger.LogDebug("POST https://graph.microsoft.com/beta/servicePrincipals/Microsoft.Graph.AgentIdentity (delegated)");
+            _logger.LogDebug("POST {GraphBaseUrl}/beta/servicePrincipals/Microsoft.Graph.AgentIdentity (delegated)", _graphBaseUrl);
             _logger.LogDebug("Body: {Body}", body.ToJsonString());
 
             // Use GraphPostWithResponseAsync so we can log the full error body on failure.
@@ -1827,13 +1859,13 @@ public class GraphApiService
             {
                 body["sponsors@odata.bind"] = new JsonArray
                 {
-                    $"https://graph.microsoft.com/v1.0/users/{currentUserId}"
+                    $"{_graphBaseUrl}/v1.0/users/{currentUserId}"
                 };
             }
 
             const int maxAttempts = 5;
             const int baseDelaySeconds = 5;
-            const string agentIdentityUrl = "https://graph.microsoft.com/beta/serviceprincipals/Microsoft.Graph.AgentIdentity";
+            var agentIdentityUrl = $"{_graphBaseUrl}/beta/serviceprincipals/Microsoft.Graph.AgentIdentity";
 
             for (int attempt = 0; attempt < maxAttempts; attempt++)
             {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
@@ -16,8 +16,8 @@ public enum GraphAuthenticationMode
 
     /// <summary>
     /// Force the ambient bootstrap identity, ignoring the resolved client app and any requested
-    /// scopes. Required when probing whether a client app exists: authenticating as the app being
-    /// probed makes its own absence unverifiable.
+    /// scopes. Required when reading or repairing a client app registration so an underconfigured
+    /// app does not need to authorize its own diagnosis.
     /// </summary>
     Ambient = 1
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/AdminConsentHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/AdminConsentHelper.cs
@@ -78,12 +78,14 @@ public static class AdminConsentHelper
         string scopeDescriptor,
         int timeoutSeconds,
         int intervalSeconds,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? graphBaseUrl = null)
     {
         if (BypassConsentChecksForTests)
             return true;
 
         var start = DateTime.UtcNow;
+        var baseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
         string? spId = null;
         int lastProgressReportSeconds = 0;
 
@@ -107,7 +109,7 @@ public static class AdminConsentHelper
                 if (spId == null)
                 {
                     var spResult = await executor.ExecuteAsync("az",
-                        $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals?$filter=appId eq '{appId}'\"",
+                        $"rest --method GET --url \"{baseUrl}/v1.0/servicePrincipals?$filter=appId eq '{appId}'\"",
                         captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
 
                     if (spResult.Success)
@@ -128,7 +130,7 @@ public static class AdminConsentHelper
                 if (spId != null)
                 {
                     var grants = await executor.ExecuteAsync("az",
-                        $"rest --method GET --url \"https://graph.microsoft.com/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spId}'\"",
+                        $"rest --method GET --url \"{baseUrl}/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spId}'\"",
                         captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
 
                     if (grants.Success)
@@ -387,7 +389,8 @@ public static class AdminConsentHelper
         CancellationToken ct,
         string? consentType = null,
         string? blueprintSpObjectId = null,
-        string? resourceSpObjectId = null)
+        string? resourceSpObjectId = null,
+        string? graphBaseUrl = null)
     {
         if (BypassConsentChecksForTests)
             return true;
@@ -406,11 +409,12 @@ public static class AdminConsentHelper
 
         try
         {
+            var baseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
             // Skip SP lookups when the caller already resolved them in Phase 1 — each az rest
             // call costs ~1.7s due to az's Python startup. The orchestrator passes pre-resolved
             // IDs to cut 4-resource setup pre-check from ~21s to ~7s.
             var blueprintSpId = blueprintSpObjectId
-                ?? await LookupSpObjectIdByAppIdAsync(executor, blueprintAppId, ct);
+                ?? await LookupSpObjectIdByAppIdAsync(executor, blueprintAppId, baseUrl, ct);
             if (blueprintSpId == null)
             {
                 logger.LogDebug("Blueprint SP not found for appId {BlueprintAppId} via az rest", blueprintAppId);
@@ -418,7 +422,7 @@ public static class AdminConsentHelper
             }
 
             var resourceSpId = resourceSpObjectId
-                ?? await LookupSpObjectIdByAppIdAsync(executor, resourceAppId, ct);
+                ?? await LookupSpObjectIdByAppIdAsync(executor, resourceAppId, baseUrl, ct);
             if (resourceSpId == null)
             {
                 logger.LogDebug("Resource SP not found for appId {ResourceAppId} via az rest", resourceAppId);
@@ -430,7 +434,7 @@ public static class AdminConsentHelper
                 filter += $" and consentType eq '{consentType}'";
 
             var grantsResult = await executor.ExecuteAsync("az",
-                $"rest --method GET --url \"https://graph.microsoft.com/v1.0/oauth2PermissionGrants?$filter={Uri.EscapeDataString(filter)}\"",
+                $"rest --method GET --url \"{baseUrl}/v1.0/oauth2PermissionGrants?$filter={Uri.EscapeDataString(filter)}\"",
                 captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
 
             if (!grantsResult.Success)
@@ -480,10 +484,10 @@ public static class AdminConsentHelper
     }
 
     private static async Task<string?> LookupSpObjectIdByAppIdAsync(
-        CommandExecutor executor, string appId, CancellationToken ct)
+        CommandExecutor executor, string appId, string graphBaseUrl, CancellationToken ct)
     {
         var spResult = await executor.ExecuteAsync("az",
-            $"rest --method GET --url \"https://graph.microsoft.com/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id\"",
+            $"rest --method GET --url \"{graphBaseUrl}/v1.0/servicePrincipals?$filter=appId eq '{appId}'&$select=id\"",
             captureOutput: true, suppressErrorLogging: true, cancellationToken: ct);
 
         if (!spResult.Success)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/EndpointHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/EndpointHelper.cs
@@ -115,12 +115,9 @@ public static class EndpointHelper
         if (!string.IsNullOrEmpty(customEndpoint))
             return customEndpoint;
 
-        // Default to production endpoint
-        return environment?.ToLower() switch
-        {
-            "prod" => ConfigConstants.ProductionCreateEndpointUrl,
-            _ => ConfigConstants.ProductionCreateEndpointUrl
-        };
+        return ConfigConstants.BuildAgent365ToolsEndpointUrl(
+            environment,
+            ConfigConstants.CreateAgentBlueprintPath);
     }
 
     /// <summary>
@@ -134,12 +131,9 @@ public static class EndpointHelper
         if (!string.IsNullOrEmpty(customEndpoint))
             return customEndpoint;
 
-        // Default to production endpoint
-        return environment?.ToLower() switch
-        {
-            "prod" => ConfigConstants.ProductionDeleteEndpointUrl,
-            _ => ConfigConstants.ProductionDeleteEndpointUrl
-        };
+        return ConfigConstants.BuildAgent365ToolsEndpointUrl(
+            environment,
+            ConfigConstants.DeleteAgentBlueprintPath);
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/EndpointHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/EndpointHelper.cs
@@ -110,7 +110,8 @@ public static class EndpointHelper
     public static string GetCreateEndpointUrl(string environment)
     {
         // Check for custom endpoint in environment variable first
-        var customEndpoint = Environment.GetEnvironmentVariable($"A365_CREATE_ENDPOINT_{environment?.ToUpper()}");
+        var customEndpoint = Environment.GetEnvironmentVariable(
+            $"A365_CREATE_ENDPOINT_{ConfigConstants.NormalizeEnvironmentKey(environment)}");
         if (!string.IsNullOrEmpty(customEndpoint))
             return customEndpoint;
 
@@ -128,7 +129,8 @@ public static class EndpointHelper
     public static string GetDeleteEndpointUrl(string environment)
     {
         // Check for custom endpoint in environment variable first
-        var customEndpoint = Environment.GetEnvironmentVariable($"A365_DELETE_ENDPOINT_{environment?.ToUpper()}");
+        var customEndpoint = Environment.GetEnvironmentVariable(
+            $"A365_DELETE_ENDPOINT_{ConfigConstants.NormalizeEnvironmentKey(environment)}");
         if (!string.IsNullOrEmpty(customEndpoint))
             return customEndpoint;
 
@@ -146,7 +148,8 @@ public static class EndpointHelper
     public static string GetDeploymentEnvironment(string environment)
     {
         // Check for custom deployment environment in environment variable first
-        var customDeploymentEnvironment = Environment.GetEnvironmentVariable($"A365_DEPLOYMENT_ENVIRONMENT_{environment?.ToUpper()}");
+        var customDeploymentEnvironment = Environment.GetEnvironmentVariable(
+            $"A365_DEPLOYMENT_ENVIRONMENT_{ConfigConstants.NormalizeEnvironmentKey(environment)}");
         if (!string.IsNullOrEmpty(customDeploymentEnvironment))
             return customDeploymentEnvironment;
 
@@ -164,7 +167,8 @@ public static class EndpointHelper
     public static string GetClusterCategory(string environment)
     {
         // Check for custom cluster category in environment variable first
-        var customClusterCategory = Environment.GetEnvironmentVariable($"A365_CLUSTER_CATEGORY_{environment?.ToUpper()}");
+        var customClusterCategory = Environment.GetEnvironmentVariable(
+            $"A365_CLUSTER_CATEGORY_{ConfigConstants.NormalizeEnvironmentKey(environment)}");
         if (!string.IsNullOrEmpty(customClusterCategory))
             return customClusterCategory;
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/InteractiveGraphAuthService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/InteractiveGraphAuthService.cs
@@ -157,7 +157,7 @@ public sealed class InteractiveGraphAuthService
         _logger.LogInformation("Successfully authenticated to Microsoft Graph!");
 
         var graphClient = new GraphServiceClient(credential!, _requiredScopes);
-        graphClient.RequestAdapter.BaseUrl = _graphBaseUrl;
+        graphClient.RequestAdapter.BaseUrl = $"{_graphBaseUrl}/{GraphApiConstants.Versions.V1}";
         _cachedClient = graphClient;
         _cachedTenantId = tenantId;
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/InteractiveGraphAuthService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/InteractiveGraphAuthService.cs
@@ -28,6 +28,9 @@ public sealed class InteractiveGraphAuthService
     private readonly string _clientAppId;
     private readonly Func<string, string, TokenCredential>? _credentialFactory;
     private readonly Func<Task<string?>> _loginHintResolver;
+    private readonly string _graphBaseUrl;
+    private readonly string _authorityHost;
+    private readonly string[] _requiredScopes;
     private GraphServiceClient? _cachedClient;
     private string? _cachedTenantId;
 
@@ -37,7 +40,9 @@ public sealed class InteractiveGraphAuthService
         ILogger logger,
         string clientAppId,
         Func<string, string, TokenCredential>? credentialFactory = null,
-        Func<Task<string?>>? loginHintResolver = null)
+        Func<Task<string?>>? loginHintResolver = null,
+        string? graphBaseUrl = null,
+        string? authorityHost = null)
     {
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
 
@@ -58,6 +63,14 @@ public sealed class InteractiveGraphAuthService
         _clientAppId = clientAppId;
         _credentialFactory = credentialFactory;
         _loginHintResolver = loginHintResolver ?? ResolveAzLoginHintAsync;
+        _graphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+        _authorityHost = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        _requiredScopes = RequiredScopes
+            .Select(scope => scope.Replace(
+                AuthenticationConstants.MicrosoftGraphResourceUri,
+                _graphBaseUrl,
+                StringComparison.OrdinalIgnoreCase))
+            .ToArray();
     }
 
     /// <summary>
@@ -84,7 +97,7 @@ public sealed class InteractiveGraphAuthService
         // Eagerly acquire a token so authentication failures are detected here rather than
         // surfacing later from inside GraphServiceClient's lazy token acquisition.
         // Resolve credential inside try/catch so factory exceptions are wrapped consistently.
-        var tokenContext = new TokenRequestContext(RequiredScopes);
+        var tokenContext = new TokenRequestContext(_requiredScopes);
         TokenCredential? credential = null;
         try
         {
@@ -93,7 +106,13 @@ public sealed class InteractiveGraphAuthService
 
             // Resolve credential: use injected factory (for tests) or default MsalBrowserCredential
             credential = _credentialFactory?.Invoke(_clientAppId, tenantId)
-                ?? new MsalBrowserCredential(_clientAppId, tenantId, redirectUri: null, _logger, loginHint: loginHint);
+                ?? new MsalBrowserCredential(
+                    _clientAppId,
+                    tenantId,
+                    redirectUri: null,
+                    _logger,
+                    authority: $"{_authorityHost}/{tenantId}",
+                    loginHint: loginHint);
 
             await credential.GetTokenAsync(tokenContext, cancellationToken);
         }
@@ -137,7 +156,8 @@ public sealed class InteractiveGraphAuthService
         // from GraphServiceClient will hit the silent cache without re-prompting.
         _logger.LogInformation("Successfully authenticated to Microsoft Graph!");
 
-        var graphClient = new GraphServiceClient(credential!, RequiredScopes);
+        var graphClient = new GraphServiceClient(credential!, _requiredScopes);
+        graphClient.RequestAdapter.BaseUrl = _graphBaseUrl;
         _cachedClient = graphClient;
         _cachedTenantId = tenantId;
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/IMicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/IMicrosoftGraphTokenProvider.cs
@@ -9,6 +9,11 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 public interface IMicrosoftGraphTokenProvider
 {
     /// <summary>
+    /// Clears access tokens cached in memory by this provider.
+    /// </summary>
+    void ClearTokenCache();
+
+    /// <summary>
     /// Acquires a delegated access token for Microsoft Graph using PowerShell authentication.
     /// </summary>
     /// <param name="tenantId">The Azure AD tenant ID (GUID or domain name).</param>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/IMicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/IMicrosoftGraphTokenProvider.cs
@@ -27,5 +27,7 @@ public interface IMicrosoftGraphTokenProvider
         string? clientAppId = null,
         CancellationToken ct = default,
         string? loginHint = null,
-        bool forceRefresh = false);
+        bool forceRefresh = false,
+        string? graphBaseUrl = null,
+        string? authorityHost = null);
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
@@ -86,6 +86,8 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
+    public void ClearTokenCache() => _tokenCache.Clear();
+
     public async Task<string?> GetMgGraphAccessTokenAsync(
         string tenantId,
         IEnumerable<string> scopes,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
@@ -93,9 +93,13 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         string? clientAppId = null,
         CancellationToken ct = default,
         string? loginHint = null,
-        bool forceRefresh = false)
+        bool forceRefresh = false,
+        string? graphBaseUrl = null,
+        string? authorityHost = null)
     {
-        var validatedScopes = ValidateAndPrepareScopes(scopes);
+        var resolvedGraphBaseUrl = ConfigConstants.NormalizeGraphBaseUrl(graphBaseUrl);
+        var resolvedAuthorityHost = ConfigConstants.NormalizeAuthorityHost(authorityHost);
+        var validatedScopes = ValidateAndPrepareScopes(scopes, resolvedGraphBaseUrl);
         ValidateTenantId(tenantId);
 
         if (!string.IsNullOrWhiteSpace(clientAppId))
@@ -149,12 +153,23 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
             // and WAM on Windows authenticates via the OS broker (no browser, CAP-compliant).
             var token = MsalTokenAcquirerOverride != null
                 ? await MsalTokenAcquirerOverride(tenantId, validatedScopes, clientAppId, ct)
-                : await AcquireGraphTokenViaMsalAsync(tenantId, validatedScopes, clientAppId, ct, loginHint, forceRefresh);
+                : await AcquireGraphTokenViaMsalAsync(
+                    tenantId, validatedScopes, clientAppId, resolvedAuthorityHost, ct, loginHint,
+                    forceRefresh);
 
             // Fall back to PowerShell Connect-MgGraph if MSAL is unavailable (e.g. no clientAppId)
             // or fails for any reason.
             if (string.IsNullOrWhiteSpace(token))
             {
+                if (!string.Equals(resolvedAuthorityHost, ConfigConstants.DefaultAuthorityHost, StringComparison.OrdinalIgnoreCase)
+                    || !string.Equals(resolvedGraphBaseUrl, GraphApiConstants.BaseUrl, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogError(
+                        "MSAL Graph authentication failed for the configured cloud. " +
+                        "PowerShell fallback is available only for commercial Graph and authority endpoints.");
+                    return null;
+                }
+
                 _logger.LogDebug("MSAL token acquisition failed, falling back to PowerShell Connect-MgGraph...");
                 var script = BuildPowerShellScript(tenantId, validatedScopes, useDeviceCode, clientAppId);
 
@@ -171,7 +186,8 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
                         _logger.LogWarning(
                             "PowerShell interactive browser authentication failed (Conditional Access Policy or embedded terminal). " +
                             "Retrying with device code authentication...");
-                        var deviceCodeScript = BuildPowerShellScript(tenantId, validatedScopes, useDeviceCode: true, clientAppId);
+                        var deviceCodeScript = BuildPowerShellScript(
+                            tenantId, validatedScopes, useDeviceCode: true, clientAppId);
                         var deviceCodeResult = await ExecuteWithFallbackAsync(deviceCodeScript, ct);
                         token = ProcessResult(deviceCodeResult);
                     }
@@ -231,7 +247,9 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
                 // Retry once — do not recurse; use the underlying acquirer directly.
                 var retryToken = MsalTokenAcquirerOverride != null
                     ? await MsalTokenAcquirerOverride(tenantId, validatedScopes, clientAppId, ct)
-                    : await AcquireGraphTokenViaMsalAsync(tenantId, validatedScopes, clientAppId, ct, loginHint, forceRefresh: true);
+                    : await AcquireGraphTokenViaMsalAsync(
+                        tenantId, validatedScopes, clientAppId, resolvedAuthorityHost, ct, loginHint,
+                        forceRefresh: true);
 
                 if (!string.IsNullOrWhiteSpace(retryToken))
                     token = retryToken;
@@ -264,13 +282,16 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         }
     }
 
-    private string[] ValidateAndPrepareScopes(IEnumerable<string> scopes)
+    private string[] ValidateAndPrepareScopes(IEnumerable<string> scopes, string graphBaseUrl)
     {
         if (scopes == null)
             throw new ArgumentNullException(nameof(scopes));
 
         var validScopes = scopes
             .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s.Contains("://", StringComparison.Ordinal)
+                ? s
+                : $"{graphBaseUrl}/{s.TrimStart('/')}")
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -307,7 +328,8 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
                 nameof(clientAppId));
     }
 
-    private static string BuildPowerShellScript(string tenantId, string[] scopes, bool useDeviceCode, string? clientAppId = null)
+    private static string BuildPowerShellScript(
+        string tenantId, string[] scopes, bool useDeviceCode, string? clientAppId = null)
     {
         var escapedTenantId = CommandStringHelper.EscapePowerShellString(tenantId);
         var scopesArray = BuildScopesArray(scopes);
@@ -387,6 +409,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
         string tenantId,
         string[] scopes,
         string? clientAppId,
+        string authorityHost,
         CancellationToken ct,
         string? loginHint = null,
         bool forceRefresh = false)
@@ -399,15 +422,16 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
 
         try
         {
-            // MSAL requires fully-qualified scope URIs; PS Connect-MgGraph handles this internally.
-            var fullScopes = scopes
-                .Select(s => s.Contains("://", StringComparison.Ordinal) ? s : $"https://graph.microsoft.com/{s}")
-                .ToArray();
+            _logger.LogDebug("Acquiring Graph token via MSAL for scopes: {Scopes}", string.Join(", ", scopes));
 
-            _logger.LogDebug("Acquiring Graph token via MSAL for scopes: {Scopes}", string.Join(", ", fullScopes));
-
-            var msalCredential = new MsalBrowserCredential(clientAppId, tenantId, logger: _logger, loginHint: loginHint, forceRefresh: forceRefresh);
-            var tokenResult = await msalCredential.GetTokenAsync(new TokenRequestContext(fullScopes), ct);
+            var msalCredential = new MsalBrowserCredential(
+                clientAppId,
+                tenantId,
+                logger: _logger,
+                authority: $"{authorityHost}/{tenantId}",
+                loginHint: loginHint,
+                forceRefresh: forceRefresh);
+            var tokenResult = await msalCredential.GetTokenAsync(new TokenRequestContext(scopes), ct);
 
             if (string.IsNullOrWhiteSpace(tokenResult.Token))
                 return null;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/MicrosoftGraphTokenProvider.cs
@@ -289,6 +289,7 @@ public sealed class MicrosoftGraphTokenProvider : IMicrosoftGraphTokenProvider, 
 
         var validScopes = scopes
             .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s.Trim())
             .Select(s => s.Contains("://", StringComparison.Ordinal)
                 ? s
                 : $"{graphBaseUrl}/{s.TrimStart('/')}")

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/LogRedactionService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/LogRedactionService.cs
@@ -60,6 +60,9 @@ public sealed class LogRedactionService : ILogRedactionService
         "00000003-0000-0000-c000-000000000000", // Microsoft Graph
         "5a807f24-c9de-44ee-a3a7-329e88a00ffc", // Agent 365 Messaging Bot API
         "9b975845-388f-4429-889e-eab1ef63949c", // Agent 365 Observability API
+        ConfigConstants.GccObservabilityApiAppId,
+        ConfigConstants.GccHighObservabilityApiAppId,
+        ConfigConstants.DodObservabilityApiAppId,
         "8578e004-a5c6-46e7-913e-12f58912df43", // Power Platform API (Connectivity)
         "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1", // Agent 365 Tools (MCP audience, production)
         AuthenticationConstants.WellKnownClientAppId, // Agent 365 CLI (well-known first-party application)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -119,9 +119,7 @@ public sealed class MsalBrowserCredential : TokenCredential
         _loginHint = loginHint;
         _forceRefresh = forceRefresh;
 
-        // Capture the login authority host so consent URLs surfaced later (BuildAdminConsentUrl)
-        // target the same cloud this credential authenticates against. Falls back to commercial
-        // when no explicit sovereign authority was supplied.
+        // Pin consent URLs (BuildAdminConsentUrl) to the cloud we authenticate against; default commercial.
         _authorityHost = Uri.TryCreate(authority, UriKind.Absolute, out var authorityUri)
             ? authorityUri.GetLeftPart(UriPartial.Authority)
             : ConfigConstants.DefaultAuthorityHost;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -45,6 +45,7 @@ public sealed class MsalBrowserCredential : TokenCredential
     private readonly IntPtr _windowHandle;
     private readonly string? _loginHint;
     private readonly bool _forceRefresh;
+    private readonly string _authorityHost;
 
     // Shared persistent cache helper - initialized once and reused across all instances.
     // This is the key to reducing multiple WAM prompts during setup operations.
@@ -89,8 +90,7 @@ public sealed class MsalBrowserCredential : TokenCredential
     /// <param name="redirectUri">The redirect URI for authentication callbacks.</param>
     /// <param name="logger">Optional logger for diagnostic output.</param>
     /// <param name="useWam">Whether to use WAM on Windows. Default is true.</param>
-    /// <param name="authority">Optional authority URL. When provided, overrides the default AzurePublic authority.
-    /// Use this for government clouds (e.g., "https://login.microsoftonline.us/{tenantId}").</param>
+    /// <param name="authority">Optional authority URL. When provided, overrides the default public-cloud authority.</param>
     /// <param name="loginHint">Optional UPN/email to pre-select the account for silent acquisition and interactive auth.
     /// When provided, WAM and silent auth will target this identity instead of the first cached account.</param>
     public MsalBrowserCredential(
@@ -118,6 +118,13 @@ public sealed class MsalBrowserCredential : TokenCredential
         _logger = logger;
         _loginHint = loginHint;
         _forceRefresh = forceRefresh;
+
+        // Capture the login authority host so consent URLs surfaced later (BuildAdminConsentUrl)
+        // target the same cloud this credential authenticates against. Falls back to commercial
+        // when no explicit sovereign authority was supplied.
+        _authorityHost = Uri.TryCreate(authority, UriKind.Absolute, out var authorityUri)
+            ? authorityUri.GetLeftPart(UriPartial.Authority)
+            : ConfigConstants.DefaultAuthorityHost;
 
         // Get window handle for WAM on Windows
         // Try multiple sources: console window, foreground window, or desktop window
@@ -576,7 +583,7 @@ public sealed class MsalBrowserCredential : TokenCredential
     /// </summary>
     private void LogConsentRequiredAndThrow(Exception inner)
     {
-        var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(_clientAppId, _tenantId);
+        var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(_clientAppId, _tenantId, _authorityHost);
         _logger?.LogWarning("Admin consent has not been granted for this application.");
         _logger?.LogWarning("An administrator must grant tenant-wide consent to proceed.");
         if (consentUrl != null)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Extensions.Logging;
 
@@ -86,7 +87,8 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
             return RequirementCheckResult.Success(details: $"'wids' is present on accessToken optionalClaims for {config.ClientAppId}");
         }
 
-        var manualPatch = BuildManualPatchInstructions(config.ClientAppId, config.TenantId);
+        var graphBaseUrl = ConfigConstants.GetGraphBaseUrl(config.Environment, config.GraphBaseUrl);
+        var manualPatch = BuildManualPatchInstructions(config.ClientAppId, config.TenantId, graphBaseUrl);
 
         return RequirementCheckResult.Failure(
             errorMessage: $"Client app {config.ClientAppId} is missing the 'wids' optional claim on accessToken. " +
@@ -99,7 +101,7 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
                 "the orchestrator collapses Unknown to 'not GA' and skips Phase 2b.");
     }
 
-    private static string BuildManualPatchInstructions(string clientAppId, string tenantId)
+    private static string BuildManualPatchInstructions(string clientAppId, string tenantId, string graphBaseUrl)
     {
         // Two-line remediation: portal path for humans, raw `az rest` for scriptable runs.
         // Both add { name: "wids", essential: false } to optionalClaims.accessToken.
@@ -107,7 +109,7 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
             "Add the 'wids' optional claim on the client app's access tokens. Options:\n" +
             $"  1. Portal: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/TokenConfiguration/appId/{clientAppId} → 'Add optional claim' → Token type 'Access' → check 'wids' → Add.\n" +
             "  2. Or run as an Application Administrator / Global Administrator:\n" +
-            $"     az rest --method PATCH --url \"https://graph.microsoft.com/v1.0/applications(appId='{clientAppId}')\" --headers \"Content-Type=application/json\" --body \"{{\\\"optionalClaims\\\":{{\\\"accessToken\\\":[{{\\\"name\\\":\\\"wids\\\",\\\"essential\\\":false,\\\"additionalProperties\\\":[]}}]}}}}\"\n" +
+            $"     az rest --method PATCH --url \"{graphBaseUrl}/v1.0/applications(appId='{clientAppId}')\" --headers \"Content-Type=application/json\" --body \"{{\\\"optionalClaims\\\":{{\\\"accessToken\\\":[{{\\\"name\\\":\\\"wids\\\",\\\"essential\\\":false,\\\"additionalProperties\\\":[]}}]}}}}\"\n" +
             "After updating, sign out and back in (az logout && az login) so the next token carries the new claim, then re-run 'a365 setup requirements'.";
     }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/TeamsGraphBackendConfigurator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/TeamsGraphBackendConfigurator.cs
@@ -65,6 +65,7 @@ public class TeamsGraphBackendConfigurator : ITeamsGraphBackendConfigurator
 
             var createEndpointUrl = EndpointHelper.GetCreateEndpointUrl(config.Environment);
             var audience = ConfigConstants.GetAgent365ToolsResourceAppId(config.Environment);
+            var authorityHost = ConfigConstants.GetAuthorityHost(config.Environment, config.AuthorityHost);
 
             _logger.LogDebug("Create endpoint URL: {Url}", createEndpointUrl);
 
@@ -79,7 +80,13 @@ public class TeamsGraphBackendConfigurator : ITeamsGraphBackendConfigurator
             {
                 bool forceRefresh = attempt > 0;
 
-                var authToken = await _authService.GetAccessTokenAsync(audience, tenantId, forceRefresh: forceRefresh, userId: currentUser, ct: ct);
+                var authToken = await _authService.GetAccessTokenAsync(
+                    audience,
+                    tenantId,
+                    forceRefresh: forceRefresh,
+                    userId: currentUser,
+                    ct: ct,
+                    authorityHost: authorityHost);
                 if (string.IsNullOrWhiteSpace(authToken))
                 {
                     _logger.LogError("Failed to acquire authentication token");
@@ -188,6 +195,7 @@ public class TeamsGraphBackendConfigurator : ITeamsGraphBackendConfigurator
 
             var deleteEndpointUrl = EndpointHelper.GetDeleteEndpointUrl(config.Environment);
             var audience = ConfigConstants.GetAgent365ToolsResourceAppId(config.Environment);
+            var authorityHost = ConfigConstants.GetAuthorityHost(config.Environment, config.AuthorityHost);
 
             _logger.LogDebug("Delete endpoint URL: {Url}", deleteEndpointUrl);
 
@@ -201,7 +209,13 @@ public class TeamsGraphBackendConfigurator : ITeamsGraphBackendConfigurator
             {
                 bool forceRefresh = attempt > 0;
 
-                var authToken = await _authService.GetAccessTokenAsync(audience, tenantId, forceRefresh: forceRefresh, userId: currentUser, ct: ct);
+                var authToken = await _authService.GetAccessTokenAsync(
+                    audience,
+                    tenantId,
+                    forceRefresh: forceRefresh,
+                    userId: currentUser,
+                    ct: ct,
+                    authorityHost: authorityHost);
                 if (string.IsNullOrWhiteSpace(authToken))
                 {
                     _logger.LogError("Failed to acquire authentication token");

--- a/src/Microsoft.Agents.A365.DevTools.Cli/design.md
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/design.md
@@ -149,7 +149,9 @@ For security and flexibility, the CLI supports environment variable overrides:
 |----------|---------|
 | `A365_MCP_APP_ID` | Override Agent 365 Tools App ID for authentication |
 | `A365_MCP_APP_ID_{ENV}` | Per-environment MCP Platform App ID |
-| `A365_DISCOVER_ENDPOINT_{ENV}` | Per-environment discover endpoint URL |
+| `A365_DISCOVER_ENDPOINT_{ENV}` | Canonical per-environment Agent 365 endpoint; discover uses the configured URL, while create and delete use its validated HTTPS origin with fixed routes |
+| `A365_CREATE_ENDPOINT_{ENV}` | Higher-precedence per-environment create endpoint override |
+| `A365_DELETE_ENDPOINT_{ENV}` | Higher-precedence per-environment delete endpoint override |
 | `POWERPLATFORM_API_URL` | Override Power Platform API URL |
 
 **Design Decision:** All test/preprod App IDs and URLs have been removed from the codebase. The production App ID is the only hardcoded value. Internal Microsoft developers use environment variables for non-production testing.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/design.md
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/design.md
@@ -154,11 +154,20 @@ For security and flexibility, the CLI supports environment variable overrides:
 | `A365_DELETE_ENDPOINT_{ENV}` | Higher-precedence per-environment delete endpoint override |
 | `POWERPLATFORM_API_URL` | Override Power Platform API URL |
 
-**Design Decision:** All test/preprod App IDs and URLs have been removed from the codebase. The production App ID is the only hardcoded value. Internal Microsoft developers use environment variables for non-production testing.
+**Design Decision:** Test and preproduction App IDs and URLs are supplied through environment variables. Public production resource IDs that differ by sovereign cloud, including Observability, are selected from the configured environment.
+
+| Cloud | `environment` value | Observability resource app ID |
+|-------|---------------------|-------------------------------|
+| Commercial | `prod` | `9b975845-388f-4429-889e-eab1ef63949c` |
+| GCC Moderate | `gcc` | `2c672ad5-b104-44ed-8069-bb68dd138546` |
+| GCC High | `gcc-high` | `009c6bd0-82e4-4466-95b3-4c996521f3d7` |
+| DoD | `dod` | `a9e04047-c6a7-430b-a7ae-faf8f8eed1b7` |
 
 ### Sovereign / Government Cloud Configuration
 
-By default the CLI targets the commercial Microsoft Graph endpoint. For sovereign or government cloud tenants, set `graphBaseUrl` in `a365.config.json`:
+Set `environment` explicitly for every government cloud because it selects cloud-specific Agent 365 endpoints, authentication audiences, and Observability resources. The Graph endpoint alone cannot distinguish GCC High from DoD.
+
+By default the CLI targets the commercial Microsoft Graph endpoint. For GCC High, DoD, or other sovereign tenants, also set `graphBaseUrl` in `a365.config.json`:
 
 | Cloud | `graphBaseUrl` value |
 |-------|----------------------|

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AzRestConsentRunnerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AzRestConsentRunnerTests.cs
@@ -156,12 +156,14 @@ public class AzRestConsentRunnerTests
             .Returns(Task.FromResult(new CommandResult { ExitCode = 0 }));
 
         var (attempted, succeeded) = await AzRestConsentRunner.TryRunAsync(
-            _executor, BlueprintSpId, new[] { ObsSpec() }, _logger, ct: default);
+            _executor, BlueprintSpId, new[] { ObsSpec() }, _logger,
+            ct: default, graphBaseUrl: "https://graph.example");
 
         attempted.Should().BeTrue();
         succeeded.Should().BeTrue();
         await _executor.Received().ExecuteAsync(
-            "az", Arg.Is<string>(s => s.Contains("--method POST") && s.Contains("oauth2PermissionGrants") && !s.Contains($"/{ExistingGrantId}")),
+            "az", Arg.Is<string>(s => s.Contains("https://graph.example/v1.0/oauth2PermissionGrants")
+                && s.Contains("--method POST") && !s.Contains($"/{ExistingGrantId}")),
             Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         await _executor.DidNotReceive().ExecuteAsync(
             "az", Arg.Is<string>(s => s.Contains("--method PATCH")),

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AzRestS2SRunnerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AzRestS2SRunnerTests.cs
@@ -174,12 +174,14 @@ public class AzRestS2SRunnerTests
             .Returns(Task.FromResult(new CommandResult { ExitCode = 0 }));
 
         var (attempted, succeeded) = await AzRestS2SRunner.TryRunAsync(
-            _executor, BlueprintSpId, new[] { ObsSpec() }, _logger, ct: default);
+            _executor, BlueprintSpId, new[] { ObsSpec() }, _logger,
+            ct: default, graphBaseUrl: "https://graph.example");
 
         attempted.Should().BeTrue();
         succeeded.Should().BeTrue();
         await _executor.Received().ExecuteAsync(
-            "az", Arg.Is<string>(s => s.Contains("--method POST") && s.Contains($"/servicePrincipals/{BlueprintSpId}/appRoleAssignments")),
+            "az", Arg.Is<string>(s => s.Contains("https://graph.example/v1.0")
+                && s.Contains("--method POST") && s.Contains($"/servicePrincipals/{BlueprintSpId}/appRoleAssignments")),
             Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BatchPermissionsOrchestratorMissingSpTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BatchPermissionsOrchestratorMissingSpTests.cs
@@ -376,9 +376,10 @@ public class BatchPermissionsOrchestratorMissingSpTests
         // (first party token-to-self). This URL has the blueprint as the CLIENT and the
         // resource as the SCOPE target — a normal cross-app consent that Entra accepts.
         var spec = new ResourcePermissionSpec(TeamsMcpAppId, "Work IQ Teams MCP", new[] { "Tools.ListInvoke.All" }, SetInheritable: true);
-        var url = BatchPermissionsOrchestrator.BuildPerSpBlueprintConsentUrl(TenantId, BlueprintAppId, spec);
+        var url = BatchPermissionsOrchestrator.BuildPerSpBlueprintConsentUrl(
+            TenantId, BlueprintAppId, spec, authorityHost: "https://login.example");
 
-        url.Should().StartWith($"https://login.microsoftonline.com/{TenantId}/v2.0/adminconsent",
+        url.Should().StartWith($"https://login.example/{TenantId}/v2.0/adminconsent",
             because: "the per-SP recovery URL targets the v2 admin-consent endpoint scoped to the operator's tenant");
         url.Should().Contain($"client_id={BlueprintAppId}",
             because: "the BLUEPRINT must be the client so this is a normal cross-app consent — using the resource as client would hit AADSTS65003 token-to-self");

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BatchPermissionsOrchestratorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BatchPermissionsOrchestratorTests.cs
@@ -862,6 +862,39 @@ public class BatchPermissionsOrchestratorTests : IDisposable
     // the deeper layer: that the URL-building loop honors knownMcpAudienceAppIds per spec.
     // ──────────────────────────────────────────────────────────────────────────────────────
 
+    [Fact]
+    public void UpdateResourceConsents_ReplacesCommercialObservabilityEntryForGcc()
+    {
+        var config = new Agent365Config();
+        config.ResourceConsents.Add(new ResourceConsent
+        {
+            ResourceName = "Observability API",
+            ResourceAppId = ConfigConstants.ObservabilityApiAppId,
+            ConsentGranted = true,
+        });
+        var specs = new[]
+        {
+            new ResourcePermissionSpec(
+                ConfigConstants.GccObservabilityApiAppId,
+                "Observability API",
+                new[] { ConfigConstants.ObservabilityApiOtelWriteScope },
+                SetInheritable: true),
+        };
+        var inheritedResults = new Dictionary<string, (bool configured, bool alreadyExisted)>
+        {
+            [ConfigConstants.GccObservabilityApiAppId] = (true, false),
+        };
+
+        BatchPermissionsOrchestrator.UpdateResourceConsents(config, specs, inheritedResults);
+
+        config.ResourceConsents.Should().ContainSingle(
+            resourceConsent => ConfigConstants.IsObservabilityApiAppId(resourceConsent.ResourceAppId),
+            because: "state must contain only the Observability resource for the currently selected cloud");
+        config.ResourceConsents.Single().ResourceAppId.Should().Be(
+            ConfigConstants.GccObservabilityApiAppId,
+            because: "a GCC rerun must replace stale commercial Observability state");
+    }
+
     /// <summary>
     /// Non-admin path: GrantAdminConsentAsync builds the unified consent URL via the catch-all
     /// spec loop and returns it for hand-off. When a spec's appId is in knownMcpAudienceAppIds,

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintSubcommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/BlueprintSubcommandTests.cs
@@ -1858,6 +1858,125 @@ public class BlueprintSubcommandTests
         }
     }
 
+    [Fact]
+    public void RestoreExistingBlueprintSecret_WhenResolvedBlueprintMatches_ReusesStoredSecret()
+    {
+        var setupConfig = new Agent365Config();
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = "BLUEPRINT-ID",
+            ["agentBlueprintClientSecret"] = "stored-secret",
+            ["agentBlueprintClientSecretProtected"] = true
+        };
+
+        BlueprintSubcommand.RestoreExistingBlueprintSecret(
+            setupConfig,
+            generatedConfig,
+            "blueprint-id",
+            _mockLogger);
+
+        setupConfig.AgentBlueprintClientSecret.Should().Be(
+            "stored-secret",
+            because: "an idempotent setup run must validate and reuse the credential stored for the existing blueprint");
+        setupConfig.AgentBlueprintClientSecretProtected.Should().BeTrue(
+            because: "the stored protection mode is required to validate the existing credential");
+    }
+
+    [Fact]
+    public void RestoreExistingBlueprintSecret_WhenResolvedBlueprintDiffers_DoesNotReuseStoredSecret()
+    {
+        var setupConfig = new Agent365Config();
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = "different-blueprint-id",
+            ["agentBlueprintClientSecret"] = "stored-secret",
+            ["agentBlueprintClientSecretProtected"] = false
+        };
+
+        BlueprintSubcommand.RestoreExistingBlueprintSecret(
+            setupConfig,
+            generatedConfig,
+            "resolved-blueprint-id",
+            _mockLogger);
+
+        setupConfig.AgentBlueprintClientSecret.Should().BeNull(
+            because: "a credential must never be reused for a different blueprint");
+    }
+
+    [Fact]
+    public void RestoreExistingBlueprintSecret_WhenSetupConfigAlreadyHasSecret_PreservesResolvedValue()
+    {
+        var setupConfig = new Agent365Config
+        {
+            AgentBlueprintClientSecret = "resolved-secret",
+            AgentBlueprintClientSecretProtected = false
+        };
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = "blueprint-id",
+            ["agentBlueprintClientSecret"] = "stored-secret",
+            ["agentBlueprintClientSecretProtected"] = true
+        };
+
+        BlueprintSubcommand.RestoreExistingBlueprintSecret(
+            setupConfig,
+            generatedConfig,
+            "blueprint-id",
+            _mockLogger);
+
+        setupConfig.AgentBlueprintClientSecret.Should().Be(
+            "resolved-secret",
+            because: "an explicitly resolved credential takes precedence over generated state");
+        setupConfig.AgentBlueprintClientSecretProtected.Should().BeFalse(
+            because: "the protection flag must remain paired with the resolved credential");
+    }
+
+    [Fact]
+    public void RestoreExistingBlueprintSecret_WhenProtectionFlagIsMissing_TreatsStoredSecretAsPlaintext()
+    {
+        var setupConfig = new Agent365Config();
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = "blueprint-id",
+            ["agentBlueprintClientSecret"] = "stored-secret"
+        };
+
+        BlueprintSubcommand.RestoreExistingBlueprintSecret(
+            setupConfig,
+            generatedConfig,
+            "blueprint-id",
+            _mockLogger);
+
+        setupConfig.AgentBlueprintClientSecret.Should().Be(
+            "stored-secret",
+            because: "generated configurations created before the protection flag was added may contain plaintext secrets");
+        setupConfig.AgentBlueprintClientSecretProtected.Should().BeFalse(
+            because: "a missing protection flag represents the legacy plaintext storage format");
+    }
+
+    [Fact]
+    public void RestoreExistingBlueprintSecret_WhenStoredBlueprintIdIsNotAString_DoesNotReuseStoredSecret()
+    {
+        var setupConfig = new Agent365Config();
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = 42,
+            ["agentBlueprintClientSecret"] = "stored-secret",
+            ["agentBlueprintClientSecretProtected"] = false
+        };
+
+        var act = () => BlueprintSubcommand.RestoreExistingBlueprintSecret(
+            setupConfig,
+            generatedConfig,
+            "blueprint-id",
+            _mockLogger);
+
+        act.Should().NotThrow(
+            because: "malformed generated state must not crash an idempotent setup run");
+        setupConfig.AgentBlueprintClientSecret.Should().BeNull(
+            because: "a credential cannot be safely associated with a malformed blueprint identifier");
+    }
+
     #endregion
 
     #region Ownership Check Tests

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/CreateInstanceCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/CreateInstanceCommandTests.cs
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands;
@@ -16,8 +20,14 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
 /// <summary>
 /// Tests for CreateInstanceCommand functionality
 /// </summary>
+[Collection("ConfigTests")]
 public class CreateInstanceCommandTests
 {
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string AgentBlueprintId = "22222222-2222-2222-2222-222222222222";
+    private const string AgenticAppId = "33333333-3333-3333-3333-333333333333";
+    private const string AgenticUserId = "44444444-4444-4444-4444-444444444444";
+
     private readonly ILogger<CreateInstanceCommand> _mockLogger;
     private readonly ConfigService _mockConfigService;
     private readonly CommandExecutor _mockExecutor;
@@ -114,5 +124,112 @@ public class CreateInstanceCommandTests
 
         // Assert
         Assert.Equal(2, result);
+    }
+
+    [Theory]
+    [InlineData("", "Instance creation failed")]
+    [InlineData("identity", "Identity creation failed")]
+    public async Task CreateInstance_WhenGrantPreReadFails_ExitsNonzeroShowsErrorAndDoesNotMutate(
+        string subcommand,
+        string expectedCommandError)
+    {
+        var originalDirectory = Environment.CurrentDirectory;
+        var testDirectory = Path.Combine(Path.GetTempPath(), $"create-instance-command-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(testDirectory);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(testDirectory, "a365.config.json"),
+                $$"""
+                {
+                  "tenantId": "{{TenantId}}",
+                  "environment": "prod"
+                }
+                """);
+            await File.WriteAllTextAsync(
+                Path.Combine(testDirectory, "a365.generated.config.json"),
+                $$"""
+                {
+                  "agentBlueprintId": "{{AgentBlueprintId}}",
+                  "agentBlueprintClientSecret": "test-secret",
+                  "AgenticAppId": "{{AgenticAppId}}",
+                  "AgenticUserId": "{{AgenticUserId}}"
+                }
+                """);
+            Environment.CurrentDirectory = testDirectory;
+
+            var resolver = Substitute.For<IBootstrapConfigResolver>();
+            resolver.ResolveAsync(
+                    Arg.Any<string?>(),
+                    Arg.Any<string?>(),
+                    Arg.Any<FileInfo>(),
+                    Arg.Is(false),
+                    Arg.Any<CancellationToken>())
+                .Returns(new Agent365Config
+                {
+                    TenantId = TenantId,
+                    AgentBlueprintId = AgentBlueprintId,
+                    AgenticAppId = AgenticAppId,
+                    AgenticUserId = AgenticUserId
+                });
+            _mockGraphApiService.LookupServicePrincipalByAppIdAsync(
+                    TenantId,
+                    AgenticAppId,
+                    Arg.Any<CancellationToken>(),
+                    Arg.Any<IEnumerable<string>?>())
+                .Returns("agent-sp-object-id");
+            _mockGraphApiService.GetOauth2PermissionGrantsAsync(
+                    TenantId,
+                    "agent-sp-object-id",
+                    Arg.Any<CancellationToken>())
+                .Returns<Task<List<(string resourceId, string scope, string consentType)>>>(_ =>
+                    throw new InvalidOperationException("connection reset"));
+
+            var command = CreateInstanceCommand.CreateCommand(
+                _mockLogger,
+                _mockConfigService,
+                _mockExecutor,
+                _mockGraphApiService,
+                resolver);
+            var parser = new CommandLineBuilder(command).UseDefaults().Build();
+
+            var exitCode = await parser.InvokeAsync(subcommand, new TestConsole());
+
+            exitCode.Should().NotBe(0,
+                because: "a failed idempotency pre-read must fail both the root all-steps handler and the identity handler");
+            LoggerReceivedContaining(LogLevel.Error, "A365CreateInstanceRunner failed").Should().BeTrue(
+                because: "the command must visibly report that instance execution stopped");
+            LoggerReceivedContaining(LogLevel.Error, expectedCommandError).Should().BeTrue(
+                because: "each materially distinct command handler must surface its own operation-level failure");
+            await _mockGraphApiService.DidNotReceive().EnsureServicePrincipalForAppIdAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<bool>());
+            await _mockGraphApiService.DidNotReceive().CreateOrUpdateOauth2PermissionGrantAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDirectory;
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    private bool LoggerReceivedContaining(LogLevel level, string fragment)
+    {
+        return _mockLogger.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(ILogger.Log))
+            .Select(call => call.GetArguments())
+            .Where(args => args.Length >= 3 && args[0] is LogLevel loggedLevel && loggedLevel == level)
+            .Select(args => args[2]?.ToString() ?? string.Empty)
+            .Any(message => message.Contains(fragment, StringComparison.Ordinal));
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/PublishCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/PublishCommandTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.CommandLine;
+using System.Text.Json.Nodes;
 using FluentAssertions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
@@ -169,6 +170,75 @@ public class PublishCommandTests : IDisposable
 
             exitCode.Should().Be(0);
             _logger.Received().Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("EXCEEDS 30 chars")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>());
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir)) Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task PublishCommand_WithCustomizedManifestNames_PreservesNamesAndPackagesThem()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var manifestDir = Path.Combine(tempDir, "manifest");
+        Directory.CreateDirectory(manifestDir);
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(manifestDir, "manifest.json"),
+                """
+                {
+                  "id": "old-id",
+                  "name": {
+                    "short": "Custom Short Name",
+                    "full": "Custom Full Name"
+                  }
+                }
+                """);
+            await File.WriteAllTextAsync(
+                Path.Combine(manifestDir, "agenticUserTemplateManifest.json"),
+                "{\"agentIdentityBlueprintId\":\"old-id\"}");
+
+            _configService.LoadAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(new Agent365Config
+            {
+                AgentBlueprintId = "test-blueprint-id",
+                AgentBlueprintDisplayName = "This Blueprint Display Name Is Longer Than Thirty Characters",
+                TenantId = "test-tenant",
+                DeploymentProjectPath = tempDir
+            });
+
+            var root = new RootCommand();
+            root.AddCommand(PublishCommand.CreateCommand(_logger, _configService, _manifestTemplateService));
+
+            var exitCode = await root.InvokeAsync("publish");
+
+            exitCode.Should().Be(0, because: "a customized manifest should remain publishable on subsequent runs");
+            var savedManifest = JsonNode.Parse(
+                await File.ReadAllTextAsync(Path.Combine(manifestDir, "manifest.json")))!;
+            savedManifest["name"]!["short"]!.GetValue<string>().Should().Be(
+                "Custom Short Name",
+                because: "publish must not overwrite a user-customized short name with an invalid blueprint display name");
+            savedManifest["name"]!["full"]!.GetValue<string>().Should().Be(
+                "Custom Full Name",
+                because: "publish must preserve the user-facing full name customized in the manifest");
+
+            using var archive = System.IO.Compression.ZipFile.OpenRead(Path.Combine(manifestDir, "manifest.zip"));
+            var manifestEntry = archive.GetEntry("manifest.json");
+            manifestEntry.Should().NotBeNull(because: "the published package must contain the customized manifest");
+            using var reader = new StreamReader(manifestEntry!.Open());
+            var packagedManifest = JsonNode.Parse(await reader.ReadToEndAsync())!;
+            packagedManifest["name"]!["short"]!.GetValue<string>().Should().Be(
+                "Custom Short Name",
+                because: "the package must contain the preserved valid short name");
+
+            _logger.DidNotReceive().Log(
                 LogLevel.Warning,
                 Arg.Any<EventId>(),
                 Arg.Is<object>(o => o.ToString()!.Contains("EXCEEDS 30 chars")),

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/QueryEntraCommandInheritanceHandlerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/QueryEntraCommandInheritanceHandlerTests.cs
@@ -300,4 +300,98 @@ public class QueryEntraCommandInheritanceHandlerTests
         LoggerReceivedContaining(LogLevel.Error, "Failed to query inheritable permissions").Should().BeTrue(
             because: "the error message must clearly identify the operation that failed so operators can correlate with logs");
     }
+
+    [Fact]
+    public async Task InheritanceSubcommand_WhenGrantEnumerationIsForbidden_LogsError_AndExitsOne()
+    {
+        SetupResolver(new Agent365Config { TenantId = ValidTenantId, AgentBlueprintId = ValidBlueprintId });
+        _mockBlueprintService.ListInheritablePermissionsAsync(
+            ValidTenantId, ValidBlueprintId, Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<(string, bool, bool)>
+            {
+                (GraphAppId, true, true)
+            }));
+        _mockBlueprintService.GetBlueprintSpGrantsAsync(
+                ValidTenantId,
+                ValidBlueprintId,
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<Dictionary<string, (string[], string[])>>>(_ =>
+                throw new InvalidOperationException("Microsoft Graph could not read OAuth2 permission grants: HTTP 403 Forbidden."));
+
+        var parser = new CommandLineBuilder(BuildRootCommand()).Build();
+        var exitCode = await parser.InvokeAsync("inheritance --agent-name test-agent", new TestConsole());
+
+        exitCode.Should().Be(1,
+            because: "an unreadable grants table is not evidence of zero grants and must fail scripted inheritance checks");
+        LoggerReceivedContaining(LogLevel.Error, "HTTP 403 Forbidden").Should().BeTrue(
+            because: "operators need the authorization failure surfaced instead of a misleading no-permissions result");
+    }
+
+    [Fact]
+    public async Task BlueprintScopesSubcommand_WhenGrantEnumerationIsForbidden_LogsError_AndExitsOne()
+    {
+        SetupResolver(new Agent365Config { TenantId = ValidTenantId, AgentBlueprintId = ValidBlueprintId });
+        _mockBlueprintService.ListInheritablePermissionsAsync(
+            ValidTenantId, ValidBlueprintId, Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<(string, bool, bool)>
+            {
+                (GraphAppId, true, true)
+            }));
+        _mockBlueprintService.GetBlueprintSpGrantsAsync(
+                ValidTenantId,
+                ValidBlueprintId,
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns<Task<Dictionary<string, (string[], string[])>>>(_ =>
+                throw new InvalidOperationException("Microsoft Graph could not read OAuth2 permission grants: HTTP 403 Forbidden."));
+
+        var parser = new CommandLineBuilder(BuildRootCommand()).Build();
+        var exitCode = await parser.InvokeAsync("blueprint-scopes --agent-name test-agent", new TestConsole());
+
+        exitCode.Should().Be(1,
+            because: "blueprint-scopes must not report zero permissions when Graph denied access to the grants table");
+        LoggerReceivedContaining(LogLevel.Error, "HTTP 403 Forbidden").Should().BeTrue(
+            because: "the command must make the denied administrative read visible to the operator");
+    }
+
+    [Fact]
+    public async Task BlueprintScopesSubcommand_WhenKnownResourcesHaveNoGrants_ReportsEmptyPermissions_AndExitsZero()
+    {
+        SetupResolver(new Agent365Config { TenantId = ValidTenantId, AgentBlueprintId = ValidBlueprintId });
+        _mockBlueprintService.ListInheritablePermissionsAsync(
+            ValidTenantId, ValidBlueprintId, Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new List<(string, bool, bool)>
+            {
+                (GraphAppId, true, true),
+                (ObservabilityAppId, true, true)
+            }));
+        _mockBlueprintService.GetBlueprintSpGrantsAsync(
+                ValidTenantId,
+                ValidBlueprintId,
+                Arg.Any<IEnumerable<string>>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Dictionary<string, (string[], string[])>(StringComparer.OrdinalIgnoreCase)
+            {
+                [GraphAppId] = (Array.Empty<string>(), Array.Empty<string>()),
+                [ObservabilityAppId] = (Array.Empty<string>(), Array.Empty<string>())
+            }));
+
+        var parser = new CommandLineBuilder(BuildRootCommand()).Build();
+        var exitCode = await parser.InvokeAsync("blueprint-scopes --agent-name test-agent", new TestConsole());
+
+        exitCode.Should().Be(0,
+            because: "a successful administrative read proving that known resources have zero grants is a valid query result");
+        LoggerReceivedContaining(LogLevel.Information, "Delegated permissions (0): (none)").Should().BeTrue(
+            because: "the command must visibly report empty delegated permissions rather than conflating them with an unreadable grants table");
+        LoggerReceivedContaining(LogLevel.Information, "Application permissions (0): (none)").Should().BeTrue(
+            because: "the command must visibly report empty application permissions for successfully read resources");
+        LoggerReceivedContaining(LogLevel.Information, "0 of 2 resource(s) have at least one granted permission").Should().BeTrue(
+            because: "the summary must preserve the known-resource versus zero-grants distinction for scripted diagnostics");
+        LoggerReceivedContaining(LogLevel.Error, "Failed to query blueprint granted permissions").Should().BeFalse(
+            because: "a successful empty grants response is not an error");
+    }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSubcommandInvalidationTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSubcommandInvalidationTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using FluentAssertions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
@@ -92,12 +93,18 @@ public class BlueprintSubcommandInvalidationTests
         {
             // Force the displayName-first lookup to report "not found" so we reach the new-blueprint
             // creation path. The service's `if (doc == null)` branch maps to Found=false.
-            _graphApiService.GraphGetAsync(
+            _graphApiService.GraphGetWithResponseAsync(
                 Arg.Any<string>(),
                 Arg.Any<string>(),
-                Arg.Any<CancellationToken>(),
-                Arg.Any<IEnumerable<string>?>())
-                .Returns(Task.FromResult<JsonDocument?>(null));
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.GraphResponse
+                {
+                    IsSuccess = true,
+                    StatusCode = 200,
+                    Json = JsonDocument.Parse("""{"value":[]}""")
+                });
 
             // Pre-populate the in-memory JsonObject with the kinds of stale identifiers the
             // invalidation block exists to wipe. If the clear loop is removed, these survive and
@@ -215,6 +222,73 @@ public class BlueprintSubcommandInvalidationTests
             {
                 Directory.Delete(tempDir, recursive: true);
             }
+        }
+    }
+
+    [Fact]
+    public async Task CreateAgentBlueprintAsync_WhenLookupIsForbidden_DoesNotInvalidateGeneratedConfig()
+    {
+        // Arrange
+        var tempDir = Path.Combine(Path.GetTempPath(), $"a365-blueprint-lookup-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var configFile = new FileInfo(Path.Combine(tempDir, "a365.config.json"));
+        var generatedConfig = new JsonObject
+        {
+            ["agentBlueprintId"] = "existing-blueprint-app-id",
+            ["agentBlueprintObjectId"] = "existing-blueprint-object-id"
+        };
+        var setupConfig = new Agent365Config
+        {
+            TenantId = TenantId,
+            AgentBlueprintDisplayName = DisplayName,
+            AgentBlueprintObjectId = "existing-blueprint-object-id"
+        };
+
+        try
+        {
+            _graphApiService.GraphGetWithResponseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.GraphResponse
+                {
+                    IsSuccess = false,
+                    StatusCode = 403,
+                    ReasonPhrase = "Forbidden"
+                });
+
+            // Act
+            var act = () => BlueprintSubcommand.CreateAgentBlueprintAsync(
+                _logger,
+                _executor,
+                _graphApiService,
+                _blueprintService,
+                _blueprintLookupService,
+                _federatedCredentialService,
+                tenantId: TenantId,
+                displayName: DisplayName,
+                agentIdentityDisplayName: null,
+                managedIdentityPrincipalId: null,
+                useManagedIdentity: true,
+                generatedConfig,
+                setupConfig,
+                _configService,
+                configFile,
+                CancellationToken.None);
+
+            // Assert
+            await act.Should().ThrowAsync<SetupValidationException>(
+                because: "an authorization failure makes existing-resource discovery inconclusive");
+            await _configService.DidNotReceiveWithAnyArgs()
+                .InvalidateGeneratedConfigAsync(default!, default!, default!);
+            generatedConfig["agentBlueprintObjectId"]!.GetValue<string>().Should().Be("existing-blueprint-object-id",
+                because: "inconclusive discovery must preserve the current generated state");
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
         }
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/PermissionSpecsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/PermissionSpecsTests.cs
@@ -104,6 +104,26 @@ public class PermissionSpecsTests : IDisposable
     }
 
     [Fact]
+    public async Task GccPath_UsesGccObservabilityResource()
+    {
+        var config = new Agent365Config
+        {
+            DeploymentProjectPath = _tempDir,
+            Environment = "gcc",
+        };
+
+        var specs = await SetupHelpers.BuildConfiguredPermissionSpecsAsync(
+            config,
+            setInheritable: true,
+            isM365: true);
+
+        ResourceAppIds(specs).Should().Contain(ConfigConstants.GccObservabilityApiAppId,
+            because: "GCC blueprints must inherit permissions from the GCC Observability resource");
+        ResourceAppIds(specs).Should().NotContain(ConfigConstants.ObservabilityApiAppId,
+            because: "the commercial Observability resource must not be stamped on a GCC blueprint");
+    }
+
+    [Fact]
     public async Task DwPath_WithV1Manifest_CollapsesLegacyAudienceOntoAtgAppId()
     {
         // Arrange: a V1-style manifest entry with an api:// audience.

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/AuthenticationConstantsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/AuthenticationConstantsTests.cs
@@ -12,6 +12,17 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Constants;
 public class AuthenticationConstantsTests
 {
     [Fact]
+    public void RequiredPermissionGrantScopes_IncludeApplicationAndBlueprintScopes()
+    {
+        AuthenticationConstants.RequiredPermissionGrantScopes.Should().Contain(
+            AuthenticationConstants.ApplicationReadAllScope,
+            because: "permission setup reads applications and service principals before applying grants");
+        AuthenticationConstants.RequiredPermissionGrantScopes.Should().Contain(
+            "AgentIdentityBlueprint.ReadWrite.All",
+            because: "permission setup reads and writes inheritable blueprint permissions");
+    }
+
+    [Fact]
     public void AzureCliClientId_ShouldBeValidGuid()
     {
         Guid.TryParse(AuthenticationConstants.AzureCliClientId, out _).Should().BeTrue();

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/ConfigConstantsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/ConfigConstantsTests.cs
@@ -65,6 +65,40 @@ public class ConfigConstantsTests
     }
 
     [Theory]
+    [InlineData("prod", ConfigConstants.ObservabilityApiAppId)]
+    [InlineData("commercial", ConfigConstants.ObservabilityApiAppId)]
+    [InlineData("gcc", ConfigConstants.GccObservabilityApiAppId)]
+    [InlineData("GCC Moderate", ConfigConstants.GccObservabilityApiAppId)]
+    [InlineData("gcc-moderate", ConfigConstants.GccObservabilityApiAppId)]
+    [InlineData("gcc-high", ConfigConstants.GccHighObservabilityApiAppId)]
+    [InlineData("GCC High", ConfigConstants.GccHighObservabilityApiAppId)]
+    [InlineData("dod", ConfigConstants.DodObservabilityApiAppId)]
+    public void GetObservabilityApiAppId_ReturnsCloudSpecificResource(
+        string environment,
+        string expected)
+    {
+        ConfigConstants.GetObservabilityApiAppId(environment).Should().Be(expected,
+            because: "Observability tokens and permission grants must target the resource deployed in the selected cloud");
+    }
+
+    [Fact]
+    public void GetObservabilityApiIdentifierUri_UsesResolvedCloudResource()
+    {
+        ConfigConstants.GetObservabilityApiIdentifierUri("gcc")
+            .Should().Be($"api://{ConfigConstants.GccObservabilityApiAppId}",
+                because: "the admin-consent scope prefix must match the GCC Observability application ID");
+    }
+
+    [Fact]
+    public void GetObservabilityApiAppId_WithAmbiguousAzureGovernmentCloud_Throws()
+    {
+        var act = () => ConfigConstants.GetObservabilityApiAppId("AzureUSGovernment");
+
+        act.Should().Throw<ArgumentException>(
+            because: "the Azure CLI government cloud name cannot distinguish GCC Moderate, GCC High, and DoD resources");
+    }
+
+    [Theory]
     [InlineData("http://graph.example")]
     [InlineData("https://user@graph.example")]
     [InlineData("https://graph.example/path")]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/ConfigConstantsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/ConfigConstantsTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Constants;
+
+[Collection("ConfigTests")]
+public class ConfigConstantsTests
+{
+    [Theory]
+    [InlineData("gcc-high", "GCC_HIGH")]
+    [InlineData("Gcc High", "GCC_HIGH")]
+    [InlineData("gcch", "GCCH")]
+    [InlineData("", "PROD")]
+    public void NormalizeEnvironmentKey_ProducesEnvironmentVariableSuffix(
+        string environment,
+        string expected)
+    {
+        ConfigConstants.NormalizeEnvironmentKey(environment).Should().Be(expected);
+    }
+
+    [Fact]
+    public void EnvironmentScopedOverrides_UseNormalizedCloudName()
+    {
+        const string appId = "11111111-2222-3333-4444-555555555555";
+        const string discoverEndpoint = "https://tools.example/discover";
+
+        WithEnvironmentVariable("A365_MCP_APP_ID_GCC_HIGH", appId, () =>
+            ConfigConstants.GetAgent365ToolsResourceAppId("gcc-high").Should().Be(appId));
+        WithEnvironmentVariable("A365_DISCOVER_ENDPOINT_GCC_HIGH", discoverEndpoint, () =>
+            ConfigConstants.GetDiscoverEndpointUrl("gcc-high").Should().Be(discoverEndpoint));
+    }
+
+    [Fact]
+    public void GraphBaseUrl_UsesScopedOverrideThenConfigThenDefault()
+    {
+        const string key = "A365_GRAPH_BASE_URL_GCC_HIGH";
+
+        WithEnvironmentVariable(key, "https://scoped.example/", () =>
+            ConfigConstants.GetGraphBaseUrl("gcc-high", "https://config.example")
+                .Should().Be("https://scoped.example"));
+
+        WithEnvironmentVariable(key, null, () =>
+            ConfigConstants.GetGraphBaseUrl("gcc-high", "https://config.example/")
+                .Should().Be("https://config.example"));
+
+    }
+
+    [Fact]
+    public void AuthorityHost_UsesScopedOverrideThenConfigThenDefault()
+    {
+        const string key = "A365_AUTHORITY_HOST_GCC_HIGH";
+
+        WithEnvironmentVariable(key, "https://login.scoped.example/", () =>
+            ConfigConstants.GetAuthorityHost("gcc-high", "https://login.config.example")
+                .Should().Be("https://login.scoped.example"));
+
+        WithEnvironmentVariable(key, null, () =>
+            ConfigConstants.GetAuthorityHost("gcc-high", "https://login.config.example/")
+                .Should().Be("https://login.config.example"));
+
+    }
+
+    [Theory]
+    [InlineData("http://graph.example")]
+    [InlineData("https://user@graph.example")]
+    [InlineData("https://graph.example/path")]
+    [InlineData("https://graph.example?query=value")]
+    [InlineData("https://graph.example#fragment")]
+    public void GraphBaseUrl_RejectsValuesThatAreNotHttpsOrigins(string value)
+    {
+        WithEnvironmentVariable("A365_GRAPH_BASE_URL_GCC_HIGH", null, () =>
+            FluentActions.Invoking(() => ConfigConstants.GetGraphBaseUrl("gcc-high", value))
+                .Should().Throw<ArgumentException>());
+    }
+
+    private static void WithEnvironmentVariable(string name, string? value, Action assertion)
+    {
+        var previous = Environment.GetEnvironmentVariable(name);
+        try
+        {
+            Environment.SetEnvironmentVariable(name, value);
+            assertion();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(name, previous);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Exceptions/ClientAppValidationExceptionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Exceptions/ClientAppValidationExceptionTests.cs
@@ -159,7 +159,8 @@ public class ClientAppValidationExceptionTests
 
         // Assert
         consentUrl.Should().NotBeNull();
-        consentUrl.Should().StartWith($"https://login.example/{TestTenantId}/adminconsent");
+        consentUrl.Should().StartWith($"https://login.example/{TestTenantId}/adminconsent",
+            because: "the admin consent URL must be rooted at the cloud-specific authority host with the tenant ID in the path — using the wrong authority host produces an AADSTS error for sovereign/government clouds");
         consentUrl.Should().Contain($"client_id={TestClientAppId}", because: "the client ID must be preserved in the admin consent URL query string");
         consentUrl.Should().Contain(
             $"redirect_uri={Uri.EscapeDataString("https://login.example/common/oauth2/nativeclient")}",

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Exceptions/ClientAppValidationExceptionTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Exceptions/ClientAppValidationExceptionTests.cs
@@ -154,16 +154,18 @@ public class ClientAppValidationExceptionTests
     public void BuildAdminConsentUrl_EncodesRedirectUri()
     {
         // Act
-        var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(TestClientAppId, TestTenantId);
+        var consentUrl = ClientAppValidationException.BuildAdminConsentUrl(
+            TestClientAppId, TestTenantId, "https://login.example");
 
         // Assert
         consentUrl.Should().NotBeNull();
+        consentUrl.Should().StartWith($"https://login.example/{TestTenantId}/adminconsent");
         consentUrl.Should().Contain($"client_id={TestClientAppId}", because: "the client ID must be preserved in the admin consent URL query string");
         consentUrl.Should().Contain(
-            $"redirect_uri={Uri.EscapeDataString("https://login.microsoftonline.com/common/oauth2/nativeclient")}",
+            $"redirect_uri={Uri.EscapeDataString("https://login.example/common/oauth2/nativeclient")}",
             because: "redirect_uri is a URL-valued query parameter and must be encoded so the consent link remains valid when copied through shells, logs, and browsers");
         consentUrl.Should().NotContain(
-            "&redirect_uri=https://login.microsoftonline.com/common/oauth2/nativeclient",
+            "&redirect_uri=https://login.example/common/oauth2/nativeclient",
             because: "an unescaped redirect URI contains reserved characters that can corrupt the admin consent query string");
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersAdminConsentInstructionsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersAdminConsentInstructionsTests.cs
@@ -136,6 +136,17 @@ public class SetupHelpersAdminConsentInstructionsTests
     }
 
     [Fact]
+    public void GetNonDwAdminConsentSpecs_ForGcc_UsesGccObservabilityResource()
+    {
+        var specs = SetupHelpers.GetNonDwAdminConsentSpecs("gcc");
+
+        specs.Where(spec => spec.ResourceName == "Observability API")
+            .Should().OnlyContain(
+                spec => spec.ResourceAppId == ConfigConstants.GccObservabilityApiAppId,
+                because: "manual GCC consent instructions must target the GCC Observability resource");
+    }
+
+    [Fact]
     public void NonDwAdminConsentSpecs_PowerPlatformApi_IsDelegatedOnly()
     {
         var specs = SetupHelpers.NonDwAdminConsentSpecs;

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
@@ -232,7 +232,7 @@ public class SetupHelpersBootstrapTests : IDisposable
     [Fact]
     public async Task ResolveBootstrapEnvironmentAsync_WhenEnvironmentVariableIsSet_UsesItWithoutCallingAzureCli()
     {
-        const string expectedEnvironment = "AzureUSGovernment";
+        const string expectedEnvironment = "gcc";
         var originalEnvironment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT");
         Environment.SetEnvironmentVariable("A365_ENVIRONMENT", $" {expectedEnvironment} ");
         try
@@ -265,15 +265,44 @@ public class SetupHelpersBootstrapTests : IDisposable
                 .Returns(new CommandResult
                 {
                     ExitCode = 0,
-                    StandardOutput = "AzureUSGovernment\n",
+                    StandardOutput = "AzureCloud\n",
                     StandardError = string.Empty
                 });
 
             var result = await SetupHelpers.ResolveBootstrapEnvironmentAsync(
                 _mockExecutor, NullLogger.Instance, CancellationToken.None);
 
-            result.Should().Be("AzureUSGovernment",
+            result.Should().Be("AzureCloud",
                 because: "config-free bootstrap must target the active Azure CLI cloud before resolving the client application");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("A365_ENVIRONMENT", originalEnvironment);
+        }
+    }
+
+    [Fact]
+    public async Task ResolveBootstrapEnvironmentAsync_WhenAzureCliUsesUsGovernment_RequiresExplicitEnvironment()
+    {
+        var originalEnvironment = Environment.GetEnvironmentVariable("A365_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("A365_ENVIRONMENT", null);
+        try
+        {
+            _mockExecutor.ExecuteAsync(
+                    "az", "cloud show --query name -o tsv",
+                    Arg.Any<string?>(), true, true, Arg.Any<CancellationToken>())
+                .Returns(new CommandResult
+                {
+                    ExitCode = 0,
+                    StandardOutput = "AzureUSGovernment\n",
+                    StandardError = string.Empty
+                });
+
+            var act = () => SetupHelpers.ResolveBootstrapEnvironmentAsync(
+                _mockExecutor, NullLogger.Instance, CancellationToken.None);
+
+            await act.Should().ThrowAsync<SetupValidationException>(
+                because: "AzureUSGovernment cannot identify whether the tenant is GCC Moderate, GCC High, or DoD");
         }
         finally
         {

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
@@ -230,6 +230,26 @@ public class SetupHelpersConsentUrlTests
     }
 
     [Fact]
+    public void BuildCombinedConsentUrl_WithGccObservabilityResource_UsesGccAudience()
+    {
+        var url = SetupHelpers.BuildCombinedConsentUrl(
+            TenantId,
+            BlueprintClientId,
+            Array.Empty<string>(),
+            Array.Empty<string>(),
+            observabilityResourceAppId: ConfigConstants.GccObservabilityApiAppId);
+
+        url.Should().Contain(
+            Uri.EscapeDataString(
+                $"api://{ConfigConstants.GccObservabilityApiAppId}/{ConfigConstants.ObservabilityApiOtelWriteScope}"),
+            because: "GCC admin consent must grant the OtelWrite scope on the GCC Observability resource");
+        url.Should().NotContain(
+            Uri.EscapeDataString(
+                $"{ConfigConstants.ObservabilityApiIdentifierUri}/{ConfigConstants.ObservabilityApiOtelWriteScope}"),
+            because: "a GCC consent URL must not request the commercial Observability audience");
+    }
+
+    [Fact]
     public void BuildCombinedConsentUrl_ScopesJoinedWithEncodedSpaceNotAmpersand()
     {
         var url = SetupHelpers.BuildCombinedConsentUrl(

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
@@ -177,10 +177,13 @@ public class SetupHelpersConsentUrlTests
     {
         var url = SetupHelpers.BuildCombinedConsentUrl(
             TenantId, BlueprintClientId,
-            new[] { "Mail.Send" }, new[] { "McpServers.Mail.All" });
+            new[] { "Mail.Send" }, new[] { "McpServers.Mail.All" },
+            graphResourceUri: "https://graph.example",
+            authorityHost: "https://login.example");
 
-        url.Should().StartWith($"https://login.microsoftonline.com/{TenantId}/v2.0/adminconsent");
+        url.Should().StartWith($"https://login.example/{TenantId}/v2.0/adminconsent");
         url.Should().Contain($"client_id={BlueprintClientId}");
+        url.Should().Contain(Uri.EscapeDataString("https://graph.example/Mail.Send"));
         url.Should().Contain($"redirect_uri={Uri.EscapeDataString(AuthenticationConstants.BlueprintConsentRedirectUri)}",
             because: "redirect_uri must be registered on the blueprint app — AADSTS500113 is returned if absent or unregistered");
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersConsentUrlTests.cs
@@ -183,7 +183,8 @@ public class SetupHelpersConsentUrlTests
 
         url.Should().StartWith($"https://login.example/{TenantId}/v2.0/adminconsent");
         url.Should().Contain($"client_id={BlueprintClientId}");
-        url.Should().Contain(Uri.EscapeDataString("https://graph.example/Mail.Send"));
+        url.Should().Contain(Uri.EscapeDataString("https://graph.example/Mail.Send"),
+            because: "Graph scopes in the consent URL must be fully-qualified resource URIs and URI-encoded — AAD rejects bare scope names or unencoded URIs in the adminconsent query string");
         url.Should().Contain($"redirect_uri={Uri.EscapeDataString(AuthenticationConstants.BlueprintConsentRedirectUri)}",
             because: "redirect_uri must be registered on the blueprint app — AADSTS500113 is returned if absent or unregistered");
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersDisplaySetupSummaryTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersDisplaySetupSummaryTests.cs
@@ -273,6 +273,33 @@ public class SetupHelpersDisplaySetupSummaryTests
             because: "when no consent URL is available the non-DW summary must fall back to the LogNonDwAdminConsentInstructions portal walkthrough so the user still has a recovery path");
     }
 
+    [Fact]
+    public void DisplaySetupSummary_NonDwGccAdminConsentPending_UsesGccObservabilityResource()
+    {
+        var logger = new CapturingLogger();
+        var results = new SetupResults
+        {
+            IsNonDwBlueprintFlow = true,
+            BlueprintCreated = true,
+            BlueprintId = BlueprintId,
+            AgentIdentityCreated = true,
+            AgentIdentityId = AgentSpId,
+            TenantId = TenantId,
+            EffectiveAuthMode = Cli.Models.AuthMode.Obo,
+            TenantWideConsentOutcome = Cli.Models.GrantOutcome.Failed,
+            BatchPermissionsPhase1Completed = true,
+            BatchPermissionsPhase2Completed = true,
+            ObservabilityResourceAppId = ConfigConstants.GccObservabilityApiAppId,
+        };
+
+        SetupHelpers.DisplaySetupSummary(results, logger);
+
+        logger.AllOutput.Should().Contain(ConfigConstants.GccObservabilityApiAppId,
+            because: "manual GCC recovery instructions must target the GCC Observability service");
+        logger.AllOutput.Should().NotContain(ConfigConstants.ObservabilityApiAppId,
+            because: "manual GCC recovery instructions must not target the commercial Observability service");
+    }
+
     /// <summary>
     /// B2 regression — non-admin AID developer running `setup all` as OBO must see the consent URL
     /// surfaced as an action item. Pre-refactor, the orchestrator wrote a misleading

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/A365CreateInstanceRunnerTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/A365CreateInstanceRunnerTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
+
+public sealed class A365CreateInstanceRunnerTests : IDisposable
+{
+    private readonly string _testDirectory;
+
+    public A365CreateInstanceRunnerTests()
+    {
+        _testDirectory = Path.Combine(Path.GetTempPath(), $"a365-create-instance-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDirectory);
+    }
+
+    [Fact]
+    public async Task RunAsync_WhenExistingGrantReadFails_LogsErrorReturnsFalseAndDoesNotWriteGrants()
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        var generatedConfigPath = Path.Combine(_testDirectory, "a365.generated.config.json");
+        await File.WriteAllTextAsync(
+            configPath,
+            """
+            {
+              "tenantId": "11111111-1111-1111-1111-111111111111",
+              "environment": "prod"
+            }
+            """);
+        await File.WriteAllTextAsync(
+            generatedConfigPath,
+            """
+            {
+              "agentBlueprintId": "22222222-2222-2222-2222-222222222222",
+              "agentBlueprintClientSecret": "test-secret",
+              "AgenticAppId": "33333333-3333-3333-3333-333333333333",
+              "AgenticUserId": "44444444-4444-4444-4444-444444444444"
+            }
+            """);
+
+        var logger = Substitute.For<ILogger<A365CreateInstanceRunner>>();
+        var executor = Substitute.For<CommandExecutor>(NullLogger<CommandExecutor>.Instance);
+        var graph = Substitute.ForPartsOf<GraphApiService>(
+            NullLogger<GraphApiService>.Instance,
+            executor,
+            (Func<Task<string?>>?)(() => Task.FromResult<string?>(null)));
+        graph.LookupServicePrincipalByAppIdAsync(
+                "11111111-1111-1111-1111-111111111111",
+                "33333333-3333-3333-3333-333333333333",
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns("agent-sp-object-id");
+        graph.GetOauth2PermissionGrantsAsync(
+                "11111111-1111-1111-1111-111111111111",
+                "agent-sp-object-id",
+                Arg.Any<CancellationToken>())
+            .Returns<Task<List<(string resourceId, string scope, string consentType)>>>(_ =>
+                throw new InvalidOperationException("Microsoft Graph could not read OAuth2 permission grants: HTTP 403 Forbidden."));
+
+        var runner = new A365CreateInstanceRunner(logger, executor, graph);
+
+        var succeeded = await runner.RunAsync(
+            configPath,
+            generatedConfigPath,
+            step: "identity");
+
+        succeeded.Should().BeFalse(
+            because: "grant creation cannot safely continue when the idempotency pre-read is unreadable");
+        logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("no grant changes were attempted", StringComparison.Ordinal)),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
+        await graph.DidNotReceive().EnsureServicePrincipalForAppIdAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<bool>());
+        await graph.DidNotReceive().CreateOrUpdateOauth2PermissionGrantAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<IEnumerable<string>>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>());
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_testDirectory))
+        {
+            Directory.Delete(_testDirectory, recursive: true);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AdminConsentHelperTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AdminConsentHelperTests.cs
@@ -30,9 +30,15 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services
                 .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult { ExitCode = 0, StandardOutput = grantsJson }));
 
             var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var result = await AdminConsentHelper.PollAdminConsentAsync(executor, logger, "appId-1", "Test", 10, 1, cts.Token);
+            var result = await AdminConsentHelper.PollAdminConsentAsync(
+                executor, logger, "appId-1", "Test", 10, 1, cts.Token,
+                graphBaseUrl: "https://graph.example");
 
             result.Should().BeTrue();
+            await executor.Received(2).ExecuteAsync(
+                "az",
+                Arg.Is<string>(args => args.Contains("https://graph.example/v1.0", StringComparison.Ordinal)),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
         }
 
         [Fact]
@@ -464,4 +470,3 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services
         }
     }
 }
-

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
@@ -243,6 +243,9 @@ public class AgentBlueprintServiceTests
     [Fact]
     public async Task GetBlueprintSpGrantsAsync_ReturnsScopesAndResolvedRoleNames()
     {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string appRoleId = "44444444-4444-4444-4444-444444444444";
+
         // Arrange — single resource with one delegated scope grant and one app role assignment on
         // the blueprint SP. The role assignment's appRoleId must be resolved to a human-readable
         // name via a lookup of the resource SP's appRoles array (the same shape Graph returns).
@@ -268,38 +271,123 @@ public class AgentBlueprintServiceTests
         // 2) GetOauth2PermissionGrantsAsync — one delegated grant for the resource
         handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { resourceId = "obs-sp-id", scope = "otel-write extra-scope", consentType = "AllPrincipals" } } }))
+            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { resourceId = resourceSpId, scope = "otel-write extra-scope", consentType = "AllPrincipals" } } }))
         });
         // 3) appRoleAssignments on the blueprint SP — one assignment for the resource
         handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { resourceId = "obs-sp-id", appRoleId = "role-guid-1" } } }))
+            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { resourceId = resourceSpId, appRoleId } } }))
         });
         // 4) LookupServicePrincipalByAppIdAsync(resourceAppId) -> resource SP id
         handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
         {
-            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { id = "obs-sp-id" } } }))
+            Content = new StringContent(JsonSerializer.Serialize(new { value = new[] { new { id = resourceSpId } } }))
         });
         // 5) GET resource SP appRoles to resolve the role id to a human-readable name
         handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(JsonSerializer.Serialize(new
             {
-                appRoles = new[] { new { id = "role-guid-1", value = "Agent365.Observability.OtelWrite" } }
+                appRoles = new[] { new { id = appRoleId, value = "Agent365.Observability.OtelWrite" } }
             }))
         });
 
         // Act
+        const string blueprintAppId = "11111111-1111-1111-1111-111111111111";
+        const string resourceAppId = "22222222-2222-2222-2222-222222222222";
+
         var grants = await service.GetBlueprintSpGrantsAsync(
-            "tid", "blueprint-app-id", new[] { "observability-app-id" });
+            "tid", blueprintAppId, new[] { resourceAppId });
 
         // Assert
-        grants.Should().ContainKey("observability-app-id");
-        var (delegatedScopes, appRoleNames) = grants["observability-app-id"];
+        grants.Should().ContainKey(resourceAppId);
+        var (delegatedScopes, appRoleNames) = grants[resourceAppId];
         delegatedScopes.Should().BeEquivalentTo(new[] { "extra-scope", "otel-write" },
             because: "the space-delimited Graph scope string must be split into individual scopes and returned sorted");
         appRoleNames.Should().BeEquivalentTo(new[] { "Agent365.Observability.OtelWrite" },
             because: "app role IDs must be resolved to their human-readable values via the resource SP's appRoles array");
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WithUnrelatedNullValuedRole_ResolvesAssignedRole()
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string assignedRoleId = "44444444-4444-4444-4444-444444444444";
+        const string unrelatedRoleId = "55555555-5555-5555-5555-555555555555";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{assignedRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "appRoles": [
+                        { "id": "{{assignedRoleId}}", "value": "Assigned.Role" },
+                        { "id": "{{unrelatedRoleId}}", "value": null }
+                      ]
+                    }
+                    """)
+            });
+
+        var result = await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        result["resource-app-id"].AppRoleNames.Should().Equal(new[] { "Assigned.Role" },
+            because: "an unrelated app role with no value must not invalidate otherwise usable role metadata");
     }
 
     [Fact]
@@ -1149,10 +1237,15 @@ public class AgentBlueprintServiceTests
         result.Should().BeEmpty(
             because: "no resource app IDs means there's nothing to enumerate — the method must short-circuit to an empty dict");
 
-        await graph.DidNotReceive().LookupServicePrincipalByAppIdAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+        await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>());
         await graph.DidNotReceive().GetOauth2PermissionGrantsAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -1163,9 +1256,16 @@ public class AgentBlueprintServiceTests
         // answer would otherwise come back empty without explanation.
         var (service, graph) = BuildServiceWithMockedGraph();
 
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "blueprint-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns((string?)null);
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
 
         var result = await service.GetBlueprintSpGrantsAsync(
             "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
@@ -1175,7 +1275,9 @@ public class AgentBlueprintServiceTests
 
         // No grant enumeration must occur after the SP lookup failed.
         await graph.DidNotReceive().GetOauth2PermissionGrantsAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
 
         _mockLogger.Received().Log(
             LogLevel.Warning,
@@ -1183,6 +1285,235 @@ public class AgentBlueprintServiceTests
             Arg.Is<object>(o => o.ToString()!.Contains("Blueprint service principal not found")),
             Arg.Any<Exception>(),
             Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenBlueprintSpLookupFails_Throws()
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = 403,
+                FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 403 Forbidden."
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*HTTP 403 Forbidden*",
+                because: "an unreadable blueprint lookup must not masquerade as a successfully absent service principal");
+        await graph.DidNotReceive().GetOauth2PermissionGrantsAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenAppRoleAssignmentsReadFails_Throws()
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 403,
+                ReasonPhrase = "Forbidden"
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*app role assignments*HTTP 403 Forbidden*",
+                because: "a failed assignments read must remain distinct from a successful empty value array");
+        await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-id",
+            "resource-app-id",
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenAppRoleAssignmentsTransportFails_ThrowsWithFailureReason()
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 0,
+                ReasonPhrase = "connection reset"
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "a transport failure while reading assignments must not be treated as a successful empty assignment list");
+        exception.Which.Message.Should().Contain("connection reset",
+            because: "the status-zero response reason is the only visible transport diagnostic");
+        exception.Which.Message.Should().NotContain("HTTP 0",
+            because: "no HTTP response exists when Graph reports status zero");
+        await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-id",
+            "resource-app-id",
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenAppRoleAssignmentsShapeIsMalformed_Throws()
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc(@"{ ""value"": {} }")
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid app role assignments response*",
+                because: "an unexpected successful response shape must not be treated as an empty assignments collection");
+    }
+
+    [Theory]
+    [InlineData("not-a-guid", "44444444-4444-4444-4444-444444444444")]
+    [InlineData("33333333-3333-3333-3333-333333333333", "not-a-guid")]
+    public async Task GetBlueprintSpGrantsAsync_WhenAppRoleAssignmentIdentifierIsNotGuid_Throws(
+        string resourceId,
+        string appRoleId)
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceId}}", "appRoleId": "{{appRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid app role assignment*",
+                because: "Graph app role assignment identifiers must be GUIDs rather than arbitrary non-empty strings");
+        await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-id",
+            "resource-app-id",
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
     }
 
     [Fact]
@@ -1194,23 +1525,47 @@ public class AgentBlueprintServiceTests
         // and the inheritance command surfaces the two cases differently.
         var (service, graph) = BuildServiceWithMockedGraph();
 
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "blueprint-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns("bp-sp-id");
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
         graph.GetOauth2PermissionGrantsAsync(
-                "tenant-id", "bp-sp-id", Arg.Any<CancellationToken>())
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
             .Returns(new List<(string resourceId, string scope, string consentType)>());
         // appRoleAssignments — empty
-        graph.GraphGetAsync(
+        graph.GraphGetWithResponseAsync(
                 "tenant-id",
                 Arg.Is<string>(s => s.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>(),
-                Arg.Any<IEnumerable<string>?>())
-            .Returns(JsonDoc(@"{ ""value"": [] }"));
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc(@"{ ""value"": [] }")
+            });
         // Resource SP lookup returns null — this resource is unprovisioned.
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "missing-resource-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns((string?)null);
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "missing-resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
 
         var result = await service.GetBlueprintSpGrantsAsync(
             "tenant-id", "blueprint-app-id", new[] { "missing-resource-app-id" });
@@ -1222,6 +1577,60 @@ public class AgentBlueprintServiceTests
     }
 
     [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenResourceSpLookupFails_Throws()
+    {
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc(@"{ ""value"": [] }")
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = 503,
+                FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 503 Service Unavailable."
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*HTTP 503 Service Unavailable*",
+                because: "a failed resource lookup must not be omitted as though Graph successfully found no service principal");
+    }
+
+    [Fact]
     public async Task GetBlueprintSpGrantsAsync_WhenResourceHasZeroGrants_IncludesResourceWithEmptyArrays()
     {
         // The contract documented on the method: "Resources with no grants on the blueprint SP
@@ -1230,22 +1639,47 @@ public class AgentBlueprintServiceTests
         // tell "this resource has no grants" apart from "we couldn't look this resource up".
         var (service, graph) = BuildServiceWithMockedGraph();
 
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "blueprint-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns("bp-sp-id");
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
         graph.GetOauth2PermissionGrantsAsync(
-                "tenant-id", "bp-sp-id", Arg.Any<CancellationToken>())
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
             .Returns(new List<(string resourceId, string scope, string consentType)>());
-        graph.GraphGetAsync(
+        graph.GraphGetWithResponseAsync(
                 "tenant-id",
                 Arg.Is<string>(s => s.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>(),
-                Arg.Any<IEnumerable<string>?>())
-            .Returns(JsonDoc(@"{ ""value"": [] }"));
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc(@"{ ""value"": [] }")
+            });
         // Resource SP exists but has no delegated grants or app role assignments.
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "zero-grants-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns("zero-grants-sp-id");
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "zero-grants-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "zero-grants-sp-id",
+                StatusCode = 200
+            });
 
         var result = await service.GetBlueprintSpGrantsAsync(
             "tenant-id", "blueprint-app-id", new[] { "zero-grants-app-id" });
@@ -1257,11 +1691,19 @@ public class AgentBlueprintServiceTests
             because: "no delegated grants were issued on the blueprint SP for this resource");
         appRoleNames.Should().BeEmpty(
             because: "no app role assignments were issued on the blueprint SP for this resource");
+        await graph.Received(1).GetOauth2PermissionGrantsAsync(
+            "tenant-id",
+            "bp-sp-id",
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task GetBlueprintSpGrantsAsync_WhenAppRoleIdIsUnknown_FallsBackToAngleBracketPlaceholder()
     {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string unknownRoleId = "44444444-4444-4444-4444-444444444444";
+        const string otherRoleId = "55555555-5555-5555-5555-555555555555";
+
         // When the blueprint SP has an app role assignment but the resource SP's appRoles array
         // does not contain a matching entry (e.g. the role was removed from the resource after
         // assignment, or the resource SP doc was fetched with a $select that elided it), the
@@ -1270,45 +1712,473 @@ public class AgentBlueprintServiceTests
         // to flag the entry as unresolved.
         var (service, graph) = BuildServiceWithMockedGraph();
 
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "blueprint-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns("bp-sp-id");
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
         graph.GetOauth2PermissionGrantsAsync(
-                "tenant-id", "bp-sp-id", Arg.Any<CancellationToken>())
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
             .Returns(new List<(string resourceId, string scope, string consentType)>());
         // App role assignment exists on the blueprint SP for our resource.
-        graph.GraphGetAsync(
+        graph.GraphGetWithResponseAsync(
                 "tenant-id",
                 Arg.Is<string>(s => s.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>(),
-                Arg.Any<IEnumerable<string>?>())
-            .Returns(JsonDoc(@"{
-              ""value"": [
-                { ""resourceId"": ""resource-sp-id"", ""appRoleId"": ""unknown-role-guid"" }
-              ]
-            }"));
-        graph.LookupServicePrincipalByAppIdAsync(
-                "tenant-id", "resource-app-id", Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
-            .Returns("resource-sp-id");
-        // Resource SP appRoles does NOT contain "unknown-role-guid".
-        graph.GraphGetAsync(
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{unknownRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
                 "tenant-id",
-                Arg.Is<string>(s => s.Contains("/servicePrincipals/resource-sp-id?$select=appRoles", StringComparison.Ordinal)),
+                "resource-app-id",
                 Arg.Any<CancellationToken>(),
-                Arg.Any<IEnumerable<string>?>())
-            .Returns(JsonDoc(@"{
-              ""appRoles"": [
-                { ""id"": ""some-other-role-id"", ""value"": ""Some.Other.Role"" }
-              ]
-            }"));
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        // Resource SP appRoles does not contain the assigned role ID.
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(s => s.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "appRoles": [
+                        { "id": "{{otherRoleId}}", "value": "Some.Other.Role" }
+                      ]
+                    }
+                    """)
+            });
 
         var result = await service.GetBlueprintSpGrantsAsync(
             "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
 
         result.Should().ContainKey("resource-app-id");
         var (_, appRoleNames) = result["resource-app-id"];
-        appRoleNames.Should().Equal(new[] { "<unknown-role-guid>" },
+        appRoleNames.Should().Equal(new[] { $"<{unknownRoleId}>" },
             because: "an unresolvable role ID must surface as '<role-id>' so operators can still see and investigate the assignment — silently dropping it would hide a real grant");
+        await graph.Received(1).GraphGetWithResponseAsync(
+            "tenant-id",
+            Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenAssignedRoleMetadataIsEmpty_ReturnsAngleBracketPlaceholder()
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string assignedRoleId = "44444444-4444-4444-4444-444444444444";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{assignedRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc("""{ "appRoles": [] }""")
+            });
+
+        var result = await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        result["resource-app-id"].AppRoleNames.Should().Equal(new[] { $"<{assignedRoleId}>" },
+            because: "a successful empty metadata array cannot erase a real assignment and must use the documented unresolved-role placeholder");
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"appRoles\":{}}")]
+    public async Task GetBlueprintSpGrantsAsync_WhenRoleMetadataTopLevelPayloadIsMalformed_Throws(string responseBody)
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string assignedRoleId = "44444444-4444-4444-4444-444444444444";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{assignedRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc(responseBody)
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid app role metadata*",
+                because: "a successful response without an array-valued 'appRoles' member cannot resolve a real assignment safely");
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenAppRoleMetadataIdIsNotGuid_Throws()
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string assignedRoleId = "44444444-4444-4444-4444-444444444444";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{assignedRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc("""
+                    {
+                      "appRoles": [
+                        { "id": "not-a-guid", "value": "Malformed.Role" }
+                      ]
+                    }
+                    """)
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid app role metadata*",
+                because: "Graph app role metadata identifiers must be GUIDs rather than arbitrary non-empty strings");
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenRoleMetadataReadFails_Throws()
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string appRoleId = "44444444-4444-4444-4444-444444444444";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{appRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 503,
+                ReasonPhrase = "Service Unavailable"
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*app role metadata*HTTP 503 Service Unavailable*",
+                because: "unreadable role metadata must not turn known assignments into unresolved placeholders");
+    }
+
+    [Fact]
+    public async Task GetBlueprintSpGrantsAsync_WhenRoleMetadataTransportFails_ThrowsWithFailureReason()
+    {
+        const string resourceSpId = "33333333-3333-3333-3333-333333333333";
+        const string appRoleId = "44444444-4444-4444-4444-444444444444";
+        var (service, graph) = BuildServiceWithMockedGraph();
+
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "blueprint-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "bp-sp-id",
+                StatusCode = 200
+            });
+        graph.GetOauth2PermissionGrantsAsync(
+                "tenant-id",
+                "bp-sp-id",
+                Arg.Any<CancellationToken>())
+            .Returns(new List<(string resourceId, string scope, string consentType)>());
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains("/servicePrincipals/bp-sp-id/appRoleAssignments", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDoc($$"""
+                    {
+                      "value": [
+                        { "resourceId": "{{resourceSpId}}", "appRoleId": "{{appRoleId}}" }
+                      ]
+                    }
+                    """)
+            });
+        graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                "resource-app-id",
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = resourceSpId,
+                StatusCode = 200
+            });
+        graph.GraphGetWithResponseAsync(
+                "tenant-id",
+                Arg.Is<string>(path => path.Contains($"/servicePrincipals/{resourceSpId}?$select=appRoles", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 0,
+                ReasonPhrase = "connection reset"
+            });
+
+        Func<Task> act = async () => await service.GetBlueprintSpGrantsAsync(
+            "tenant-id", "blueprint-app-id", new[] { "resource-app-id" });
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "a role metadata transport failure must remain distinct from a successful empty metadata array");
+        exception.Which.Message.Should().Contain("connection reset",
+            because: "the status-zero Graph response reason must remain visible to the operator");
+        exception.Which.Message.Should().NotContain("HTTP 0",
+            because: "status zero represents absence of an HTTP response rather than an HTTP protocol status");
     }
 }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BlueprintLookupServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BlueprintLookupServiceTests.cs
@@ -92,11 +92,13 @@ public class BlueprintLookupServiceTests
         }}";
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
-        _graphApiService.GraphGetAsync(
+        _graphApiService.GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("/beta/applications?$filter=")),
+            false,
+            Arg.Is<IEnumerable<string>?>(scopes => scopes != null && scopes.Contains("Application.Read.All")),
             Arg.Any<CancellationToken>())
-            .Returns(jsonDoc);
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
 
         // Act
         var result = await _service.GetApplicationByDisplayNameAsync(TestTenantId, TestDisplayName);
@@ -118,11 +120,13 @@ public class BlueprintLookupServiceTests
         var jsonResponse = @"{""value"": []}";
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
-        _graphApiService.GraphGetAsync(
+        _graphApiService.GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("/beta/applications?$filter=")),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>())
-            .Returns(jsonDoc);
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
 
         // Act
         var result = await _service.GetApplicationByDisplayNameAsync(TestTenantId, TestDisplayName);
@@ -142,22 +146,24 @@ public class BlueprintLookupServiceTests
         var jsonResponse = @"{""value"": []}";
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
-        _graphApiService.GraphGetAsync(
+        _graphApiService.GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("Test%27%27Blueprint%27%27Name")), // URL encoded double single quotes
-            Arg.Any<CancellationToken>(),
-            null)
-            .Returns(jsonDoc);
+            false,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
 
         // Act
         await _service.GetApplicationByDisplayNameAsync(TestTenantId, displayNameWithQuotes);
 
         // Assert
-        await _graphApiService.Received(1).GraphGetAsync(
+        await _graphApiService.Received(1).GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("Test%27%27Blueprint%27%27Name")),
-            Arg.Any<CancellationToken>(),
-            null);
+            false,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -235,7 +241,7 @@ public class BlueprintLookupServiceTests
     }
 
     [Fact]
-    public async Task GetApplicationByDisplayNameAsync_WhenMultipleBlueprintsFound_ReturnsFirst()
+    public async Task GetApplicationByDisplayNameAsync_WhenMultipleBlueprintsFoundWithoutPreferredId_ReturnsInconclusiveError()
     {
         // Arrange - Simulate multiple results (shouldn't happen with proper naming, but test resilience)
         var objectId1 = "44444444-4444-4444-4444-444444444444";
@@ -256,19 +262,107 @@ public class BlueprintLookupServiceTests
         }}";
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
-        _graphApiService.GraphGetAsync(
+        _graphApiService.GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("/beta/applications?$filter=")),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>())
-            .Returns(jsonDoc);
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
 
         // Act
         var result = await _service.GetApplicationByDisplayNameAsync(TestTenantId, TestDisplayName);
 
         // Assert
-        result.Should().NotBeNull();
-        result.Found.Should().BeTrue();
-        result.ObjectId.Should().Be(objectId1); // Should return the first match
+        result.Found.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Multiple blueprints",
+            because: "setup must not select an arbitrary application when display names are ambiguous");
+    }
+
+    [Fact]
+    public async Task GetApplicationByDisplayNameAsync_WhenMultipleBlueprintsFound_PrefersCachedObjectId()
+    {
+        // Arrange
+        var objectId1 = "44444444-4444-4444-4444-444444444444";
+        var objectId2 = "55555555-5555-5555-5555-555555555555";
+        var jsonDoc = JsonDocument.Parse($$"""
+            {
+              "value": [
+                { "id": "{{objectId1}}", "appId": "{{TestAppId}}", "displayName": "{{TestDisplayName}}" },
+                { "id": "{{objectId2}}", "appId": "66666666-6666-6666-6666-666666666666", "displayName": "{{TestDisplayName}}" }
+              ]
+            }
+            """);
+
+        _graphApiService.GraphGetWithResponseAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
+
+        // Act
+        var result = await _service.GetApplicationByDisplayNameAsync(
+            TestTenantId,
+            TestDisplayName,
+            preferredObjectId: objectId2);
+
+        // Assert
+        result.ObjectId.Should().Be(objectId2,
+            because: "a cached blueprint object ID must win when duplicate display names exist");
+    }
+
+    [Fact]
+    public async Task GetApplicationByDisplayNameAsync_WhenGraphRequestFails_ReturnsInconclusiveError()
+    {
+        // Arrange
+        _graphApiService.GraphGetWithResponseAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 403,
+                ReasonPhrase = "Forbidden",
+                Body = """{"error":{"code":"Authorization_RequestDenied"}}"""
+            });
+
+        // Act
+        var result = await _service.GetApplicationByDisplayNameAsync(TestTenantId, TestDisplayName);
+
+        // Assert
+        result.Found.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("HTTP 403 Forbidden",
+            because: "authorization failures must remain distinguishable from a successful empty lookup");
+    }
+
+    [Fact]
+    public async Task GetApplicationByDisplayNameAsync_WhenCanceled_PropagatesCancellation()
+    {
+        // Arrange
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _graphApiService.GraphGetWithResponseAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
+            cts.Token)
+            .Returns<Task<GraphApiService.GraphResponse>>(_ => throw new OperationCanceledException(cts.Token));
+
+        // Act
+        var act = () => _service.GetApplicationByDisplayNameAsync(
+            TestTenantId,
+            TestDisplayName,
+            cancellationToken: cts.Token);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "Ctrl+C must remain cancellation rather than being reported as a permission failure");
     }
 
     [Fact]
@@ -290,11 +384,13 @@ public class BlueprintLookupServiceTests
         var jsonResponse = @"{""value"": []}"; // No blueprints match the new displayName
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
-        _graphApiService.GraphGetAsync(
+        _graphApiService.GraphGetWithResponseAsync(
             TestTenantId,
             Arg.Is<string>(s => s.Contains("/beta/applications?$filter=") && s.Contains("NewAgent")),
+            false,
+            Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>())
-            .Returns(jsonDoc);
+            .Returns(new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = jsonDoc });
 
         // Act
         var result = await _service.GetApplicationByDisplayNameAsync(TestTenantId, newDisplayName);

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
@@ -31,7 +31,7 @@ public class ClientAppValidatorTests
     private const string FirstPartyClientAppId = AuthenticationConstants.WellKnownClientAppId;
     private const string ValidTenantId = "12345678-1234-1234-1234-123456789012";
     private const string InvalidGuid = "not-a-guid";
-    private const string AppObjId = "object-id-123";
+    private const string AppObjId = "11111111-2222-3333-4444-555555555555";
     private const string SpObjId = "sp-object-id-123";
 
     // Stable test GUIDs for required permissions — must match between SetupPermissionResolution
@@ -57,8 +57,53 @@ public class ClientAppValidatorTests
         var executor = Substitute.For<CommandExecutor>(executorLogger);
         var graphServiceLogger = Substitute.For<ILogger<GraphApiService>>();
         _graphApiService = Substitute.For<GraphApiService>(graphServiceLogger, executor);
+        ForwardAmbientCallsToExistingSubstitutions(_graphApiService);
 
         _validator = new ClientAppValidator(_logger, _graphApiService);
+    }
+
+    private static void ForwardAmbientCallsToExistingSubstitutions(GraphApiService graphApiService)
+    {
+        graphApiService.GraphGetAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(callInfo => graphApiService.GraphGetAsync(
+                callInfo.ArgAt<string>(0),
+                callInfo.ArgAt<string>(1),
+                callInfo.ArgAt<CancellationToken>(2),
+                callInfo.ArgAt<IEnumerable<string>?>(3)));
+
+        graphApiService.GraphPatchAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(callInfo => graphApiService.GraphPatchAsync(
+                callInfo.ArgAt<string>(0),
+                callInfo.ArgAt<string>(1),
+                callInfo.ArgAt<object>(2),
+                callInfo.ArgAt<CancellationToken>(3),
+                callInfo.ArgAt<IEnumerable<string>?>(4)));
+
+        graphApiService.GraphGetWithResponseAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(callInfo => graphApiService.GraphGetWithResponseAsync(
+                callInfo.ArgAt<string>(0),
+                callInfo.ArgAt<string>(1),
+                callInfo.ArgAt<bool>(2),
+                callInfo.ArgAt<IEnumerable<string>?>(3),
+                callInfo.ArgAt<CancellationToken>(4),
+                GraphAuthenticationMode.ResolvedClientApp));
     }
 
     #region Constructor Tests
@@ -130,8 +175,7 @@ public class ClientAppValidatorTests
     public async Task EnsureValidClientAppAsync_WhenGraphQueryFails_ThrowsClientAppValidationException()
     {
         // Simulate a 401 on both the first attempt and the retry after cache invalidation.
-        // TokenRevoked is only thrown when the failure is specifically a 401 (auth error),
-        // not for transient failures like 503 — which would produce AppNotFound instead.
+        // Only a repeated 401 is diagnosed as revocation; operational failures stay inconclusive.
         _graphApiService.GraphGetWithResponseAsync(
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("displayName")),
@@ -579,17 +623,370 @@ public class ClientAppValidatorTests
     }
 
     [Fact]
-    public async Task EnsureValidClientAppAsync_CustomApp_PreservesExistingMutationBehavior()
+    public async Task EnsureValidClientAppAsync_CustomApp_PreservesValidationAndRepairPath()
     {
-        // Regression guard: a tenant-owned client app ID must keep the full custom-app validation
-        // path (existence via /applications, permission/consent self-healing), unchanged.
         SetupAppInfoWithAllPermissions(ValidClientAppId);
         SetupPermissionResolution();
 
         await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId);
 
         await _graphApiService.Received().GraphGetWithResponseAsync(
-            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("displayName")), Arg.Any<bool>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Is<IEnumerable<string>?>(scopes => scopes == null),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_CustomAppMetadataLookup_UsesAmbientWithoutCustomApplicationReadAll()
+    {
+        SetupAppInfoGetEmpty();
+
+        await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        await _graphApiService.Received(1).GraphGetWithResponseAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+            false,
+            Arg.Is<IEnumerable<string>?>(scopes => scopes == null),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.DidNotReceive().GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<bool>(),
+            Arg.Is<IEnumerable<string>?>(scopes =>
+                scopes != null &&
+                scopes.Contains(AuthenticationConstants.ApplicationReadAllScope)),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.ResolvedClientApp);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenAmbientMetadataLookupIsForbidden_DoesNotReportAppAbsent()
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+                ValidTenantId,
+                Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = false,
+                StatusCode = 403,
+                ReasonPhrase = "Forbidden"
+            });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "an authorization failure is inconclusive and must not be misreported as confirmed application absence");
+        exception.IssueDescription.Should().NotContain("not found",
+            because: "HTTP 403 proves only that metadata could not be read, not that the application is absent");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("HTTP 403", StringComparison.Ordinal),
+            because: "operators need the Graph status to diagnose ambient identity authorization");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenRefreshRetryHasOperationalFailure_DoesNotReportTokenRevoked()
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+                ValidTenantId,
+                Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(
+                new GraphApiService.GraphResponse
+                {
+                    IsSuccess = false,
+                    StatusCode = 401,
+                    ReasonPhrase = "Unauthorized"
+                },
+                new GraphApiService.GraphResponse
+                {
+                    IsSuccess = false,
+                    StatusCode = 503,
+                    ReasonPhrase = "Service Unavailable"
+                });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "a service failure after refresh is operationally inconclusive rather than proof of token revocation");
+        exception.IssueDescription.Should().NotContain("revoked",
+            because: "only a repeated HTTP 401 can establish the token-revocation diagnosis");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("HTTP 503", StringComparison.Ordinal),
+            because: "the final Graph status must be preserved for incident diagnosis");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenSuccessfulMetadataLookupHasNoJson_DoesNotReportAppAbsent()
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+                ValidTenantId,
+                Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = null
+            });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "an empty successful response is inconclusive rather than proof that the application is absent");
+        exception.IssueDescription.Should().NotContain("not found",
+            because: "application absence requires a valid empty Graph value array");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("empty response body", StringComparison.Ordinal),
+            because: "the protocol failure should remain actionable for operators");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenSuccessfulMetadataLookupHasInvalidSchema_DoesNotReportAppAbsent()
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+                ValidTenantId,
+                Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDocument.Parse("""{"unexpected":[]}""")
+            });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "a malformed Graph payload cannot establish whether the application exists");
+        exception.IssueDescription.Should().NotContain("not found",
+            because: "application absence requires a valid empty Graph value array");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("invalid response", StringComparison.Ordinal),
+            because: "the unexpected Graph schema should be explicit in diagnostics");
+    }
+
+    [Theory]
+    [InlineData("""{"value":[{}]}""")]
+    [InlineData("""{"value":[{"id":null,"appId":"a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6"}]}""")]
+    [InlineData("""{"value":[{"id":"11111111-2222-3333-4444-555555555555","appId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"}]}""")]
+    public async Task EnsureValidClientAppAsync_WhenMetadataApplicationRecordIsInvalid_DoesNotProceed(
+        string responseJson)
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+                ValidTenantId,
+                Arg.Is<string>(path => path.Contains("/applications", StringComparison.Ordinal)),
+                false,
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.Ambient)
+            .Returns(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDocument.Parse(responseJson)
+            });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "an invalid application record cannot establish the identity of the registration being validated");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("invalid application record", StringComparison.Ordinal),
+            because: "malformed or mismatched Graph records must be diagnosed before validation or repair continues");
+        await _graphApiService.DidNotReceiveWithAnyArgs().GraphPatchAsync(
+            default!, default!, default!, default, default, default);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_CustomRegistrationReadsAndRepairs_UseAmbientAuthentication()
+    {
+        SetupAppInfoWithAllPermissions(ValidClientAppId);
+        SetupPermissionResolution();
+        SetupRedirectUrisGet($$"""
+        {
+            "value": [{
+                "id": "{{AppObjId}}",
+                "publicClient": { "redirectUris": [] }
+            }]
+        }
+        """);
+        SetupPublicClientFlowsGet(enabled: false);
+
+        var noWidsJson = $$"""{"value":[{"id":"{{AppObjId}}","optionalClaims":null}]}""";
+        _graphApiService.GraphGetAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(path => path.Contains("optionalClaims", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(noWidsJson)));
+        _graphApiService.GraphPatchAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(true);
+
+        await _validator.EnsureValidClientAppAsync(
+            ValidClientAppId,
+            ValidTenantId,
+            skipConfirmation: true);
+
+        await _graphApiService.Received().GraphGetAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("publicClient", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphGetAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("isFallbackPublicClient", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphGetAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("optionalClaims", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+
+        await _graphApiService.Received().GraphPatchAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains($"/applications/{AppObjId}", StringComparison.Ordinal)),
+            Arg.Is<object>(payload => JsonSerializer.Serialize(payload).Contains("\"publicClient\"", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphPatchAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains($"/applications/{AppObjId}", StringComparison.Ordinal)),
+            Arg.Is<object>(payload => JsonSerializer.Serialize(payload).Contains("\"isFallbackPublicClient\"", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphPatchAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains($"/applications/{AppObjId}", StringComparison.Ordinal)),
+            Arg.Is<object>(payload => JsonSerializer.Serialize(payload).Contains("\"optionalClaims\"", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_ConsentGrantReadAndUpgrade_UseAmbientAuthentication()
+    {
+        SetupAppInfoWithAllPermissions(ValidClientAppId);
+        SetupPermissionResolution();
+
+        var servicePrincipalJson = $$"""{"value":[{"id":"{{SpObjId}}","appId":"{{ValidClientAppId}}"}]}""";
+        _graphApiService.GraphGetAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(path => path.Contains("servicePrincipals", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(servicePrincipalJson)));
+
+        var allRequiredScopes = string.Join(' ', AuthenticationConstants.RequiredClientAppPermissions);
+        var principalGrantJson = $$"""
+        {"value":[{"id":"grant-id-123","clientId":"{{SpObjId}}","consentType":"Principal","scope":"{{allRequiredScopes}}"}]}
+        """;
+        var allPrincipalsGrantJson = $$"""
+        {"value":[{"id":"grant-id-123","clientId":"{{SpObjId}}","consentType":"AllPrincipals","scope":"{{allRequiredScopes}}"}]}
+        """;
+        _graphApiService.GraphGetAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(path => path.Contains("oauth2PermissionGrants", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(principalGrantJson)));
+        _graphApiService.GraphGetWithResponseAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(path => path.Contains("oauth2PermissionGrants", StringComparison.Ordinal)),
+                Arg.Any<bool>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(
+                new GraphApiService.GraphResponse
+                {
+                    IsSuccess = true,
+                    StatusCode = 200,
+                    Json = JsonDocument.Parse(principalGrantJson)
+                },
+                new GraphApiService.GraphResponse
+                {
+                    IsSuccess = true,
+                    StatusCode = 200,
+                    Json = JsonDocument.Parse(allPrincipalsGrantJson)
+                });
+        _graphApiService.GraphPatchAsync(
+                Arg.Any<string>(),
+                Arg.Any<string>(),
+                Arg.Any<object>(),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(true);
+
+        var withWidsJson = $$$"""
+        {"value":[{"id":"{{{AppObjId}}}","optionalClaims":{"accessToken":[{"name":"wids"}]}}]}
+        """;
+        _graphApiService.GraphGetAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(path => path.Contains("optionalClaims", StringComparison.Ordinal)),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<IEnumerable<string>?>())
+            .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(withWidsJson)));
+
+        await _validator.EnsureValidClientAppAsync(
+            ValidClientAppId,
+            ValidTenantId,
+            skipConfirmation: true);
+
+        await _graphApiService.Received().GraphGetAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("servicePrincipals", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphGetWithResponseAsync(
+            ValidTenantId,
+            Arg.Is<string>(path => path.Contains("oauth2PermissionGrants", StringComparison.Ordinal)),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+        await _graphApiService.Received().GraphPatchAsync(
+            ValidTenantId,
+            "/v1.0/oauth2PermissionGrants/grant-id-123",
+            Arg.Is<object>(payload => JsonSerializer.Serialize(payload).Contains("\"AllPrincipals\"", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<IEnumerable<string>?>(),
+            GraphAuthenticationMode.Ambient);
     }
 
     #endregion
@@ -611,6 +1008,31 @@ public class ClientAppValidatorTests
 
         result.Should().BeTrue(
             because: "the claim on a token actually issued to the app is the only evidence available for an app registration the tenant cannot read");
+    }
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_CustomApp_UsesResolvedClientAppToken()
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId,
+                ValidClientAppId,
+                Arg.Is<IEnumerable<string>>(scopes =>
+                    scopes.SequenceEqual(new[] { AuthenticationConstants.UserReadScope })),
+                Arg.Any<CancellationToken>())
+            .Returns(BuildTokenWithPayload("""{"wids":["62e90394-69f5-4237-9190-012177145e10"]}"""));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            ValidClientAppId,
+            ValidTenantId);
+
+        result.Should().BeTrue(
+            because: "issued-token inspection must authenticate as the resolved custom app whose optional claims are being verified");
+        await _graphApiService.Received(1).GetClientAppAccessTokenAsync(
+            ValidTenantId,
+            ValidClientAppId,
+            Arg.Is<IEnumerable<string>>(scopes =>
+                scopes.SequenceEqual(new[] { AuthenticationConstants.UserReadScope })),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -797,6 +1219,7 @@ public class ClientAppValidatorTests
         var executor = Substitute.For<CommandExecutor>(executorLogger);
         var graphServiceLogger = Substitute.For<ILogger<GraphApiService>>();
         var graphApiService = Substitute.For<GraphApiService>(graphServiceLogger, executor);
+        ForwardAmbientCallsToExistingSubstitutions(graphApiService);
 
         // Wire up the same app/permission mocks used by the happy-path tests
         var requiredResourceAccess = $$"""
@@ -872,6 +1295,7 @@ public class ClientAppValidatorTests
         var executor = Substitute.For<CommandExecutor>(executorLogger);
         var graphServiceLogger = Substitute.For<ILogger<GraphApiService>>();
         var graphApiService = Substitute.For<GraphApiService>(graphServiceLogger, executor);
+        ForwardAmbientCallsToExistingSubstitutions(graphApiService);
 
         // App exists but has no permissions → triggers missing permissions mutation
         var appJson = $$"""

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -30,6 +30,25 @@ public class GraphApiServiceTests
         _mockTokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
     }
 
+    [Fact]
+    public async Task ClearTokenCacheAsync_ClearsProviderAndAuthenticationCaches()
+    {
+        // Arrange
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            tokenProvider: _mockTokenProvider);
+
+        // Act
+        await service.ClearTokenCacheAsync();
+
+        // Assert
+        _mockTokenProvider.Received(1).ClearTokenCache();
+        await authService.Received(1).ClearTokenCacheAsync();
+    }
+
 
     [Fact]
     public async Task GetClientAppAccessTokenAsync_PassesExplicitClientIdAndScopesToTokenProvider()

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -286,6 +286,106 @@ public class GraphApiServiceTests
     }
 
     [Fact]
+    public async Task GraphGetAsync_AmbientMode_IgnoresResolvedClientAppAndRequestedScopes()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[]}""")
+        });
+
+        string? requestedClientAppId = null;
+        string[]? requestedScopes = null;
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Do<IEnumerable<string>>(scopes => requestedScopes = scopes.ToArray()),
+                Arg.Any<bool>(),
+                Arg.Do<string?>(clientAppId => requestedClientAppId = clientAppId),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>())
+            .Returns("custom-app-token");
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6"
+        };
+
+        using var result = await service.GraphGetAsync(
+            "tenant-123",
+            "/v1.0/applications?$select=id",
+            CancellationToken.None,
+            [AuthenticationConstants.ApplicationReadAllScope],
+            GraphAuthenticationMode.Ambient);
+
+        result.Should().NotBeNull(
+            because: "the ambient bootstrap identity must be able to diagnose an underconfigured custom app");
+        requestedClientAppId.Should().BeNull(
+            because: "ambient metadata reads must never request a token from the app being diagnosed");
+        requestedScopes.Should().BeNull(
+            because: "Application.Read.All must not be requested through the underconfigured custom app");
+        await authService.ReceivedWithAnyArgs(1).GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public async Task GraphPatchAsync_AmbientMode_IgnoresResolvedClientAppAndRequestedScopes()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.NoContent));
+
+        string? requestedClientAppId = null;
+        string[]? requestedScopes = null;
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Do<IEnumerable<string>>(scopes => requestedScopes = scopes.ToArray()),
+                Arg.Any<bool>(),
+                Arg.Do<string?>(clientAppId => requestedClientAppId = clientAppId),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>())
+            .Returns("custom-app-token");
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6"
+        };
+
+        var result = await service.GraphPatchAsync(
+            "tenant-123",
+            "/v1.0/applications/application-object-id",
+            new { isFallbackPublicClient = true },
+            CancellationToken.None,
+            [AuthenticationConstants.ApplicationReadAllScope],
+            GraphAuthenticationMode.Ambient);
+
+        result.Should().BeTrue(
+            because: "repair mutations must use the ambient identity rather than depend on the app being repaired");
+        requestedClientAppId.Should().BeNull(
+            because: "ambient repairs must never acquire a token from the underconfigured custom app");
+        requestedScopes.Should().BeNull(
+            because: "requested custom-app scopes are intentionally ignored for ambient repairs");
+        await authService.ReceivedWithAnyArgs(1).GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
     public async Task LookupServicePrincipalByAppIdWithResponseAsync_UsesAmbientAuthEvenWhenProbingTheResolvedClientApp()
     {
         // Regression guard: authenticating as the app being probed makes an absent app report

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -337,6 +337,193 @@ public class GraphApiServiceTests
     }
 
     [Fact]
+    public async Task GetOauth2PermissionGrantsAsync_WhenGraphReturnsForbidden_UsesAmbientAuthAndThrowsWithStatus()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.Forbidden)
+        {
+            Content = new StringContent(
+                """{"error":{"code":"Authorization_RequestDenied","message":"Insufficient privileges"}}""")
+        });
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = AuthenticationConstants.WellKnownClientAppId
+        };
+
+        Func<Task> act = async () => await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*HTTP 403 Forbidden*",
+                because: "a denied administrative read must remain distinguishable from a successful empty grants response");
+        await tokenProvider.DidNotReceiveWithAnyArgs().GetMgGraphAccessTokenAsync(
+            default!, default!, default, default, default, default, default);
+        await authService.ReceivedWithAnyArgs(1).GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public async Task GetOauth2PermissionGrantsAsync_WhenTransportFails_ThrowsWithFailureReason()
+    {
+        using var handler = new ExceptionThrowingHttpMessageHandler(
+            () => new HttpRequestException("connection reset"));
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        Func<Task> act = async () => await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        var exception = await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "a transport failure must remain distinguishable from a successful empty grants response");
+        exception.Which.Message.Should().Contain("connection reset",
+            because: "the status-zero Graph response reason is the only actionable transport diagnostic available to the operator");
+        exception.Which.Message.Should().NotContain("HTTP 0",
+            because: "status zero means no HTTP response was received and must not be rendered as a real protocol status");
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("{\"value\":{}}")]
+    public async Task GetOauth2PermissionGrantsAsync_WhenTopLevelPayloadIsMalformed_Throws(string responseBody)
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(responseBody)
+        });
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        Func<Task> act = async () => await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid OAuth2 permission grants response*",
+                because: "a successful response without an array-valued 'value' member is not authoritative evidence of zero grants");
+    }
+
+    [Fact]
+    public async Task GetOauth2PermissionGrantsAsync_WhenGraphReturnsEmptyValue_UsesAmbientAuthAndReturnsEmptyList()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[]}""")
+        });
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = AuthenticationConstants.WellKnownClientAppId
+        };
+
+        var grants = await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        grants.Should().BeEmpty(
+            because: "a successful Graph response with an empty value array is authoritative evidence that no grants exist");
+        await tokenProvider.DidNotReceiveWithAnyArgs().GetMgGraphAccessTokenAsync(
+            default!, default!, default, default, default, default, default);
+        await authService.ReceivedWithAnyArgs(1).GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public void GetOauth2PermissionGrantsAsync_PreservesOriginalPublicVirtualSignature()
+    {
+        var method = typeof(GraphApiService).GetMethod(
+            nameof(GraphApiService.GetOauth2PermissionGrantsAsync),
+            [typeof(string), typeof(string), typeof(CancellationToken)]);
+
+        method.Should().NotBeNull(
+            because: "existing callers and NSubstitute setups depend on the original three-parameter CLR signature");
+        method!.IsPublic.Should().BeTrue();
+        method.IsVirtual.Should().BeTrue(
+            because: "tests and downstream integrations substitute this administrative read API");
+    }
+
+    [Fact]
+    public async Task GetOauth2PermissionGrantsAsync_WhenGraphReturnsMalformedGrant_Throws()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[{"resourceId":"11111111-1111-1111-1111-111111111111","scope":"User.Read"}]}""")
+        });
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        Func<Task> act = async () => await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid OAuth2 permission grant*",
+                because: "a malformed grant row must not be silently converted into a partial permissions result");
+    }
+
+    [Fact]
+    public async Task GetOauth2PermissionGrantsAsync_WhenResourceIdIsNotGuid_Throws()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"value":[{"resourceId":"not-a-guid","scope":"User.Read","consentType":"AllPrincipals"}]}""")
+        });
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        Func<Task> act = async () => await service.GetOauth2PermissionGrantsAsync(
+            "tenant-123",
+            "blueprint-sp-object-id");
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*invalid OAuth2 permission grant*",
+                because: "Graph resource identifiers must be GUIDs rather than arbitrary non-empty strings");
+    }
+
+    [Fact]
     public async Task GraphPatchAsync_AmbientMode_IgnoresResolvedClientAppAndRequestedScopes()
     {
         using var handler = new TestHttpMessageHandler();

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Helpers/EndpointHelperTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Helpers/EndpointHelperTests.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT License.
 
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services.Helpers;
 
+[Collection("ConfigTests")]
 public class EndpointHelperTests
 {
     [Fact]
@@ -336,5 +338,176 @@ public class EndpointHelperTests
         // Assert - suffix is "abcd" (4 chars), shorter than the 8-char uniqueness target
         result.Should().Be("myapp-example-com-abcd");
         result.Should().NotEndWith("-");
+    }
+
+    [Fact]
+    public void Agent365Endpoints_WithoutOverrides_PreserveCommercialUrls()
+    {
+        WithEnvironmentVariables(
+            "PROD",
+            discoverEndpoint: null,
+            createEndpoint: null,
+            deleteEndpoint: null,
+            () =>
+            {
+                ConfigConstants.GetDiscoverEndpointUrl("prod").Should().Be(
+                    ConfigConstants.ProductionDiscoverEndpointUrl,
+                    because: "commercial discover behavior must remain unchanged without overrides");
+                EndpointHelper.GetCreateEndpointUrl("prod").Should().Be(
+                    ConfigConstants.ProductionCreateEndpointUrl,
+                    because: "commercial create behavior must remain unchanged without overrides");
+                EndpointHelper.GetDeleteEndpointUrl("prod").Should().Be(
+                    ConfigConstants.ProductionDeleteEndpointUrl,
+                    because: "commercial delete behavior must remain unchanged without overrides");
+            });
+    }
+
+    [Fact]
+    public void Agent365Endpoints_WithOnlyGccDiscoverOverride_UseItsHttpsOrigin()
+    {
+        const string discoverEndpoint =
+            "https://gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers";
+
+        WithEnvironmentVariables(
+            "GCC",
+            discoverEndpoint,
+            createEndpoint: null,
+            deleteEndpoint: null,
+            () =>
+            {
+                ConfigConstants.GetDiscoverEndpointUrl("gcc").Should().Be(
+                    discoverEndpoint,
+                    because: "the configured cloud discover endpoint is canonical");
+                EndpointHelper.GetCreateEndpointUrl("gcc").Should().Be(
+                    "https://gcc.agent365.svc.cloud.microsoft/agents/botManagement/createAgentBlueprint",
+                    because: "create uses the canonical discover endpoint's HTTPS origin and fixed route");
+                EndpointHelper.GetDeleteEndpointUrl("gcc").Should().Be(
+                    "https://gcc.agent365.svc.cloud.microsoft/agents/botManagement/deleteAgentBlueprint",
+                    because: "delete uses the canonical discover endpoint's HTTPS origin and fixed route");
+            });
+    }
+
+    [Fact]
+    public void Agent365Endpoints_ExplicitCreateAndDeleteOverrides_TakeIndependentPrecedence()
+    {
+        const string discoverEndpoint =
+            "https://gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers";
+        const string createEndpoint = "https://create.example/custom";
+        const string deleteEndpoint = "https://delete.example/custom";
+
+        WithEnvironmentVariables(
+            "GCC",
+            discoverEndpoint,
+            createEndpoint,
+            deleteEndpoint,
+            () =>
+            {
+                EndpointHelper.GetCreateEndpointUrl("gcc").Should().Be(
+                    createEndpoint,
+                    because: "the explicit create override is an independent higher-precedence escape hatch");
+                EndpointHelper.GetDeleteEndpointUrl("gcc").Should().Be(
+                    deleteEndpoint,
+                    because: "the explicit delete override is an independent higher-precedence escape hatch");
+            });
+    }
+
+    [Fact]
+    public void Agent365Endpoints_ExplicitOverrides_BypassMalformedDiscoverIndependently()
+    {
+        const string createEndpoint = "https://create.example/custom";
+        const string deleteEndpoint = "https://delete.example/custom";
+
+        WithEnvironmentVariables(
+            "GCC",
+            discoverEndpoint: "not-a-url",
+            createEndpoint,
+            deleteEndpoint: null,
+            () =>
+            {
+                EndpointHelper.GetCreateEndpointUrl("gcc").Should().Be(
+                    createEndpoint,
+                    because: "the explicit create override must not depend on discover URL validity");
+                FluentActions.Invoking(() => EndpointHelper.GetDeleteEndpointUrl("gcc"))
+                    .Should().Throw<ArgumentException>(
+                        because: "delete must still validate discover when it has no explicit override");
+            });
+
+        WithEnvironmentVariables(
+            "GCC",
+            discoverEndpoint: "not-a-url",
+            createEndpoint: null,
+            deleteEndpoint,
+            () =>
+            {
+                FluentActions.Invoking(() => EndpointHelper.GetCreateEndpointUrl("gcc"))
+                    .Should().Throw<ArgumentException>(
+                        because: "create must still validate discover when it has no explicit override");
+                EndpointHelper.GetDeleteEndpointUrl("gcc").Should().Be(
+                    deleteEndpoint,
+                    because: "the explicit delete override must not depend on discover URL validity");
+            });
+    }
+
+    [Theory]
+    [InlineData("   ")]
+    [InlineData("not-a-url")]
+    [InlineData("http://gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers")]
+    [InlineData("https://user@gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers")]
+    [InlineData("https://gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers?version=2")]
+    [InlineData("https://gcc.agent365.svc.cloud.microsoft/agents/v2/discoverMCPServers#section")]
+    public void Agent365Endpoints_MalformedDiscoverOverride_FailsVisibly(string discoverEndpoint)
+    {
+        WithEnvironmentVariables(
+            "GCC",
+            discoverEndpoint,
+            createEndpoint: null,
+            deleteEndpoint: null,
+            () =>
+            {
+                FluentActions.Invoking(() => ConfigConstants.GetDiscoverEndpointUrl("gcc"))
+                    .Should().Throw<ArgumentException>(
+                        because: "discover must reject malformed or non-HTTPS endpoint URLs");
+                FluentActions.Invoking(() => EndpointHelper.GetCreateEndpointUrl("gcc"))
+                    .Should().Throw<ArgumentException>(
+                        because: "create must not silently fall back when the canonical discover endpoint is invalid");
+                FluentActions.Invoking(() => EndpointHelper.GetDeleteEndpointUrl("gcc"))
+                    .Should().Throw<ArgumentException>(
+                        because: "delete must not silently fall back when the canonical discover endpoint is invalid");
+            });
+    }
+
+    private static void WithEnvironmentVariables(
+        string environmentKey,
+        string? discoverEndpoint,
+        string? createEndpoint,
+        string? deleteEndpoint,
+        Action assertion)
+    {
+        var values = new Dictionary<string, string?>
+        {
+            [$"A365_DISCOVER_ENDPOINT_{environmentKey}"] = discoverEndpoint,
+            [$"A365_CREATE_ENDPOINT_{environmentKey}"] = createEndpoint,
+            [$"A365_DELETE_ENDPOINT_{environmentKey}"] = deleteEndpoint,
+        };
+        var previousValues = values.Keys.ToDictionary(
+            name => name,
+            Environment.GetEnvironmentVariable);
+
+        try
+        {
+            foreach (var (name, value) in values)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+
+            assertion();
+        }
+        finally
+        {
+            foreach (var (name, value) in previousValues)
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+        }
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/InteractiveGraphAuthServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/InteractiveGraphAuthServiceTests.cs
@@ -265,6 +265,31 @@ public class InteractiveGraphAuthServiceTests
     }
 
     /// <summary>
+    /// Verifies that the returned GraphServiceClient targets the configured (sovereign) Graph
+    /// base URL with the API version segment appended. Overriding RequestAdapter.BaseUrl with the
+    /// origin alone drops the SDK default "/v1.0" segment and sends every request to a 404.
+    /// </summary>
+    [Fact]
+    public async Task GetAuthenticatedGraphClientAsync_UsesConfiguredGraphBaseUrlWithVersionSegment()
+    {
+        // Arrange
+        var workingCredential = new StubTokenCredential("token-value", DateTimeOffset.UtcNow.AddHours(1));
+        var logger = Substitute.For<ILogger<InteractiveGraphAuthService>>();
+        var sut = new InteractiveGraphAuthService(logger, ValidGuid,
+            credentialFactory: (_, _) => workingCredential,
+            loginHintResolver: NoOpLoginHint,
+            graphBaseUrl: "https://graph.microsoft.us");
+
+        // Act
+        var client = await sut.GetAuthenticatedGraphClientAsync(ValidTenantId);
+
+        // Assert
+        client.RequestAdapter.BaseUrl.Should().Be(
+            "https://graph.microsoft.us/v1.0",
+            because: "the Graph SDK routes requests relative to BaseUrl, so the cloud-specific host must retain the /v1.0 API version segment or all requests 404");
+    }
+
+    /// <summary>
     /// Verifies that the service returns the same cached GraphServiceClient for the same tenant
     /// on repeated calls, avoiding redundant authentication prompts.
     /// </summary>

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/LogRedactionServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/LogRedactionServiceTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Xunit;
 
@@ -89,6 +90,21 @@ public class LogRedactionServiceTests
             because: "the original GUID must not survive in redacted output (privacy invariant)");
         result.IdsRedacted.Should().Be(1,
             because: "exactly one GUID was present and it must be counted to keep the redaction summary trustworthy");
+    }
+
+    [Theory]
+    [InlineData(ConfigConstants.ObservabilityApiAppId)]
+    [InlineData(ConfigConstants.GccObservabilityApiAppId)]
+    [InlineData(ConfigConstants.GccHighObservabilityApiAppId)]
+    [InlineData(ConfigConstants.DodObservabilityApiAppId)]
+    public void Redact_ObservabilityResourceAppId_IsPreserved(string appId)
+    {
+        var result = _sut.Redact($"[INF] Observability resource: {appId}", Source);
+
+        result.RedactedContent.Should().Contain(appId,
+            because: "public cloud-specific Observability app IDs must remain visible for support diagnostics");
+        result.IdsRedacted.Should().Be(0,
+            because: "well-known first-party resource IDs do not identify a tenant or user");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MicrosoftGraphTokenProviderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MicrosoftGraphTokenProviderTests.cs
@@ -241,7 +241,9 @@ public class MicrosoftGraphTokenProviderTests
 
         // Assert
         token.Should().Be(msalToken);
-        requestedScopes.Should().Equal("https://graph.example/AgentIdentityBlueprint.DeleteRestore.All");
+        requestedScopes.Should().Equal(
+            new[] { "https://graph.example/AgentIdentityBlueprint.DeleteRestore.All" },
+            because: "short scope names must be normalized to fully-qualified URIs by prepending the configured Graph base URL before being passed to MSAL");
         await _executor.DidNotReceive().ExecuteWithStreamingAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Func<string, string?>?>(),

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MicrosoftGraphTokenProviderTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MicrosoftGraphTokenProviderTests.cs
@@ -224,16 +224,24 @@ public class MicrosoftGraphTokenProviderTests
         var clientAppId = "87654321-4321-4321-4321-cba987654321";
         var msalToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZWxsYWsifQ.signature";
 
+        string[]? requestedScopes = null;
         var provider = new MicrosoftGraphTokenProvider(_executor, _logger)
         {
-            MsalTokenAcquirerOverride = (_, _, _, _) => Task.FromResult<string?>(msalToken)
+            MsalTokenAcquirerOverride = (_, resolvedScopes, _, _) =>
+            {
+                requestedScopes = resolvedScopes;
+                return Task.FromResult<string?>(msalToken);
+            }
         };
 
         // Act
-        var token = await provider.GetMgGraphAccessTokenAsync(tenantId, scopes, false, clientAppId);
+        var token = await provider.GetMgGraphAccessTokenAsync(
+            tenantId, scopes, false, clientAppId, graphBaseUrl: "https://graph.example",
+            authorityHost: "https://login.example");
 
         // Assert
         token.Should().Be(msalToken);
+        requestedScopes.Should().Equal("https://graph.example/AgentIdentityBlueprint.DeleteRestore.All");
         await _executor.DidNotReceive().ExecuteWithStreamingAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(),
             Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<Func<string, string?>?>(),


### PR DESCRIPTION
## Summary
Makes Graph, OAuth authority, and Agent 365 Tools endpoints cloud-agnostic so the CLI works in sovereign/government clouds in addition to commercial.

- Cloud-specific Graph, authority, and Agent 365 Tools overrides now apply across setup, consent, authentication, query, and create-instance flows.
- Arbitrary cloud names resolve via normalized environment-scoped variables (e.g. `A365_GRAPH_BASE_URL_GCC_HIGH`).
- Configured endpoints are normalized and validated to HTTPS origins (no path/query/fragment/user-info).
- Commercial cloud (`https://login.microsoftonline.com`, standard Graph base URL) remains the default fallback.

## Testing
- Added unit tests for `ConfigConstants` endpoint resolution/normalization and updated affected service/command tests.
