### PR TITLE
[S360] 1ES OSS — fix CVE-2026-44503 in Kiota

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -34,9 +34,9 @@
     <PackageVersion Include="Azure.ResourceManager.AppService" Version="1.2.0" />
     <!-- Microsoft Graph -->
     <PackageVersion Include="Microsoft.Graph" Version="5.36.0" />
-    <!-- Transitive pin: resolves NU1107 conflict between Microsoft.Extensions.Http 9.x (needs >= 9.0.8)
-         and Microsoft.Kiota.Abstractions 1.7.2 (needs < 9.0.0). CentralPackageTransitivePinningEnabled
-         allows this pin to override the Kiota upper bound. -->
+    <!-- Pin the transitive dependency to the version that fixes CVE-2026-44503. -->
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
+    <!-- Microsoft.Extensions.Http 9.x requires DiagnosticSource >= 9.0.8. -->
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
     <!-- Testing packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -35,7 +35,7 @@
     <!-- Microsoft Graph -->
     <PackageVersion Include="Microsoft.Graph" Version="5.36.0" />
     <!-- Pin the transitive dependency to the version that fixes CVE-2026-44503. -->
-    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.0" />
+    <PackageVersion Include="Microsoft.Kiota.Abstractions" Version="1.22.2" />
     <!-- Microsoft.Extensions.Http 9.x requires DiagnosticSource >= 9.0.8. -->
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.8" />
     <!-- Testing packages -->


### PR DESCRIPTION
## Security issue

[CVE-2026-44503](https://www.cve.org/CVERecord?id=CVE-2026-44503) / [GHSA-7j59-v9qr-6fq9](https://github.com/advisories/GHSA-7j59-v9qr-6fq9) affects `Microsoft.Kiota.Abstractions` versions before 1.22.0. Sensitive headers can leak when redirects cross host or scheme boundaries. The CLI resolved the vulnerable transitive version 1.7.2 through `Microsoft.Graph` 5.36.0.

## Change and rationale

- Centrally pin `Microsoft.Kiota.Abstractions` to 1.22.2, the latest compatible 1.x release and above the fixed-version floor.
- The [official kiota-dotnet changelog](https://github.com/microsoft/kiota-dotnet/blob/main/CHANGELOG.md) shows 1.22.1 and 1.22.2 contain bug fixes only (pattern-matching correctness, enum-parsing performance, and CLS compliance).
- Do not move to 2.x: Kiota 2.0 drops net5.0/net6.0 TFMs, adds net8.0/net10.0, removes obsolete APIs, and merges/removes parsing interfaces, making it a breaking upgrade outside this security fix.
- Keep the existing `Microsoft.Graph` version to avoid an unrelated broad SDK upgrade.
- Correct the adjacent `DiagnosticSource` comment, which previously described the vulnerable 1.7.2 dependency.
- No generated or lock files exist for this dependency path, so none were hand-edited.
- No new product test was added: this is an upstream package-behavior fix, and the complete existing CLI regression suite covers compatibility.

## What changed from Kiota 1.7.2 to 1.22.2

The official [current changelog](https://github.com/microsoft/kiota-dotnet/blob/main/CHANGELOG.md) and [historical abstractions changelog](https://github.com/microsoft/kiota-dotnet/blob/main/src/abstractions/Changelog-old.md) document the following 1.x evolution:

- **1.7–1.8:** URI/query fixes, AOT trimming improvements, net6/net8 targets, untyped nodes, and multipart filename support.
- **1.9:** Added async deserialization; synchronous APIs were deprecated but retained throughout 1.x.
- **1.10–1.15:** Added serialization and enum helpers, enabled CAE by default, improved backing-store performance, added authentication-handler improvements, net9 support, and telemetry enhancements.
- **1.16–1.19:** Added response-body inspection, redirect-without-location handling, browser/WASM fixes, trim-safe handlers, multipart and numeric parsing improvements, and fixed a bearer-token deadlock.
- **1.20–1.21:** Added HTTP version/version-policy handling, Azure Core updates, constructor compatibility fixes, recyclable streams, and retry improvements.
- **1.22.0:** Fixed CVE-2026-44503 by stripping cookie and proxy-authentication headers on unsafe redirects; also strips authentication when ports change and includes request-scrubbing and DI-registration fixes.
- **1.22.1–1.22.2:** Fixed enum-parsing correctness/performance and added CLS compliance.

The dependency graph also moves `Std.UriTemplate` from 0.0.46 to 2.0.8. No breaking changes are documented across this 1.x interval. Kiota 2.x is intentionally avoided because it removes APIs and drops net5/net6 targets.

**S360 closure:** Component Governance alert 13799990 affected Kiota versions below 1.22.0. The resolved graph now uses 1.22.2 and the vulnerability scan is clean for Kiota, but the S360 item clears only after this PR merges to `main`, Component Governance rescans that branch, and S360 ingests the refreshed result.
## Validation

| Command | Result |
|---|---|
| `dotnet restore .\src\Microsoft.Agents.A365.DevTools.Cli\Microsoft.Agents.A365.DevTools.Cli.csproj --nologo` | Passed; CLI and MockToolingServer restored. |
| `dotnet restore .\src\Tests\Microsoft.Agents.A365.DevTools.Cli.Tests\Microsoft.Agents.A365.DevTools.Cli.Tests.csproj --nologo` | Passed; CLI test project restored. |
| `dotnet build .\src\Microsoft.Agents.A365.DevTools.Cli\Microsoft.Agents.A365.DevTools.Cli.csproj --configuration Release --no-restore --nologo` | Passed; 0 warnings, 0 errors. |
| `dotnet test .\src\Tests\Microsoft.Agents.A365.DevTools.Cli.Tests\Microsoft.Agents.A365.DevTools.Cli.Tests.csproj --configuration Release --no-restore --nologo` | Passed: 1,921; failed: 0; skipped: 12; total: 1,933. |
| `dotnet list .\src\Microsoft.Agents.A365.DevTools.Cli\Microsoft.Agents.A365.DevTools.Cli.csproj package --include-transitive` | `Microsoft.Kiota.Abstractions` resolves to 1.22.2 (baseline was 1.7.2). |
| `dotnet list .\src\Microsoft.Agents.A365.DevTools.Cli\Microsoft.Agents.A365.DevTools.Cli.csproj package --vulnerable --include-transitive --format json` | Kiota is absent from vulnerable results. Two unrelated pre-existing IdentityModel 7.0.3 advisories remain and are not changed here. |
| `git -c core.whitespace=cr-at-eol diff --check` | Passed. |

**Finding-resolved check:** the affected project now resolves `Microsoft.Kiota.Abstractions` 1.22.2, satisfying the advisory's 1.22.0 fixed-version floor; 1.7.2 is no longer in the resolved graph and Kiota remains absent from vulnerable-package output.

## Rollback

To roll back only the 1.22.2 patch update, revert commit `c7bef2ace102016feb09955794628e46c37335ab`; this returns the pin to fixed version 1.22.0. To remove the complete remediation, revert `c7bef2ace102016feb09955794628e46c37335ab` and then `4fc9b6c2f1694f78deedbf5743273230efcbd742`, followed by restore/build/test. Removing both commits reintroduces vulnerable transitive version 1.7.2, so it should be used only for diagnosis and followed immediately by another fixed Kiota/Graph upgrade.

## Reviewers

- @sellakumaran — last changed the central dependency-conflict block in `Directory.Packages.props` (PR #296).
- @rahuldevikar761 — introduced the Graph dependency and CLI package structure (PR #4).
- @microsoft/agent365-approvers and @microsoft/Agent365-devTools-Approvers — owners of all repository paths in `.github/CODEOWNERS`.