### PR TITLE
Support multiple agents per identity blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 **Option B — CLI** (`a365 setup admin`) has been removed in this release. Use Option A above, or copy the PowerShell instructions printed in the `a365 setup all` summary output.
 
 ### Added
+- Added `a365 setup blueprint list` to list existing Agent Identity Blueprints and their Blueprint IDs.
+- Added `setup all --blueprint-id <guid>` and `--select-blueprint` to create an agent identity under a tenant-verified existing blueprint.
 - Log separator written at the start of each CLI invocation now redacts values for secret-bearing options (e.g. `--idp-client-secret`) so they are not written to the log file in plain text.
 - Authentication context (tenant and user) is now logged at the `Information` level whenever the resolved sign-in identity changes, giving operators a clear audit trail in the log file of who the CLI is acting as, without exposing credentials.
 - `a365 develop-mcp evaluate` command for evaluating MCP server tool schema quality — runs deterministic and semantic checks (via GitHub Copilot or Claude Code CLIs), computes maturity scoring, and generates an interactive HTML report

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupCommand.cs
@@ -51,10 +51,14 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Commands
                 "Granular subcommands (for re-runs or partial setup):\n" +
                 "  a365 setup requirements              Validate prerequisites\n" +
                 "  a365 setup blueprint                 Create the agent blueprint (Entra app)\n" +
+                "  a365 setup blueprint list            List existing blueprints in the tenant (read-only)\n" +
                 "  a365 setup permissions mcp           MCP server permissions (when using MCP tools)\n" +
                 "  a365 setup permissions bot           Bot API + Observability + Power Platform\n" +
                 "  a365 setup permissions custom        Inline custom resource permission (--resource-app-id, --scopes)\n" +
                 "  a365 setup permissions copilotstudio Copilot Studio agent permissions\n\n" +
+                "Add a new agent identity to an existing blueprint:\n" +
+                "  a365 setup all --agent-name \"Support Europe\" --blueprint-id <guid>\n" +
+                "  a365 setup all --agent-name \"Support Europe\" --select-blueprint    (interactive picker)\n\n" +
                 "Roles required:\n" +
                 "  - Agent ID Developer                  Blueprint + inheritable permissions\n" +
                 "  - Global Administrator                Tenant-wide OAuth2 consent grants\n\n" +

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
@@ -127,7 +127,10 @@ internal static class AllSubcommand
             description: "Agent base name (e.g. \"MyAgent\"). When provided, no config file is required.\n" +
                         "Derives AgentIdentityDisplayName=\"<name> Identity\" and AgentBlueprintDisplayName=\"<name> Blueprint\".\n" +
                         "TenantId is auto-detected from 'az account show' (override with --tenant-id).\n" +
-                        $"ClientAppId is resolved by looking up \"{Constants.AuthenticationConstants.WellKnownClientAppDisplayName}\" in your tenant.");
+                        $"ClientAppId is resolved by looking up \"{Constants.AuthenticationConstants.WellKnownClientAppDisplayName}\" in your tenant.\n" +
+                        "Each agent identity must use its own working directory: reusing a directory that\n" +
+                        "already has a365.config.json for a DIFFERENT --agent-name is refused before any\n" +
+                        "change is made; run from a fresh directory for each new agent identity.");
 
         var tenantIdOption = new Option<string?>(
             "--tenant-id",
@@ -164,6 +167,23 @@ internal static class AllSubcommand
                         "is a post-deploy artifact, so it can be set later with\n" +
                         "'a365 setup blueprint --endpoint-only --messaging-endpoint <url>'.");
 
+        var blueprintIdOption = new Option<string?>(
+            "--blueprint-id",
+            description: "Add the new agent identity to an existing Agent Identity Blueprint instead of\n" +
+                        "deriving/creating \"<agent-name> Blueprint\" (blueprint agents only; not supported\n" +
+                        "with --aiteammate). Value is the blueprint's application (client) ID; list candidates\n" +
+                        "with 'a365 setup blueprint list'. Mutually exclusive with --select-blueprint. Verified\n" +
+                        "against the current tenant before any changes are made. Reruns with the same\n" +
+                        "--agent-name and --blueprint-id reuse the existing agent identity/registration.\n" +
+                        "Example: a365 setup all --agent-name \"Support Europe\" --blueprint-id <guid>");
+
+        var selectBlueprintOption = new Option<bool>(
+            "--select-blueprint",
+            description: "Interactively list existing Agent Identity Blueprints in the tenant and choose one by\n" +
+                        "number to add the new agent identity to (blueprint agents only; not supported with\n" +
+                        "--aiteammate). Mutually exclusive with --blueprint-id. Requires an interactive terminal;\n" +
+                        "use --blueprint-id for non-interactive/CI runs.");
+
         command.AddOption(verboseOption);
         command.AddOption(dryRunOption);
         command.AddOption(skipInfrastructureOption);
@@ -176,6 +196,8 @@ internal static class AllSubcommand
         command.AddOption(authModeOption);
         command.AddOption(skipSpProvisioningOption);
         command.AddOption(messagingEndpointOption);
+        command.AddOption(blueprintIdOption);
+        command.AddOption(selectBlueprintOption);
 
         command.SetHandler(async (System.CommandLine.Invocation.InvocationContext context) =>
         {
@@ -202,6 +224,9 @@ internal static class AllSubcommand
             // hard error, not silently treated as omitted (which would prompt/defer instead).
             var messagingEndpointSpecified = context.ParseResult.CommandResult.FindResultFor(messagingEndpointOption) != null;
             var messagingEndpointFlag = context.ParseResult.GetValueForOption(messagingEndpointOption)?.Trim();
+            var blueprintIdSpecified = context.ParseResult.CommandResult.FindResultFor(blueprintIdOption) != null;
+            var blueprintIdFlag = context.ParseResult.GetValueForOption(blueprintIdOption)?.Trim();
+            var selectBlueprint = context.ParseResult.GetValueForOption(selectBlueprintOption);
             var ct = context.GetCancellationToken();
 
             if (messagingEndpointSpecified && string.IsNullOrWhiteSpace(messagingEndpointFlag))
@@ -242,6 +267,17 @@ internal static class AllSubcommand
                 }
             }
 
+            // --blueprint-id / --select-blueprint validation (mutually exclusive, GUID format,
+            // aiteammate incompatibility, noninteractive/dry-run guard for the interactive picker).
+            // Runs before any mutation so invalid combinations fail fast.
+            if (!BlueprintSelectionHelper.ValidateOptions(
+                    blueprintIdFlag, blueprintIdSpecified, selectBlueprint, aiTeammateFlag, dryRun,
+                    nonInteractive: Console.IsInputRedirected, logger))
+            {
+                context.ExitCode = 1;
+                return;
+            }
+
             // Generate correlation ID at workflow entry point
             var correlationId = HttpClientFactory.GenerateCorrelationId();
             logger.LogDebug("Starting setup all (CorrelationId: {CorrelationId})", correlationId);
@@ -269,6 +305,12 @@ internal static class AllSubcommand
                             AiTeammate = false,
                             UseBlueprint = true,
                         };
+
+                        // --blueprint-id cannot be resolved without a Graph call (skipped in dry-run),
+                        // so just surface the raw ID in the plan; --select-blueprint is rejected for
+                        // dry-run above since listing requires a Graph call.
+                        if (!string.IsNullOrWhiteSpace(blueprintIdFlag))
+                            nonDwConfig.AgentBlueprintId = blueprintIdFlag;
                     }
                     else
                     {
@@ -287,6 +329,63 @@ internal static class AllSubcommand
                             return;
                         }
 
+                        // If existing config files belong to a different tenant (e.g. the user ran
+                        // 'az login' with a different account), back them up and remove them so this
+                        // run starts with a clean state and does not inherit stale resource IDs.
+                        if (resolver != null)
+                            await resolver.BackupAndClearStaleConfigAsync(config.FullName, nonDwConfig.TenantId!);
+                        else
+                            await BackupAndClearStaleConfigAsync(config.FullName, nonDwConfig.TenantId!, logger);
+
+                        // A working directory stores state for exactly one agent identity.
+                        if (await RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+                                config.FullName, nonDwConfig.AgentIdentityDisplayName, agentName!, logger))
+                        {
+                            context.ExitCode = 1;
+                            return;
+                        }
+
+                        // Restore generated state before applying an explicit blueprint selection.
+                        var bootstrapGenPath = Path.Combine(
+                            config.DirectoryName ?? Environment.CurrentDirectory,
+                            "a365.generated.config.json");
+                        string? cachedAgentIdentityDisplayName = null;
+                        if (File.Exists(bootstrapGenPath))
+                        {
+                            try
+                            {
+                                var genConfig = await configService.LoadAsync(config.FullName, bootstrapGenPath);
+                                cachedAgentIdentityDisplayName = genConfig.AgentIdentityDisplayName;
+                                MergeCachedBootstrapState(nonDwConfig, genConfig);
+                            }
+                            catch (OperationCanceledException) { throw; }
+                            catch (Exception ex)
+                            {
+                                logger.LogDebug(ex, "Could not merge generated config in bootstrap mode; proceeding without stored IDs.");
+                            }
+                        }
+
+                        // Resolve the selected blueprint before persisting bootstrap configuration.
+                        if (!string.IsNullOrWhiteSpace(blueprintIdFlag) || selectBlueprint)
+                        {
+                            var selectedBlueprint = await BlueprintSelectionHelper.ResolveAsync(
+                                blueprintLookupService, nonDwConfig.TenantId!, blueprintIdFlag, selectBlueprint, logger, ct);
+                            if (selectedBlueprint is null)
+                            {
+                                context.ExitCode = 1;
+                                return;
+                            }
+                            nonDwConfig = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+                                nonDwConfig, selectedBlueprint, cachedAgentIdentityDisplayName);
+                            if (File.Exists(config.FullName) &&
+                                !await PersistSelectedBlueprintDisplayNameAsync(
+                                    configService, config.FullName, selectedBlueprint.DisplayName!, logger, ct))
+                            {
+                                context.ExitCode = 1;
+                                return;
+                            }
+                        }
+
                         // Log resolved config so the user can verify the inferred values
                         logger.LogInformation("Bootstrap config resolved:");
                         using (logger.Indent())
@@ -298,16 +397,9 @@ internal static class AllSubcommand
                         }
                         logger.LogInformation("");
 
-                        // If existing config files belong to a different tenant (e.g. the user ran
-                        // 'az login' with a different account), back them up and remove them so this
-                        // run starts with a clean state and does not inherit stale resource IDs.
-                        if (resolver != null)
-                            await resolver.BackupAndClearStaleConfigAsync(config.FullName, nonDwConfig.TenantId!);
-                        else
-                            await BackupAndClearStaleConfigAsync(config.FullName, nonDwConfig.TenantId!, logger);
-
-                        // Write a365.config.json so the resolved bootstrap settings are persisted in the
-                        // current working directory and reused consistently by later setup and cleanup steps.
+                        // Write a365.config.json so the resolved bootstrap settings (including the
+                        // final blueprint display name) are persisted in the current working directory
+                        // and reused consistently by later setup and cleanup steps.
                         if (!File.Exists(config.FullName))
                         {
                             if (resolver != null)
@@ -316,31 +408,8 @@ internal static class AllSubcommand
                                 await WriteBootstrapConfigFileAsync(nonDwConfig, config.FullName, logger);
                         }
 
-                        // Merge stored IDs from the existing generated config (if present) so re-running
-                        // with --agent-name reuses previously created resources. Registration has no
-                        // lookup endpoint so the stored ID is the only idempotency key; blueprint and
-                        // identity IDs are needed for the --agent-registration-only API fallback.
-                        var bootstrapGenPath = Path.Combine(
-                            config.DirectoryName ?? Environment.CurrentDirectory,
-                            "a365.generated.config.json");
-                        if (File.Exists(bootstrapGenPath))
-                        {
-                            try
-                            {
-                                var genConfig = await configService.LoadAsync(config.FullName, bootstrapGenPath);
-                                if (!string.IsNullOrWhiteSpace(genConfig.AgentRegistrationId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentRegistrationId))
-                                    nonDwConfig.AgentRegistrationId = genConfig.AgentRegistrationId;
-                                if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintId))
-                                    nonDwConfig.AgentBlueprintId = genConfig.AgentBlueprintId;
-                                if (!string.IsNullOrWhiteSpace(genConfig.AgenticAppId) && string.IsNullOrWhiteSpace(nonDwConfig.AgenticAppId))
-                                    nonDwConfig.AgenticAppId = genConfig.AgenticAppId;
-                            }
-                            catch (OperationCanceledException) { throw; }
-                            catch (Exception ex)
-                            {
-                                logger.LogDebug(ex, "Could not merge generated config in bootstrap mode; proceeding without stored IDs.");
-                            }
-                        }
+                        if (!string.IsNullOrWhiteSpace(blueprintIdFlag) || selectBlueprint)
+                            await configService.SaveStateAsync(nonDwConfig, bootstrapGenPath);
                     }
                 }
                 else
@@ -365,9 +434,60 @@ internal static class AllSubcommand
                     catch when (dryRun) { /* config is optional for dry-run; falls through to DW dry-run plan */ }
                     // If aiteammate was not explicitly set, respect what the config says
                     // (allows existing AI Teammate configs to keep working without --aiteammate true)
-                    if (nonDwConfig != null && !aiTeammateFlag.HasValue && !nonDwConfig.IsBlueprintAgent && !dryRun)
+                    if (nonDwConfig != null &&
+                        !aiTeammateFlag.HasValue &&
+                        (nonDwConfig.AiTeammate == true || (!dryRun && !nonDwConfig.IsBlueprintAgent)))
                         nonDwConfig = null; // fall through to DW path
+
+                    if (nonDwConfig != null && (!string.IsNullOrWhiteSpace(blueprintIdFlag) || selectBlueprint))
+                    {
+                        BlueprintLookupResult? selectedBlueprint;
+                        if (dryRun)
+                        {
+                            selectedBlueprint = new BlueprintLookupResult
+                            {
+                                Found = true,
+                                AppId = blueprintIdFlag,
+                                DisplayName = nonDwConfig.AgentBlueprintDisplayName
+                            };
+                        }
+                        else
+                        {
+                            selectedBlueprint = await BlueprintSelectionHelper.ResolveAsync(
+                                blueprintLookupService, nonDwConfig.TenantId!, blueprintIdFlag, selectBlueprint, logger, ct);
+                        }
+
+                        if (selectedBlueprint is null)
+                        {
+                            context.ExitCode = 1;
+                            return;
+                        }
+                        nonDwConfig = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+                            nonDwConfig, selectedBlueprint, nonDwConfig.AgentIdentityDisplayName);
+                        if (!dryRun)
+                        {
+                            if (!await PersistSelectedBlueprintDisplayNameAsync(
+                                    configService, config.FullName, selectedBlueprint.DisplayName!, logger, ct))
+                            {
+                                context.ExitCode = 1;
+                                return;
+                            }
+                            await configService.SaveStateAsync(nonDwConfig, nonDwGenPath);
+                        }
+                    }
                 }
+            }
+
+            // --blueprint-id / --select-blueprint apply only to the blueprint-agent path. Fail fast
+            // rather than silently ignoring the flag when the resolved agent turns out to be an AI
+            // Teammate (e.g. --aiteammate omitted but a365.config.json already has AiTeammate=true).
+            if (nonDwConfig is null && (!string.IsNullOrWhiteSpace(blueprintIdFlag) || selectBlueprint))
+            {
+                logger.LogError(
+                    "--{Option} applies only to blueprint agents (the default). It is not supported for AI Teammate agents.",
+                    !string.IsNullOrWhiteSpace(blueprintIdFlag) ? "blueprint-id" : "select-blueprint");
+                context.ExitCode = 1;
+                return;
             }
 
             // Validate the effective authMode (flag OR config). The CLI flag was validated above;
@@ -1168,6 +1288,129 @@ internal static class AllSubcommand
             File.Move(generatedPath, generatedBackup);
             logger.LogDebug("Backed up: {File}", Path.GetFileName(generatedBackup));
         }
+    }
+
+    /// <summary>
+    /// Restores cached blueprint state and, for the same identity, agent-specific state.
+    /// </summary>
+    internal static void MergeCachedBootstrapState(Agent365Config nonDwConfig, Agent365Config genConfig)
+    {
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintId))
+            nonDwConfig.AgentBlueprintId = genConfig.AgentBlueprintId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintObjectId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintObjectId))
+            nonDwConfig.AgentBlueprintObjectId = genConfig.AgentBlueprintObjectId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintServicePrincipalObjectId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintServicePrincipalObjectId))
+            nonDwConfig.AgentBlueprintServicePrincipalObjectId = genConfig.AgentBlueprintServicePrincipalObjectId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentBlueprintClientSecret) && string.IsNullOrWhiteSpace(nonDwConfig.AgentBlueprintClientSecret))
+        {
+            nonDwConfig.AgentBlueprintClientSecret = genConfig.AgentBlueprintClientSecret;
+            nonDwConfig.AgentBlueprintClientSecretProtected = genConfig.AgentBlueprintClientSecretProtected;
+        }
+        if (nonDwConfig.ResourceConsents.Count == 0 && genConfig.ResourceConsents.Count > 0)
+            nonDwConfig.ResourceConsents = genConfig.ResourceConsents;
+
+        var cachedIdentityMatchesTarget = string.Equals(
+            genConfig.AgentIdentityDisplayName, nonDwConfig.AgentIdentityDisplayName, StringComparison.Ordinal);
+        if (!cachedIdentityMatchesTarget)
+            return;
+
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentRegistrationId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentRegistrationId))
+            nonDwConfig.AgentRegistrationId = genConfig.AgentRegistrationId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgenticAppId) && string.IsNullOrWhiteSpace(nonDwConfig.AgenticAppId))
+            nonDwConfig.AgenticAppId = genConfig.AgenticAppId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgentInstanceId) && string.IsNullOrWhiteSpace(nonDwConfig.AgentInstanceId))
+            nonDwConfig.AgentInstanceId = genConfig.AgentInstanceId;
+        if (!string.IsNullOrWhiteSpace(genConfig.AgenticUserId) && string.IsNullOrWhiteSpace(nonDwConfig.AgenticUserId))
+            nonDwConfig.AgenticUserId = genConfig.AgenticUserId;
+        if (!string.IsNullOrWhiteSpace(genConfig.ManagedIdentityPrincipalId) && string.IsNullOrWhiteSpace(nonDwConfig.ManagedIdentityPrincipalId))
+            nonDwConfig.ManagedIdentityPrincipalId = genConfig.ManagedIdentityPrincipalId;
+        if (!string.IsNullOrWhiteSpace(genConfig.BotId) && string.IsNullOrWhiteSpace(nonDwConfig.BotId))
+            nonDwConfig.BotId = genConfig.BotId;
+        if (!string.IsNullOrWhiteSpace(genConfig.BotMsaAppId) && string.IsNullOrWhiteSpace(nonDwConfig.BotMsaAppId))
+            nonDwConfig.BotMsaAppId = genConfig.BotMsaAppId;
+        if (!string.IsNullOrWhiteSpace(genConfig.BotMessagingEndpoint) && string.IsNullOrWhiteSpace(nonDwConfig.BotMessagingEndpoint))
+            nonDwConfig.BotMessagingEndpoint = genConfig.BotMessagingEndpoint;
+        if (!string.IsNullOrWhiteSpace(genConfig.AzureOpenAIEndpoint) && string.IsNullOrWhiteSpace(nonDwConfig.AzureOpenAIEndpoint))
+            nonDwConfig.AzureOpenAIEndpoint = genConfig.AzureOpenAIEndpoint;
+        if (!string.IsNullOrWhiteSpace(genConfig.AzureOpenAIApiKey) && string.IsNullOrWhiteSpace(nonDwConfig.AzureOpenAIApiKey))
+            nonDwConfig.AzureOpenAIApiKey = genConfig.AzureOpenAIApiKey;
+        if (!nonDwConfig.Completed && genConfig.Completed)
+            nonDwConfig.Completed = true;
+        if (nonDwConfig.CompletedAt is null)
+            nonDwConfig.CompletedAt = genConfig.CompletedAt;
+    }
+
+    private static async Task<bool> PersistSelectedBlueprintDisplayNameAsync(
+        IConfigService configService,
+        string configPath,
+        string displayName,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        try
+        {
+            await configService.UpdateAgentBlueprintDisplayNameAsync(displayName, configPath, ct);
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            logger.LogError(ex, "Failed to update the selected blueprint in {ConfigPath}: {Message}", configPath, ex.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Rejects bootstrap setup when the working directory belongs to another identity.
+    /// </summary>
+    internal static async Task<bool> RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+        string configPath,
+        string targetAgentIdentityDisplayName,
+        string agentName,
+        ILogger logger)
+    {
+        if (!File.Exists(configPath))
+            return false;
+
+        string? existingIdentityDisplayName;
+        try
+        {
+            var json = await File.ReadAllTextAsync(configPath);
+            using var doc = JsonDocument.Parse(json);
+            existingIdentityDisplayName = SetupHelpers.GetJsonString(doc.RootElement, "agentIdentityDisplayName");
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Could not read {Path} to check for an existing agent identity.", configPath);
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(existingIdentityDisplayName) ||
+            string.Equals(existingIdentityDisplayName, targetAgentIdentityDisplayName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        logger.LogError(
+            "This directory is already set up for agent identity '{ExistingIdentity}' ({Path}). " +
+            "Running --agent-name \"{AgentName}\" here would target a different identity " +
+            "('{TargetIdentity}'), and the current configuration format supports only one agent " +
+            "identity per working directory.",
+            existingIdentityDisplayName, configPath, agentName, targetAgentIdentityDisplayName);
+        logger.LogInformation("");
+        logger.LogInformation("Run this command from a separate, empty working directory for the new agent identity, e.g.:");
+        logger.LogInformation("  mkdir <new-directory> && cd <new-directory>");
+        logger.LogInformation("  a365 setup all --agent-name \"{AgentName}\"", agentName);
+        logger.LogInformation("");
+
+        return true;
     }
 
     /// <summary>Step 1 — Infrastructure step (no-op, deploy command removed).</summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSelectionHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSelectionHelper.cs
@@ -1,0 +1,226 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.DevTools.Cli.Helpers;
+using Microsoft.Agents.A365.DevTools.Cli.Models;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+
+/// <summary>
+/// Validates and applies an existing blueprint selection for <c>setup all</c>.
+/// </summary>
+internal static class BlueprintSelectionHelper
+{
+    /// <summary>
+    /// Validates blueprint-selection options before setup mutates state.
+    /// </summary>
+    internal static bool ValidateOptions(
+        string? blueprintId,
+        bool blueprintIdSpecified,
+        bool selectBlueprint,
+        bool? aiTeammateFlag,
+        bool dryRun,
+        bool nonInteractive,
+        ILogger logger)
+    {
+        if (blueprintIdSpecified && selectBlueprint)
+        {
+            logger.LogError("Options --blueprint-id and --select-blueprint cannot be used together. Choose one.");
+            return false;
+        }
+
+        if (!blueprintIdSpecified && !selectBlueprint)
+            return true;
+
+        var optionName = blueprintIdSpecified ? "--blueprint-id" : "--select-blueprint";
+
+        if (aiTeammateFlag == true)
+        {
+            logger.LogError(
+                "{Option} is not supported with --aiteammate. Explicit blueprint selection applies to blueprint agents only (the default; omit --aiteammate).",
+                optionName);
+            return false;
+        }
+
+        if (blueprintIdSpecified && string.IsNullOrWhiteSpace(blueprintId))
+        {
+            logger.LogError("--blueprint-id cannot be empty or whitespace. Provide a GUID from 'a365 setup blueprint list'.");
+            return false;
+        }
+
+        if (blueprintIdSpecified && !Guid.TryParse(blueprintId, out _))
+        {
+            logger.LogError(
+                "Invalid --blueprint-id value '{Value}'. Provide the blueprint's application (client) ID as a GUID; see 'a365 setup blueprint list'.",
+                blueprintId);
+            return false;
+        }
+
+        if (selectBlueprint && nonInteractive)
+        {
+            logger.LogError(
+                "--select-blueprint requires an interactive terminal. Use --blueprint-id <guid> for non-interactive/CI runs (see 'a365 setup blueprint list').");
+            return false;
+        }
+
+        if (selectBlueprint && dryRun)
+        {
+            logger.LogError(
+                "--select-blueprint requires a real run to query the tenant and cannot be combined with --dry-run. Use --blueprint-id <guid> for a dry-run preview instead.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Resolves and verifies a selected blueprint in the active tenant.
+    /// </summary>
+    internal static async Task<BlueprintLookupResult?> ResolveAsync(
+        BlueprintLookupService blueprintLookupService,
+        string tenantId,
+        string? blueprintId,
+        bool selectBlueprint,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var resolvedAppId = blueprintId;
+
+        if (selectBlueprint)
+        {
+            IReadOnlyList<BlueprintLookupResult> blueprints;
+            try
+            {
+                blueprints = await blueprintLookupService.ListBlueprintsAsync(tenantId, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to list agent identity blueprints for selection: {Message}", ex.Message);
+                return null;
+            }
+
+            if (blueprints.Count == 0)
+            {
+                logger.LogError(
+                    "No Agent Identity Blueprints found in tenant {TenantId}. Omit --select-blueprint to create a new one.",
+                    tenantId);
+                return null;
+            }
+
+            logger.LogInformation("Agent Identity Blueprints in tenant {TenantId}:", tenantId);
+            using (logger.Indent())
+            {
+                for (var i = 0; i < blueprints.Count; i++)
+                {
+                    logger.LogInformation("{Index}. {DisplayName}  (Blueprint ID: {AppId})",
+                        i + 1, blueprints[i].DisplayName ?? "(unnamed)", blueprints[i].AppId ?? "(unknown)");
+                }
+            }
+            logger.LogInformation("");
+
+            Console.Write($"Select a blueprint [1-{blueprints.Count}]: ");
+            var input = ConsoleHelper.ReadLineCancellable(ct)?.Trim();
+            if (!int.TryParse(input, out var choice) || choice < 1 || choice > blueprints.Count)
+            {
+                logger.LogError(
+                    "Invalid selection '{Input}'. Run 'a365 setup all --select-blueprint' again and choose a number from the list.",
+                    input);
+                return null;
+            }
+
+            resolvedAppId = blueprints[choice - 1].AppId;
+        }
+
+        if (string.IsNullOrWhiteSpace(resolvedAppId))
+        {
+            logger.LogError("Could not determine a blueprint application ID to use.");
+            return null;
+        }
+
+        var lookup = await blueprintLookupService.GetBlueprintByAppIdAsync(tenantId, resolvedAppId, ct);
+        if (!lookup.Found)
+        {
+            if (!string.IsNullOrWhiteSpace(lookup.ErrorMessage))
+            {
+                logger.LogError(
+                    "Could not verify blueprint '{BlueprintId}' in tenant '{TenantId}': {Error}",
+                    resolvedAppId, tenantId, lookup.ErrorMessage);
+            }
+            else
+            {
+                logger.LogError(
+                    "Blueprint '{BlueprintId}' was not found in tenant '{TenantId}'. Verify the ID with 'a365 setup blueprint list' and that it belongs to the currently signed-in tenant.",
+                    resolvedAppId, tenantId);
+            }
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(lookup.AppId) ||
+            string.IsNullOrWhiteSpace(lookup.ObjectId) ||
+            string.IsNullOrWhiteSpace(lookup.DisplayName) ||
+            !string.Equals(lookup.AppId, resolvedAppId, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogError(
+                "Blueprint '{BlueprintId}' returned incomplete or inconsistent identifiers from Microsoft Graph.",
+                resolvedAppId);
+            return null;
+        }
+
+        return lookup;
+    }
+
+    /// <summary>
+    /// Applies authoritative blueprint IDs and clears state owned by another blueprint or identity.
+    /// </summary>
+    internal static Agent365Config ApplyExplicitBlueprintSelection(
+        Agent365Config config,
+        BlueprintLookupResult blueprint,
+        string? cachedAgentIdentityDisplayName = null)
+    {
+        var isSameBlueprintAsCached = !string.IsNullOrWhiteSpace(config.AgentBlueprintId) &&
+            string.Equals(config.AgentBlueprintId, blueprint.AppId, StringComparison.OrdinalIgnoreCase);
+
+        var isSameIdentityAsCached = isSameBlueprintAsCached &&
+            !string.IsNullOrWhiteSpace(cachedAgentIdentityDisplayName) &&
+            string.Equals(cachedAgentIdentityDisplayName, config.AgentIdentityDisplayName, StringComparison.Ordinal);
+
+        var updated = config.WithAgentBlueprintDisplayName(blueprint.DisplayName);
+        updated.AgentBlueprintId = blueprint.AppId;
+        updated.AgentBlueprintObjectId = blueprint.ObjectId;
+        updated.ResourceConsents = isSameBlueprintAsCached
+            ? new(config.ResourceConsents)
+            : new();
+
+        if (isSameBlueprintAsCached)
+        {
+            updated.AgentBlueprintServicePrincipalObjectId = config.AgentBlueprintServicePrincipalObjectId;
+            updated.AgentBlueprintClientSecret = config.AgentBlueprintClientSecret;
+            updated.AgentBlueprintClientSecretProtected = config.AgentBlueprintClientSecretProtected;
+        }
+        else
+        {
+            updated.AgentBlueprintServicePrincipalObjectId = null;
+            updated.AgentBlueprintClientSecret = null;
+            updated.AgentBlueprintClientSecretProtected = false;
+        }
+
+        if (!isSameIdentityAsCached)
+        {
+            updated.AgentInstanceId = null;
+            updated.AgenticAppId = null;
+            updated.AgenticUserId = null;
+            updated.AgentRegistrationId = null;
+            updated.BotId = null;
+            updated.BotMsaAppId = null;
+            updated.BotMessagingEndpoint = null;
+            updated.Completed = false;
+            updated.CompletedAt = null;
+        }
+
+        return updated;
+    }
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/BlueprintSubcommand.cs
@@ -130,7 +130,9 @@ internal static class BlueprintSubcommand
     {
         var command = new Command("blueprint",
             "Create agent blueprint (Entra ID application registration)\n" +
-            "Minimum required permissions: Agent ID Developer role\n");
+            "Minimum required permissions: Agent ID Developer role\n\n" +
+            "Subcommand:\n" +
+            "  a365 setup blueprint list             List existing blueprints in the tenant (read-only)\n");
 
         var agentNameOption = new Option<string?>(
             ["--agent-name", "-n"],
@@ -194,6 +196,9 @@ internal static class BlueprintSubcommand
         command.AddOption(skipRequirementsOption);
         command.AddOption(m365Option);
         command.AddOption(showSecretOption);
+
+        // Keep listing separate from the blueprint create/update handler.
+        command.AddCommand(CreateListSubcommand(logger, executor, graphApiService, blueprintLookupService));
 
         command.SetHandler(async (System.CommandLine.Invocation.InvocationContext context) =>
         {
@@ -454,6 +459,87 @@ internal static class BlueprintSubcommand
                 isM365: isM365
                 );
 
+        });
+
+        return command;
+    }
+
+    /// <summary>
+    /// Creates the read-only blueprint listing command.
+    /// </summary>
+    private static Command CreateListSubcommand(
+        ILogger logger,
+        CommandExecutor executor,
+        GraphApiService graphApiService,
+        BlueprintLookupService blueprintLookupService)
+    {
+        var command = new Command("list",
+            "List Agent Identity Blueprints in the tenant (read-only)\n" +
+            "Shows each blueprint's display name and Blueprint ID (application/client ID); pass the\n" +
+            "Blueprint ID to 'a365 setup all --blueprint-id <id>' to add a new agent identity to it.\n" +
+            "Minimum required permissions: AgentIdentityBlueprint.Read.All (or ReadWrite.All)\n");
+
+        var tenantIdOption = new Option<string?>(
+            "--tenant-id",
+            description: "Azure AD tenant ID. Overrides auto-detection from 'az account show'.");
+
+        command.AddOption(tenantIdOption);
+
+        command.SetHandler(async (System.CommandLine.Invocation.InvocationContext context) =>
+        {
+            var tenantIdSpecified = context.ParseResult.CommandResult.FindResultFor(tenantIdOption) != null;
+            var tenantIdFlag = context.ParseResult.GetValueForOption(tenantIdOption)?.Trim();
+            var ct = context.GetCancellationToken();
+
+            if (tenantIdSpecified && string.IsNullOrWhiteSpace(tenantIdFlag))
+            {
+                logger.LogError("--tenant-id cannot be empty or whitespace.");
+                context.ExitCode = 1;
+                return;
+            }
+
+            var tenantId = await SetupHelpers.ResolveBootstrapTenantIdAsync(tenantIdFlag, executor, logger);
+            if (string.IsNullOrWhiteSpace(tenantId))
+            {
+                logger.LogError("Could not detect tenant ID. Sign in with 'az login' or pass --tenant-id.");
+                context.ExitCode = 1;
+                return;
+            }
+
+            IReadOnlyList<Models.BlueprintLookupResult> blueprints;
+            try
+            {
+                blueprints = await blueprintLookupService.ListBlueprintsAsync(tenantId, ct);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to list agent identity blueprints: {Message}", ex.Message);
+                context.ExitCode = 1;
+                return;
+            }
+
+            if (blueprints.Count == 0)
+            {
+                logger.LogInformation("No Agent Identity Blueprints found in tenant {TenantId}.", tenantId);
+                logger.LogInformation("");
+                logger.LogInformation("Create one with: a365 setup blueprint --agent-name <name>");
+                return;
+            }
+
+            logger.LogInformation("Agent Identity Blueprints in tenant {TenantId}:", tenantId);
+            logger.LogInformation("");
+            using (logger.Indent())
+            {
+                for (var i = 0; i < blueprints.Count; i++)
+                {
+                    logger.LogInformation("{Index}. {DisplayName}  (Blueprint ID: {AppId})",
+                        i + 1, blueprints[i].DisplayName ?? "(unnamed)", blueprints[i].AppId ?? "(unknown)");
+                }
+            }
+            logger.LogInformation("");
+            logger.LogInformation("To add a new agent identity under an existing blueprint, run:");
+            logger.LogInformation("  a365 setup all --agent-name <name> --blueprint-id <id>");
         });
 
         return command;
@@ -862,10 +948,61 @@ internal static class BlueprintSubcommand
     }
 
     /// <summary>
-    /// Creates Agent Blueprint application using Graph API
-    /// Implements displayName-first discovery for idempotency: always searches by displayName from a365.config.json (the source of truth).
-    /// Cached objectIds are only used for dependent resources (FIC, etc.) after blueprint existence is confirmed.
-    /// Returns: (success, appId, objectId, servicePrincipalId, alreadyExisted, graphPermissionsConfigured, graphInheritablePermissionsFailed, graphInheritablePermissionsError, ficConfigured, ficError, adminConsentUrl)
+    /// Resolves a blueprint by stable object ID, then falls back to its display name.
+    /// </summary>
+    internal static async Task<BlueprintLookupResult> ResolveExistingBlueprintAsync(
+        BlueprintLookupService blueprintLookupService,
+        string tenantId,
+        string? cachedObjectId,
+        string displayName,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        if (!string.IsNullOrWhiteSpace(cachedObjectId))
+        {
+            logger.LogDebug("Verifying cached blueprint object ID: {ObjectId}...", cachedObjectId);
+            var idLookupResult = await blueprintLookupService.GetApplicationByObjectIdAsync(tenantId, cachedObjectId, ct);
+
+            if (idLookupResult.Found)
+            {
+                logger.LogInformation("Found existing blueprint by object ID (authoritative)");
+                using (logger.Indent())
+                {
+                    logger.LogInformation("Blueprint ID: {AppId}", idLookupResult.AppId);
+                    logger.LogDebug("Object ID: {ObjectId}", idLookupResult.ObjectId);
+                }
+
+                return idLookupResult;
+            }
+
+            logger.LogDebug(
+                "Cached blueprint object ID {ObjectId} no longer resolves in the tenant; falling back to display-name discovery.",
+                cachedObjectId);
+        }
+
+        // Always search by displayName from a365.config.json (the master source of truth) when no
+        // authoritative object ID was already confirmed above.
+        if (string.IsNullOrWhiteSpace(displayName))
+            return new BlueprintLookupResult { Found = false };
+
+        logger.LogDebug("Searching for existing blueprint by display name: {DisplayName}...", displayName);
+        var lookupResult = await blueprintLookupService.GetApplicationByDisplayNameAsync(tenantId, displayName, cancellationToken: ct);
+
+        if (lookupResult.Found)
+        {
+            logger.LogInformation("Found existing blueprint by display name");
+            using (logger.Indent())
+            {
+                logger.LogInformation("Blueprint ID: {AppId}", lookupResult.AppId);
+                logger.LogDebug("Object ID: {ObjectId}", lookupResult.ObjectId);
+            }
+        }
+
+        return lookupResult;
+    }
+
+    /// <summary>
+    /// Creates or reuses an Agent Identity Blueprint through Microsoft Graph.
     /// </summary>
     public static async Task<(bool success, string? appId, string? objectId, string? servicePrincipalId, bool alreadyExisted, bool graphPermissionsConfigured, bool graphInheritablePermissionsFailed, string? graphInheritablePermissionsError, bool ficConfigured, string? ficError, string? adminConsentUrl)> CreateAgentBlueprintAsync(
         ILogger logger,
@@ -888,13 +1025,7 @@ internal static class BlueprintSubcommand
         Func<Task<string?>>? loginHintResolver = null,
         IConfirmationProvider? confirmationProvider = null)
     {
-        // ========================================================================
-        // Idempotency Check: DisplayName-First Discovery
-        // ========================================================================
-        // IMPORTANT: a365.config.json is the source of truth for displayName.
-        // We always search by displayName first to handle scenarios where the user
-        // changes displayName in a365.config.json. Cached objectIds are only used
-        // for dependent resources (FIC, etc.) after blueprint is confirmed to exist.
+        // Prefer the stable object ID because blueprint display names are not unique.
 
         string? existingObjectId = null;
         string? existingAppId = null;
@@ -902,26 +1033,14 @@ internal static class BlueprintSubcommand
         bool blueprintAlreadyExists = false;
         bool requiresPersistence = false;
 
-        // Always search by displayName from a365.config.json (the master source of truth)
-        if (!string.IsNullOrWhiteSpace(displayName))
+        var discovery = await ResolveExistingBlueprintAsync(
+            blueprintLookupService, tenantId, setupConfig.AgentBlueprintObjectId, displayName, logger, ct);
+        if (discovery.Found)
         {
-            logger.LogDebug("Searching for existing blueprint by display name: {DisplayName}...", displayName);
-            var lookupResult = await blueprintLookupService.GetApplicationByDisplayNameAsync(tenantId, displayName, cancellationToken: ct);
-
-            if (lookupResult.Found)
-            {
-                logger.LogInformation("Found existing blueprint by display name");
-                using (logger.Indent())
-                {
-                    logger.LogInformation("Blueprint ID: {AppId}", lookupResult.AppId);
-                    logger.LogDebug("Object ID: {ObjectId}", lookupResult.ObjectId);
-                }
-
-                existingObjectId = lookupResult.ObjectId;
-                existingAppId = lookupResult.AppId;
-                blueprintAlreadyExists = true;
-                requiresPersistence = lookupResult.RequiresPersistence;
-            }
+            existingObjectId = discovery.ObjectId;
+            existingAppId = discovery.AppId;
+            blueprintAlreadyExists = true;
+            requiresPersistence = discovery.RequiresPersistence;
         }
 
         // If blueprint exists, verify service principal still exists (cached ID may be stale if SP was deleted externally)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
 using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
@@ -672,6 +673,26 @@ public class Agent365Config
 
         return config;
     }
+
+    /// <summary>
+    /// Returns a shallow copy of this config with <see cref="AgentBlueprintDisplayName"/> overridden.
+    /// </summary>
+    /// <remarks>
+    /// Setter metadata determines static config persistence; callers must replace shared collections
+    /// before mutating them on the shallow copy.
+    /// </remarks>
+    public Agent365Config WithAgentBlueprintDisplayName(string? displayName)
+    {
+        var clone = (Agent365Config)MemberwiseClone();
+        SetAgentBlueprintDisplayName(clone, displayName);
+        return clone;
+    }
+
+    /// <summary>
+    /// Invokes the init-only display-name setter on a cloned config.
+    /// </summary>
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_" + nameof(AgentBlueprintDisplayName))]
+    private static extern void SetAgentBlueprintDisplayName(Agent365Config config, string? value);
 
     /// <summary>
     /// Creates a new Agent365Config instance with the same static properties but updated CustomBlueprintPermissions.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/BlueprintLookupService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/BlueprintLookupService.cs
@@ -43,13 +43,23 @@ public class BlueprintLookupService
         string objectId,
         CancellationToken cancellationToken = default)
     {
+        if (!Guid.TryParse(objectId, out var validGuid))
+        {
+            return new BlueprintLookupResult
+            {
+                Found = false,
+                LookupMethod = "objectId",
+                ErrorMessage = "Invalid GUID format."
+            };
+        }
+
         try
         {
             _logger.LogDebug("Looking up blueprint by objectId: {ObjectId}", objectId);
 
-            var doc = await _graphApiService.GraphGetAsync(
+            using var doc = await _graphApiService.GraphGetAsync(
                 tenantId,
-                $"/beta/applications/{objectId}",
+                $"/beta/applications/{validGuid:D}/microsoft.graph.agentIdentityBlueprint?$select=id,appId,displayName",
                 cancellationToken);
 
             if (doc == null)
@@ -63,20 +73,40 @@ public class BlueprintLookupService
             }
 
             var root = doc.RootElement;
-            var appId = root.GetProperty("appId").GetString();
-            var displayName = root.GetProperty("displayName").GetString();
+            var match = root.TryGetProperty("value", out var valueElement) &&
+                valueElement.ValueKind == JsonValueKind.Object
+                ? valueElement
+                : root;
+            var resolvedObjectId = match.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
+            var appId = match.TryGetProperty("appId", out var appIdProp) ? appIdProp.GetString() : null;
+            var displayName = match.TryGetProperty("displayName", out var nameProp) ? nameProp.GetString() : null;
+            if (!string.Equals(resolvedObjectId, validGuid.ToString("D"), StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(appId) ||
+                string.IsNullOrWhiteSpace(displayName))
+            {
+                return new BlueprintLookupResult
+                {
+                    Found = false,
+                    LookupMethod = "objectId",
+                    ErrorMessage = "Microsoft Graph returned incomplete or inconsistent blueprint identifiers."
+                };
+            }
 
             _logger.LogDebug("Found blueprint: {DisplayName} (ObjectId: {ObjectId}, AppId: {AppId})", 
-                displayName, objectId, appId);
+                displayName, resolvedObjectId, appId);
 
             return new BlueprintLookupResult
             {
                 Found = true,
-                ObjectId = objectId,
+                ObjectId = resolvedObjectId,
                 AppId = appId,
                 DisplayName = displayName,
                 LookupMethod = "objectId"
             };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -112,7 +142,7 @@ public class BlueprintLookupService
             var escapedDisplayName = displayName.Replace("'", "''");
             var filter = $"displayName eq '{escapedDisplayName}' and signInAudience eq '{signInAudience}'";
 
-            var doc = await _graphApiService.GraphGetAsync(
+            using var doc = await _graphApiService.GraphGetAsync(
                 tenantId,
                 $"/beta/applications?$filter={Uri.EscapeDataString(filter)}",
                 cancellationToken);
@@ -163,6 +193,10 @@ public class BlueprintLookupService
                 RequiresPersistence = true
             };
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogDebug(ex, "Failed to look up blueprint by displayName: {DisplayName}", displayName);
@@ -172,6 +206,141 @@ public class BlueprintLookupService
                 LookupMethod = "displayName",
                 ErrorMessage = ex.Message
             };
+        }
+    }
+
+    /// <summary>
+    /// Lists all Agent Identity Blueprint applications in the tenant, following <c>@odata.nextLink</c>
+    /// pagination. Uses the beta cast collection endpoint
+    /// (<c>/beta/applications/microsoft.graph.agentIdentityBlueprint</c>) which returns only
+    /// blueprint-typed applications, never other application types.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID for authentication.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>All blueprints found, in the order returned by Graph. Empty when none exist.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a page request fails (e.g. authentication or query failure). Callers should
+    /// catch this and surface a non-zero exit code rather than reporting an empty result as success.
+    /// </exception>
+    public virtual async Task<IReadOnlyList<BlueprintLookupResult>> ListBlueprintsAsync(
+        string tenantId,
+        CancellationToken cancellationToken = default)
+    {
+        var results = new List<BlueprintLookupResult>();
+        string? nextPath = "/beta/applications/microsoft.graph.agentIdentityBlueprint?$select=id,appId,displayName&$top=100";
+
+        while (!string.IsNullOrWhiteSpace(nextPath))
+        {
+            _logger.LogDebug("Listing agent identity blueprints: {Path}", nextPath);
+            using var doc = await _graphApiService.GraphGetAsync(tenantId, nextPath, cancellationToken);
+
+            if (doc is null)
+            {
+                throw new InvalidOperationException(
+                    "Failed to list Agent Identity Blueprints from Microsoft Graph. This usually indicates " +
+                    "an authentication failure or insufficient permissions (AgentIdentityBlueprint.Read.All).");
+            }
+
+            var root = doc.RootElement;
+            if (root.TryGetProperty("value", out var valueElement) && valueElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var item in valueElement.EnumerateArray())
+                {
+                    results.Add(new BlueprintLookupResult
+                    {
+                        Found = true,
+                        ObjectId = item.TryGetProperty("id", out var idProp) ? idProp.GetString() : null,
+                        AppId = item.TryGetProperty("appId", out var appIdProp) ? appIdProp.GetString() : null,
+                        DisplayName = item.TryGetProperty("displayName", out var nameProp) ? nameProp.GetString() : null,
+                        LookupMethod = "list"
+                    });
+                }
+            }
+
+            nextPath = root.TryGetProperty("@odata.nextLink", out var nextLink) ? nextLink.GetString() : null;
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Gets a single Agent Identity Blueprint by its application (client) ID, scoped to
+    /// <paramref name="tenantId"/>. Uses the same cast collection endpoint as
+    /// <see cref="ListBlueprintsAsync"/> so a match confirms both that the appId exists AND that it
+    /// is specifically an Agent Identity Blueprint (not merely any Entra application) belonging to
+    /// the caller's tenant.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID for authentication.</param>
+    /// <param name="appId">The blueprint's application (client) ID.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// A result whose <see cref="BlueprintLookupResult.Found"/> is <c>false</c> when <paramref name="appId"/>
+    /// is not a valid GUID, the query fails, or no matching blueprint exists in this tenant.
+    /// </returns>
+    public virtual async Task<BlueprintLookupResult> GetBlueprintByAppIdAsync(
+        string tenantId,
+        string appId,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Guid.TryParse(appId, out var validGuid))
+        {
+            _logger.LogDebug("Invalid blueprint appId format: {AppId}", appId);
+            return new BlueprintLookupResult { Found = false, LookupMethod = "appId", ErrorMessage = "Invalid GUID format." };
+        }
+
+        try
+        {
+            using var doc = await _graphApiService.GraphGetAsync(
+                tenantId,
+                $"/beta/applications/microsoft.graph.agentIdentityBlueprint?$filter=appId eq '{validGuid:D}'&$select=id,appId,displayName&$top=1",
+                cancellationToken);
+
+            if (doc is null)
+            {
+                _logger.LogDebug("Blueprint lookup by appId {AppId} failed (Graph query returned no result).", appId);
+                return new BlueprintLookupResult { Found = false, LookupMethod = "appId", ErrorMessage = "Graph query failed." };
+            }
+
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("value", out var valueElement) || valueElement.GetArrayLength() == 0)
+            {
+                _logger.LogDebug("No agent identity blueprint found with appId: {AppId}", appId);
+                return new BlueprintLookupResult { Found = false, LookupMethod = "appId" };
+            }
+
+            var match = valueElement[0];
+            var objectId = match.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
+            var resolvedAppId = match.TryGetProperty("appId", out var appIdProp) ? appIdProp.GetString() : null;
+            var displayName = match.TryGetProperty("displayName", out var nameProp) ? nameProp.GetString() : null;
+            if (string.IsNullOrWhiteSpace(objectId) ||
+                !string.Equals(resolvedAppId, validGuid.ToString("D"), StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(displayName))
+            {
+                return new BlueprintLookupResult
+                {
+                    Found = false,
+                    LookupMethod = "appId",
+                    ErrorMessage = "Microsoft Graph returned incomplete or inconsistent blueprint identifiers."
+                };
+            }
+
+            return new BlueprintLookupResult
+            {
+                Found = true,
+                ObjectId = objectId,
+                AppId = resolvedAppId,
+                DisplayName = displayName,
+                LookupMethod = "appId"
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to look up blueprint by appId: {AppId}", appId);
+            return new BlueprintLookupResult { Found = false, LookupMethod = "appId", ErrorMessage = ex.Message };
         }
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -264,6 +264,27 @@ public class ConfigService : IConfigService
     }
 
     /// <inheritdoc />
+    public async Task UpdateAgentBlueprintDisplayNameAsync(
+        string displayName,
+        string configPath = "a365.config.json",
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(displayName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+
+        var resolvedPath = FindConfigFile(configPath) ?? configPath;
+        if (!File.Exists(resolvedPath))
+            throw new FileNotFoundException("Static configuration file was not found.", resolvedPath);
+
+        await PatchStringPropertyInConfigFileAsync(
+            resolvedPath,
+            "agentBlueprintDisplayName",
+            displayName,
+            ct);
+        _logger?.LogDebug("Updated agentBlueprintDisplayName in {ConfigPath}", resolvedPath);
+    }
+
+    /// <inheritdoc />
     public async Task<string?> InvalidateGeneratedConfigAsync(
         Agent365Config config,
         string reason,
@@ -613,25 +634,38 @@ public class ConfigService : IConfigService
     }
 
     /// <summary>
-    /// Patches only the clientAppId field in a365.config.json, preserving all other fields and formatting.
+    /// Patches one string field in a365.config.json, preserving all other fields and formatting.
     /// Uses targeted regex replacement so JSON property order and any comments are kept intact.
     /// Falls back to deserialize/re-serialize if the field is not found (e.g., first-time write).
     /// </summary>
-    private static async Task PatchClientAppIdInConfigFileAsync(string configPath, string newClientAppId, CancellationToken ct)
+    private static Task PatchClientAppIdInConfigFileAsync(string configPath, string newClientAppId, CancellationToken ct)
+        => PatchStringPropertyInConfigFileAsync(configPath, "clientAppId", newClientAppId, ct);
+
+    private static async Task PatchStringPropertyInConfigFileAsync(
+        string configPath,
+        string propertyName,
+        string newValue,
+        CancellationToken ct)
     {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(propertyName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(newValue);
+
         var json = await File.ReadAllTextAsync(configPath, ct);
-        var escapedValue = JsonSerializer.Serialize(newClientAppId); // produces "\"value\""
+        var escapedValue = JsonSerializer.Serialize(newValue);
+        var escapedPropertyName = Regex.Escape(propertyName);
 
-        // Replace the clientAppId value in-place, preserving property order and comments.
-        var patched = Regex.Replace(
-            json,
-            @"(""clientAppId""\s*:\s*)""[^""\\]*(?:\\.[^""\\]*)*""",
-            $"$1{escapedValue}",
-            RegexOptions.None);
-
-        if (patched != json)
+        var pattern = $@"(""{escapedPropertyName}""\s*:\s*)""[^""\\]*(?:\\.[^""\\]*)*""";
+        if (Regex.IsMatch(json, pattern))
         {
-            await File.WriteAllTextAsync(configPath, patched, ct);
+            var patched = Regex.Replace(
+                json,
+                pattern,
+                match => match.Groups[1].Value + escapedValue,
+                RegexOptions.None);
+
+            if (patched != json)
+                await File.WriteAllTextAsync(configPath, patched, ct);
             return;
         }
 
@@ -640,7 +674,7 @@ public class ConfigService : IConfigService
             json, new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip })
             ?? throw new JsonException("Failed to parse config file for patching.");
 
-        dict["clientAppId"] = JsonSerializer.SerializeToElement(newClientAppId);
+        dict[propertyName] = JsonSerializer.SerializeToElement(newValue);
         var updated = JsonSerializer.Serialize(dict, new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(configPath, updated, ct);
     }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IConfigService.cs
@@ -43,6 +43,14 @@ public interface IConfigService
         string statePath = "a365.generated.config.json");
 
     /// <summary>
+    /// Updates the selected blueprint display name in the static configuration file.
+    /// </summary>
+    Task UpdateAgentBlueprintDisplayNameAsync(
+        string displayName,
+        string configPath = "a365.config.json",
+        CancellationToken ct = default);
+
+    /// <summary>
     /// Backs up the current generated state file (if it exists) to a timestamped sibling file,
     /// then resets every dynamic (get/set) property on <paramref name="config"/> to its default value
     /// and persists an empty state file. Use when a structural root resource (e.g. the agent blueprint)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AllSubcommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/AllSubcommandTests.cs
@@ -130,6 +130,175 @@ public class AllSubcommandTests : IDisposable
             because: "no backup should be created when tenants match case-insensitively");
     }
 
+    // MergeCachedBootstrapState
+
+    [Fact]
+    public void MergeCachedBootstrapState_SameAgentIdentity_MergesGeneratedState()
+    {
+        var genConfig = new Agent365Config
+        {
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintId = "cached-blueprint-id",
+            AgentBlueprintObjectId = "cached-blueprint-object-id",
+            AgentBlueprintServicePrincipalObjectId = "cached-blueprint-sp-id",
+            AgentBlueprintClientSecret = "cached-secret",
+            AgentBlueprintClientSecretProtected = true,
+            AgentRegistrationId = "cached-registration-id",
+            AgenticAppId = "cached-agentic-app-id",
+            AgentInstanceId = "cached-instance-id",
+            AgenticUserId = "cached-agentic-user-id",
+            ManagedIdentityPrincipalId = "cached-managed-identity-id",
+            BotId = "cached-bot-id",
+            BotMsaAppId = "cached-bot-app-id",
+            BotMessagingEndpoint = "https://example.test/api/messages",
+            AzureOpenAIEndpoint = "https://openai.example.test",
+            AzureOpenAIApiKey = "cached-openai-key",
+            Completed = true,
+            CompletedAt = DateTime.UtcNow,
+        };
+        genConfig.ResourceConsents.Add(new ResourceConsent { ResourceAppId = "resource-app-id" });
+        var nonDwConfig = new Agent365Config { AgentIdentityDisplayName = "Support Europe Identity" };
+
+        AllSubcommand.MergeCachedBootstrapState(nonDwConfig, genConfig);
+
+        nonDwConfig.AgentBlueprintId.Should().Be("cached-blueprint-id",
+            because: "a bootstrap rerun must reuse the selected blueprint");
+        nonDwConfig.AgentBlueprintObjectId.Should().Be("cached-blueprint-object-id",
+            because: "the stable object ID prevents ambiguous display-name discovery");
+        nonDwConfig.AgentBlueprintServicePrincipalObjectId.Should().Be("cached-blueprint-sp-id");
+        nonDwConfig.AgentBlueprintClientSecret.Should().Be("cached-secret");
+        nonDwConfig.AgentBlueprintClientSecretProtected.Should().BeTrue();
+        nonDwConfig.ResourceConsents.Should().ContainSingle();
+        nonDwConfig.AgentRegistrationId.Should().Be("cached-registration-id",
+            because: "an exact rerun for the same agent identity must reuse the existing registration, not recreate it");
+        nonDwConfig.AgenticAppId.Should().Be("cached-agentic-app-id",
+            because: "an exact rerun for the same agent identity must reuse the existing agent identity, not recreate it");
+        nonDwConfig.AgentInstanceId.Should().Be("cached-instance-id");
+        nonDwConfig.AgenticUserId.Should().Be("cached-agentic-user-id");
+        nonDwConfig.ManagedIdentityPrincipalId.Should().Be("cached-managed-identity-id");
+        nonDwConfig.BotId.Should().Be("cached-bot-id");
+        nonDwConfig.BotMsaAppId.Should().Be("cached-bot-app-id");
+        nonDwConfig.BotMessagingEndpoint.Should().Be("https://example.test/api/messages");
+        nonDwConfig.AzureOpenAIEndpoint.Should().Be("https://openai.example.test");
+        nonDwConfig.AzureOpenAIApiKey.Should().Be("cached-openai-key");
+        nonDwConfig.Completed.Should().BeTrue();
+        nonDwConfig.CompletedAt.Should().Be(genConfig.CompletedAt);
+    }
+
+    [Fact]
+    public void MergeCachedBootstrapState_DifferentAgentIdentity_MergesBlueprintStateOnly()
+    {
+        var genConfig = new Agent365Config
+        {
+            AgentIdentityDisplayName = "Agent A Identity",
+            AgentBlueprintId = "shared-blueprint-id",
+            AgentBlueprintObjectId = "shared-blueprint-object-id",
+            AgentBlueprintClientSecret = "shared-secret",
+            AgentRegistrationId = "agent-a-registration-id",
+            AgenticAppId = "agent-a-agentic-app-id",
+            BotId = "agent-a-bot-id",
+        };
+        genConfig.ResourceConsents.Add(new ResourceConsent { ResourceAppId = "resource-app-id" });
+        var nonDwConfig = new Agent365Config { AgentIdentityDisplayName = "Agent B Identity" };
+
+        AllSubcommand.MergeCachedBootstrapState(nonDwConfig, genConfig);
+
+        nonDwConfig.AgentBlueprintId.Should().Be("shared-blueprint-id",
+            because: "AgentBlueprintId is blueprint-scoped and safe to share across agent identities hosted under the same blueprint");
+        nonDwConfig.AgentBlueprintObjectId.Should().Be("shared-blueprint-object-id");
+        nonDwConfig.AgentBlueprintClientSecret.Should().Be("shared-secret");
+        nonDwConfig.ResourceConsents.Should().ContainSingle();
+        nonDwConfig.AgentRegistrationId.Should().BeNull(
+            because: "a shared blueprint does not make another agent's registration reusable");
+        nonDwConfig.AgenticAppId.Should().BeNull(
+            because: "Agent A's identity must not be handed to Agent B");
+        nonDwConfig.BotId.Should().BeNull(
+            because: "bot state belongs to the specific agent identity");
+    }
+
+    [Fact]
+    public void MergeCachedBootstrapState_DoesNotOverwriteAlreadyResolvedIds()
+    {
+        var genConfig = new Agent365Config
+        {
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintId = "cached-blueprint-id",
+            AgenticAppId = "cached-agentic-app-id",
+        };
+        var nonDwConfig = new Agent365Config
+        {
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintId = "already-resolved-blueprint-id",
+        };
+
+        AllSubcommand.MergeCachedBootstrapState(nonDwConfig, genConfig);
+
+        nonDwConfig.AgentBlueprintId.Should().Be("already-resolved-blueprint-id",
+            because: "an already-resolved value on the target config must not be clobbered by the cached one");
+    }
+
+    // RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync
+
+    [Fact]
+    public async Task RefuseIfDirectoryBelongsToDifferentAgentIdentity_WhenConfigFileAbsent_ReturnsFalse()
+    {
+        var configPath = Path.Combine(_tempDir, "a365.config.json");
+        // deliberately not created — fresh directory, must always be allowed to proceed.
+
+        var refused = await AllSubcommand.RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+            configPath, "Agent B Identity", "Agent B", NullLogger.Instance);
+
+        refused.Should().BeFalse(because: "a fresh directory with no existing config must always be allowed to proceed");
+    }
+
+    [Fact]
+    public async Task RefuseIfDirectoryBelongsToDifferentAgentIdentity_WhenIdentityMatches_ReturnsFalse()
+    {
+        var configPath = Path.Combine(_tempDir, "a365.config.json");
+        File.WriteAllText(configPath, """{"tenantId": "tenant", "agentIdentityDisplayName": "Agent A Identity"}""");
+
+        var refused = await AllSubcommand.RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+            configPath, "Agent A Identity", "Agent A", NullLogger.Instance);
+
+        refused.Should().BeFalse(
+            because: "an exact --agent-name rerun in the same directory must remain idempotent and must not be refused");
+        File.Exists(configPath).Should().BeTrue(because: "the check must not mutate the file either way");
+    }
+
+    [Fact]
+    public async Task RefuseIfDirectoryBelongsToDifferentAgentIdentity_WhenIdentityDiffers_ReturnsTrueAndLeavesFileUntouched()
+    {
+        var configPath = Path.Combine(_tempDir, "a365.config.json");
+        File.WriteAllText(configPath, """{"tenantId": "tenant", "agentIdentityDisplayName": "Agent A Identity"}""");
+        var logger = Substitute.For<ILogger>();
+
+        var refused = await AllSubcommand.RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+            configPath, "Agent B Identity", "Agent B", logger);
+
+        refused.Should().BeTrue(
+            because: "the current config format supports only one agent identity per working directory");
+        File.ReadAllText(configPath).Should().Contain("Agent A Identity",
+            because: "the prior agent's static config must be left completely untouched, not silently overwritten or merged");
+        logger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Agent A Identity") && o.ToString()!.Contains("only one agent identity per working directory")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task RefuseIfDirectoryBelongsToDifferentAgentIdentity_WhenConfigHasNoIdentityField_ReturnsFalse()
+    {
+        var configPath = Path.Combine(_tempDir, "a365.config.json");
+        File.WriteAllText(configPath, """{"tenantId": "tenant"}""");
+
+        var refused = await AllSubcommand.RefuseIfDirectoryBelongsToDifferentAgentIdentityAsync(
+            configPath, "Agent B Identity", "Agent B", NullLogger.Instance);
+
+        refused.Should().BeFalse(because: "with no identity recorded on disk there is nothing to conflict with");
+    }
+
     // -----------------------------------------------------------------------
     // ExecuteMessagingEndpointStepAsync
     // -----------------------------------------------------------------------

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
@@ -13,6 +13,7 @@ using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.IO;
 using System.CommandLine.Parsing;
+using System.Text.Json;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
 
@@ -63,7 +64,6 @@ public class SetupCommandTests
         _mockConfirmationProvider = Substitute.For<IConfirmationProvider>();
         _mockConfirmationProvider.ConfirmAsync(Arg.Any<string>()).Returns(true);
     }
-
     [Fact]
     public async Task SetupAllCommand_DryRun_ValidConfig_OnlyValidatesConfig()
     {
@@ -676,5 +676,500 @@ public class SetupCommandTests
             Arg.Is<object>(o => o.ToString()!.Contains("S2S")),
             Arg.Any<Exception?>(),
             Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    // ── --blueprint-id / --select-blueprint (setup all) ────────────────────────
+
+    /// <summary>
+    /// --blueprint-id and --select-blueprint are mutually exclusive. Must fail before any mutation
+    /// (no tenant/Graph calls needed to detect this — pure option validation).
+    /// </summary>
+    [Fact]
+    public async Task SetupAll_BlueprintIdAndSelectBlueprint_MutuallyExclusive_ExitsWithCode1()
+    {
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync(
+            "all --agent-name TestAgent --blueprint-id 11111111-1111-1111-1111-111111111111 --select-blueprint --dry-run",
+            new TestConsole());
+
+        result.Should().Be(1, because: "--blueprint-id and --select-blueprint are mutually exclusive and must fail before any mutation");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("cannot be used together")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+        await _mockExecutor.DidNotReceive().ExecuteAsync(
+            Arg.Is<string>(s => s == "az"), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>A malformed --blueprint-id value must be rejected before any tenant/Graph call.</summary>
+    [Fact]
+    public async Task SetupAll_BlueprintIdInvalidGuid_ExitsWithCode1()
+    {
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("all --agent-name TestAgent --blueprint-id not-a-guid --dry-run", new TestConsole());
+
+        result.Should().Be(1, because: "--blueprint-id must be a valid GUID");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Invalid --blueprint-id value")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task SetupAll_BlueprintIdWhitespace_ExitsWithCode1()
+    {
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("all --agent-name TestAgent --blueprint-id \" \" --dry-run", new TestConsole());
+
+        result.Should().Be(1,
+            because: "an explicitly supplied whitespace blueprint ID must not silently use the default create flow");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("--blueprint-id cannot be empty")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    /// <summary>Explicit blueprint selection is unsupported for AI Teammate agents — must fail fast.</summary>
+    [Theory]
+    [InlineData("--blueprint-id 11111111-1111-1111-1111-111111111111")]
+    [InlineData("--select-blueprint")]
+    public async Task SetupAll_ExplicitBlueprintSelection_WithAiteammateTrue_ExitsWithCode1(string blueprintOption)
+    {
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync($"all --agent-name TestAgent --aiteammate true {blueprintOption} --dry-run", new TestConsole());
+
+        result.Should().Be(1, because: "explicit blueprint selection applies to blueprint agents only, not AI Teammate agents");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("not supported with --aiteammate")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SetupAll_BlueprintId_WithExistingAiTeammateConfig_ExitsWithCode1(bool dryRun)
+    {
+        var config = new Agent365Config
+        {
+            TenantId = "tenant",
+            AgentIdentityDisplayName = "agent",
+            AgentBlueprintDisplayName = "TestBlueprint",
+            DeploymentProjectPath = ".",
+            AiTeammate = true,
+            UseBlueprint = false,
+        };
+        _mockConfigService.LoadAsync(Arg.Any<string>(), Arg.Any<string>()).Returns(config);
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+        var dryRunOption = dryRun ? " --dry-run" : string.Empty;
+
+        var result = await parser.InvokeAsync(
+            $"all --blueprint-id 11111111-1111-1111-1111-111111111111{dryRunOption}",
+            new TestConsole());
+
+        result.Should().Be(1,
+            because: "explicit blueprint selection must be rejected when the loaded config belongs to an AI Teammate");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("applies only to blueprint agents")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+        await _mockConfigService.DidNotReceiveWithAnyArgs().SaveStateAsync(
+            Arg.Any<Agent365Config>(),
+            Arg.Any<string>());
+    }
+
+    /// <summary>
+    /// A syntactically valid --blueprint-id that does not resolve to an existing Agent Identity
+    /// Blueprint in the active tenant (not found, or belongs to a different tenant) must fail before
+    /// any mutation — no a365.config.json / a365.generated.config.json is written.
+    /// </summary>
+    [Fact]
+    public async Task SetupAll_BlueprintId_NotFoundInTenant_ExitsWithCode1_AndWritesNoState()
+    {
+        _mockExecutor.ExecuteAsync(
+                Arg.Is<string>(s => s == "az"),
+                Arg.Is<string>(s => s.StartsWith("account show", StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = "{\"tenantId\":\"blueprint-lookup-tenant\"}",
+                StandardError = string.Empty
+            }));
+        _mockGraphApiService.FindApplicationByDisplayNameAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("99999999-9999-9999-9999-999999999999");
+        _mockBlueprintLookupService.GetBlueprintByAppIdAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new BlueprintLookupResult { Found = false });
+
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync(
+            "all --agent-name TestAgent --blueprint-id 22222222-2222-2222-2222-222222222222",
+            new TestConsole());
+
+        result.Should().Be(1,
+            because: "an unresolvable --blueprint-id must fail — verifying tenant membership happens before any mutation");
+        await _mockConfigService.DidNotReceiveWithAnyArgs().SaveStateAsync(Arg.Any<Agent365Config>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SetupAll_BlueprintIdResolvesSuccessfully_PersistsBootstrapSelection()
+    {
+        const string tenantId = "11111111-1111-1111-1111-111111111111";
+        const string clientAppId = "22222222-2222-2222-2222-222222222222";
+        const string blueprintAppId = "33333333-3333-3333-3333-333333333333";
+        const string blueprintObjectId = "44444444-4444-4444-4444-444444444444";
+        const string blueprintDisplayName = "Tenant Blueprint";
+        var tempDir = Path.Combine(Path.GetTempPath(), $"a365-setupall-blueprintid-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var originalDir = Environment.CurrentDirectory;
+
+        try
+        {
+            Environment.CurrentDirectory = tempDir;
+            _mockExecutor.ExecuteAsync(
+                    Arg.Is<string>(command => command == "az"),
+                    Arg.Is<string>(arguments => arguments.StartsWith("account show", StringComparison.OrdinalIgnoreCase)),
+                    Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult
+                {
+                    ExitCode = 0,
+                    StandardOutput = tenantId,
+                    StandardError = string.Empty
+                }));
+            _mockGraphApiService.FindApplicationByDisplayNameAsync(
+                    tenantId,
+                    Arg.Any<string>(),
+                    Arg.Any<CancellationToken>())
+                .Returns(clientAppId);
+            _mockBlueprintLookupService.GetBlueprintByAppIdAsync(
+                    tenantId,
+                    blueprintAppId,
+                    Arg.Any<CancellationToken>())
+                .Returns(new BlueprintLookupResult
+                {
+                    Found = true,
+                    AppId = blueprintAppId,
+                    ObjectId = blueprintObjectId,
+                    DisplayName = blueprintDisplayName
+                });
+            _mockBlueprintService.FindExistingAgentIdentityAsync(
+                    tenantId,
+                    blueprintAppId,
+                    "TestAgent Identity",
+                    Arg.Any<CancellationToken>())
+                .Returns("agentic-app-id");
+            _mockGraphApiService.RegisterAgentInstanceAsyncV2(
+                    Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(),
+                    Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(("registration-id", false));
+            _mockClientAppValidator.GetUnconsentedRequiredPermissionsAsync(
+                    Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns([]);
+
+            var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+            var result = await parser.InvokeAsync(
+                $"all --agent-name TestAgent --blueprint-id {blueprintAppId} --agent-registration-only",
+                new TestConsole());
+
+            result.Should().Be(0,
+                because: "a tenant-verified blueprint must be usable for a new agent identity");
+            using var staticConfig = JsonDocument.Parse(
+                await File.ReadAllTextAsync(Path.Combine(tempDir, "a365.config.json")));
+            staticConfig.RootElement.GetProperty("agentBlueprintDisplayName").GetString().Should().Be(
+                blueprintDisplayName,
+                because: "the tenant-verified display name must become the static source of truth");
+            await _mockConfigService.Received().SaveStateAsync(
+                Arg.Is<Agent365Config>(candidate =>
+                    candidate.AgentBlueprintId == blueprintAppId &&
+                    candidate.AgentBlueprintObjectId == blueprintObjectId),
+                Arg.Is<string>(path => path == Path.Combine(tempDir, "a365.generated.config.json")));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDir;
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task SetupAll_ExistingConfig_BlueprintId_PersistsRefreshedBlueprintMetadata()
+    {
+        const string tenantId = "11111111-1111-1111-1111-111111111111";
+        const string clientAppId = "22222222-2222-2222-2222-222222222222";
+        const string blueprintAppId = "33333333-3333-3333-3333-333333333333";
+        const string blueprintObjectId = "44444444-4444-4444-4444-444444444444";
+        const string blueprintDisplayName = "Tenant Blueprint";
+        const string agenticAppId = "66666666-6666-6666-6666-666666666666";
+        const string registrationId = "77777777-7777-7777-7777-777777777777";
+        var tempDir = Path.Combine(Path.GetTempPath(), $"a365-setupall-existing-blueprint-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var configPath = Path.Combine(tempDir, "a365.config.json");
+        var generatedPath = Path.Combine(tempDir, "a365.generated.config.json");
+        await File.WriteAllTextAsync(configPath, $$"""
+            {
+              "tenantId": "{{tenantId}}",
+              "clientAppId": "{{clientAppId}}",
+              "agentIdentityDisplayName": "TestAgent Identity",
+              "agentBlueprintDisplayName": "Stale Blueprint Name",
+              "agentDescription": "TestAgent",
+              "aiTeammate": false,
+              "useBlueprint": true
+            }
+            """);
+        await File.WriteAllTextAsync(generatedPath, $$"""
+            {
+              "agentBlueprintId": "{{blueprintAppId}}",
+              "agentBlueprintObjectId": "55555555-5555-5555-5555-555555555555",
+              "agenticAppId": "{{agenticAppId}}",
+              "agentRegistrationId": "{{registrationId}}"
+            }
+            """);
+        var originalDir = Environment.CurrentDirectory;
+
+        try
+        {
+            Environment.CurrentDirectory = tempDir;
+            _mockBlueprintLookupService.GetBlueprintByAppIdAsync(
+                    tenantId,
+                    blueprintAppId,
+                    Arg.Any<CancellationToken>())
+                .Returns(new BlueprintLookupResult
+                {
+                    Found = true,
+                    AppId = blueprintAppId,
+                    ObjectId = blueprintObjectId,
+                    DisplayName = blueprintDisplayName
+                });
+            _mockGraphApiService.AgentRegistrationExistsAsync(
+                    tenantId,
+                    registrationId,
+                    Arg.Any<CancellationToken>())
+                .Returns(true);
+            _mockClientAppValidator.GetUnconsentedRequiredPermissionsAsync(
+                    clientAppId,
+                    tenantId,
+                    Arg.Any<CancellationToken>())
+                .Returns([]);
+            var configService = new ConfigService();
+            var command = SetupCommand.CreateCommand(
+                _mockLogger, configService, _mockExecutor, _mockBackendConfigurator,
+                _mockAuthValidator, _mockPlatformDetector, _mockGraphApiService, _mockBlueprintService,
+                _mockBlueprintLookupService, _mockFederatedCredentialService, _mockClientAppValidator,
+                _mockConfirmationProvider);
+            var parser = new CommandLineBuilder(command).Build();
+
+            var result = await parser.InvokeAsync(
+                $"all --blueprint-id {blueprintAppId} --agent-registration-only",
+                new TestConsole());
+
+            result.Should().Be(0,
+                because: "reselecting the same blueprint must be an idempotent successful rerun");
+            using var staticConfig = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+            staticConfig.RootElement.GetProperty("agentBlueprintDisplayName").GetString().Should().Be(
+                blueprintDisplayName,
+                because: "the static config must reflect the tenant-verified blueprint name");
+            using var generatedConfig = JsonDocument.Parse(await File.ReadAllTextAsync(generatedPath));
+            generatedConfig.RootElement.GetProperty("agentBlueprintObjectId").GetString().Should().Be(
+                blueprintObjectId,
+                because: "the stable tenant-verified object ID must replace stale cached metadata");
+            generatedConfig.RootElement.GetProperty("agenticAppId").GetString().Should().Be(
+                agenticAppId,
+                because: "reselecting the same blueprint for the same identity must preserve identity state");
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDir;
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A working directory configured for another identity must be rejected before mutation.
+    /// </summary>
+    [Fact]
+    public async Task SetupAll_AgentNameDiffersFromExistingDirectoryIdentity_ExitsWithCode1_AndLeavesDirectoryUntouched()
+    {
+        const string tenantId = "matching-tenant-id";
+        _mockExecutor.ExecuteAsync(
+                Arg.Is<string>(s => s == "az"),
+                Arg.Is<string>(s => s.StartsWith("account show", StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = tenantId,
+                StandardError = string.Empty
+            }));
+        _mockGraphApiService.FindApplicationByDisplayNameAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns("11111111-1111-1111-1111-111111111111");
+
+        var tempDir = Path.Combine(Path.GetTempPath(), $"a365-setupall-identity-mismatch-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        var configPath = Path.Combine(tempDir, "a365.config.json");
+        var generatedPath = Path.Combine(tempDir, "a365.generated.config.json");
+        await File.WriteAllTextAsync(configPath,
+            $"{{\"tenantId\":\"{tenantId}\",\"agentIdentityDisplayName\":\"AgentA Identity\",\"agentBlueprintDisplayName\":\"AgentA Blueprint\"}}");
+        await File.WriteAllTextAsync(generatedPath,
+            "{\"agenticAppId\":\"agent-a-agentic-app-id\",\"agentRegistrationId\":\"agent-a-registration-id\"}");
+
+        var originalDir = Environment.CurrentDirectory;
+        try
+        {
+            Environment.CurrentDirectory = tempDir;
+
+            var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+            var result = await parser.InvokeAsync("all --agent-name AgentB", new TestConsole());
+
+            result.Should().Be(1,
+                because: "the current config format supports only one agent identity per working directory");
+            _mockLogger.Received().Log(
+                LogLevel.Error,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(o => o.ToString()!.Contains("AgentA Identity") && o.ToString()!.Contains("only one agent identity per working directory")),
+                Arg.Any<Exception?>(),
+                Arg.Any<Func<object, Exception?, string>>());
+            (await File.ReadAllTextAsync(configPath)).Should().Contain("AgentA Identity",
+                because: "the prior agent's static config must be left completely untouched, not silently overwritten or merged");
+            (await File.ReadAllTextAsync(generatedPath)).Should().Contain("agent-a-agentic-app-id",
+                because: "the prior agent's generated config/state must be left completely untouched — refusing must happen before any mutation");
+            await _mockConfigService.DidNotReceiveWithAnyArgs().SaveStateAsync(Arg.Any<Agent365Config>(), Arg.Any<string>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalDir;
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    // ── setup blueprint list ────────────────────────────────────────────────────
+
+    private static void MockAzAccountShow(CommandExecutor executor, string tenantId) =>
+        executor.ExecuteAsync(
+                Arg.Is<string>(s => s == "az"),
+                Arg.Is<string>(s => s.StartsWith("account show", StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult
+            {
+                ExitCode = 0,
+                StandardOutput = $"{{\"tenantId\":\"{tenantId}\"}}",
+                StandardError = string.Empty
+            }));
+
+    [Fact]
+    public async Task BlueprintList_WhenBlueprintsExist_ExitsWithCode0AndListsThem()
+    {
+        MockAzAccountShow(_mockExecutor, "list-tenant");
+        _mockBlueprintLookupService.ListBlueprintsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<BlueprintLookupResult>
+            {
+                new() { Found = true, AppId = "11111111-1111-1111-1111-111111111111", DisplayName = "Contoso Blueprint" }
+            });
+
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("blueprint list", new TestConsole());
+
+        result.Should().Be(0, because: "listing blueprints is read-only and must succeed when the query succeeds");
+        _mockLogger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("Contoso Blueprint") && o.ToString()!.Contains("11111111-1111-1111-1111-111111111111")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task BlueprintList_WhenTenantHasNoBlueprints_ExitsWithCode0AndShowsClearMessage()
+    {
+        MockAzAccountShow(_mockExecutor, "empty-tenant");
+        _mockBlueprintLookupService.ListBlueprintsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new List<BlueprintLookupResult>());
+
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("blueprint list", new TestConsole());
+
+        result.Should().Be(0, because: "an empty list is a successful outcome, not an error");
+        _mockLogger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("No Agent Identity Blueprints found")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task BlueprintList_WhenGraphQueryFails_ExitsWithCode1()
+    {
+        MockAzAccountShow(_mockExecutor, "failing-tenant");
+        _mockBlueprintLookupService.ListBlueprintsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<IReadOnlyList<BlueprintLookupResult>>(new InvalidOperationException("Graph auth failed")));
+
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("blueprint list", new TestConsole());
+
+        result.Should().Be(1, because: "an auth/query failure must exit non-zero rather than silently reporting an empty list as success");
+    }
+
+    [Fact]
+    public async Task BlueprintList_WhenTenantIdIsWhitespace_ExitsWithCode1WithoutQueryingAzure()
+    {
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("blueprint list --tenant-id \" \"", new TestConsole());
+
+        result.Should().Be(1,
+            because: "an explicitly supplied whitespace tenant ID must produce a targeted validation error");
+        await _mockExecutor.DidNotReceiveWithAnyArgs().ExecuteAsync(
+            default!, default!, default, default, default, default);
+        await _mockBlueprintLookupService.DidNotReceiveWithAnyArgs().ListBlueprintsAsync(default!, default);
+    }
+
+    [Fact]
+    public async Task BlueprintList_WhenTenantCannotBeAutoDetected_ExitsWithCode1()
+    {
+        _mockExecutor.ExecuteAsync(
+                Arg.Is<string>(command => command == "az"),
+                Arg.Is<string>(arguments => arguments.StartsWith("account show", StringComparison.OrdinalIgnoreCase)),
+                Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(new Microsoft.Agents.A365.DevTools.Cli.Services.CommandResult
+            {
+                ExitCode = 1,
+                StandardOutput = string.Empty,
+                StandardError = "not logged in"
+            }));
+        var parser = new CommandLineBuilder(BuildSetupCommand()).Build();
+
+        var result = await parser.InvokeAsync("blueprint list", new TestConsole());
+
+        result.Should().Be(1,
+            because: "listing cannot query a tenant until the user signs in or supplies --tenant-id");
+        _mockLogger.Received().Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state => state.ToString()!.Contains("Could not detect tenant ID")),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+        await _mockBlueprintLookupService.DidNotReceiveWithAnyArgs().ListBlueprintsAsync(default!, default);
     }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSelectionHelperTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSelectionHelperTests.cs
@@ -1,0 +1,478 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Helpers;
+using Microsoft.Agents.A365.DevTools.Cli.Models;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands.SetupSubcommands;
+
+/// <summary>
+/// Tests blueprint selection validation, lookup, and state isolation.
+/// </summary>
+public class BlueprintSelectionHelperTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+    private const string BlueprintAppId = "22222222-2222-2222-2222-222222222222";
+    private const string OtherBlueprintAppId = "33333333-3333-3333-3333-333333333333";
+    private const string BlueprintObjectId = "44444444-4444-4444-4444-444444444444";
+    private const string BlueprintDisplayName = "Contoso Support Blueprint";
+
+    private static BlueprintLookupService CreateBlueprintLookupService(GraphApiService? graphApiService = null) =>
+        new(NullLogger<BlueprintLookupService>.Instance, graphApiService ?? Substitute.For<GraphApiService>());
+
+    // -----------------------------------------------------------------------
+    // ValidateOptions
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateOptions_NeitherOptionSupplied_ReturnsTrue()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: null, blueprintIdSpecified: false, selectBlueprint: false, aiTeammateFlag: null,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeTrue(because: "default derive/create behavior must be unaffected when neither option is used");
+    }
+
+    [Fact]
+    public void ValidateOptions_BothBlueprintIdAndSelectBlueprint_ReturnsFalse()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: BlueprintAppId, blueprintIdSpecified: true, selectBlueprint: true, aiTeammateFlag: null,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeFalse(because: "--blueprint-id and --select-blueprint are mutually exclusive");
+    }
+
+    [Fact]
+    public void ValidateOptions_InvalidGuidBlueprintId_ReturnsFalse()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: "not-a-guid", blueprintIdSpecified: true, selectBlueprint: false, aiTeammateFlag: null,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeFalse(because: "--blueprint-id must be a valid GUID");
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void ValidateOptions_WithAiTeammateTrue_ReturnsFalse(bool useBlueprintId, bool useSelectBlueprint)
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: useBlueprintId ? BlueprintAppId : null,
+            blueprintIdSpecified: useBlueprintId,
+            selectBlueprint: useSelectBlueprint,
+            aiTeammateFlag: true,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeFalse(because: "explicit blueprint selection applies to blueprint agents only, not AI Teammate agents");
+    }
+
+    [Fact]
+    public void ValidateOptions_SelectBlueprintWithRedirectedStdin_ReturnsFalse()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: null, blueprintIdSpecified: false, selectBlueprint: true, aiTeammateFlag: null,
+            dryRun: false, nonInteractive: true, NullLogger.Instance);
+
+        result.Should().BeFalse(because: "--select-blueprint requires an interactive terminal and must fail clearly when stdin is redirected");
+    }
+
+    [Fact]
+    public void ValidateOptions_SelectBlueprintWithDryRun_ReturnsFalse()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: null, blueprintIdSpecified: false, selectBlueprint: true, aiTeammateFlag: null,
+            dryRun: true, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeFalse(because: "--select-blueprint requires a real run to query the tenant and cannot combine with --dry-run");
+    }
+
+    [Fact]
+    public void ValidateOptions_BlueprintIdWithDryRun_ReturnsTrue()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: BlueprintAppId, blueprintIdSpecified: true, selectBlueprint: false, aiTeammateFlag: null,
+            dryRun: true, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeTrue(because: "--blueprint-id does not require a Graph call and may be previewed in --dry-run");
+    }
+
+    [Fact]
+    public void ValidateOptions_ValidBlueprintId_ReturnsTrue()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: BlueprintAppId, blueprintIdSpecified: true, selectBlueprint: false, aiTeammateFlag: false,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateOptions_WhitespaceBlueprintId_ReturnsFalse()
+    {
+        var result = BlueprintSelectionHelper.ValidateOptions(
+            blueprintId: " ", blueprintIdSpecified: true, selectBlueprint: false, aiTeammateFlag: null,
+            dryRun: false, nonInteractive: false, NullLogger.Instance);
+
+        result.Should().BeFalse(
+            because: "an explicitly supplied empty option must not fall back to creating a new blueprint");
+    }
+
+    // -----------------------------------------------------------------------
+    // ResolveAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ResolveAsync_BlueprintIdNotFoundInTenant_ReturnsNull()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        graphApiService.GraphGetAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>(), null)
+            .Returns((System.Text.Json.JsonDocument?)null);
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSelectionHelper.ResolveAsync(
+            lookupService, TenantId, OtherBlueprintAppId, selectBlueprint: false, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeNull(
+            because: "a blueprint ID that does not resolve in the active tenant (not found, or belongs to a different tenant) must fail before any mutation");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_BlueprintIdFound_ReturnsLookupResult()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        var json = $@"{{ ""value"": [ {{ ""id"": ""{BlueprintObjectId}"", ""appId"": ""{BlueprintAppId}"", ""displayName"": ""{BlueprintDisplayName}"" }} ] }}";
+        graphApiService.GraphGetAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>(), null)
+            .Returns(System.Text.Json.JsonDocument.Parse(json));
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSelectionHelper.ResolveAsync(
+            lookupService, TenantId, BlueprintAppId, selectBlueprint: false, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.AppId.Should().Be(BlueprintAppId);
+        result.DisplayName.Should().Be(BlueprintDisplayName);
+        result.ObjectId.Should().Be(BlueprintObjectId);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_BlueprintLookupReturnsMismatchedAppId_ReturnsNull()
+    {
+        var lookupService = Substitute.ForPartsOf<BlueprintLookupService>(
+            NullLogger<BlueprintLookupService>.Instance,
+            Substitute.For<GraphApiService>());
+        lookupService.GetBlueprintByAppIdAsync(
+                TenantId,
+                BlueprintAppId,
+                Arg.Any<CancellationToken>())
+            .Returns(new BlueprintLookupResult
+            {
+                Found = true,
+                AppId = OtherBlueprintAppId,
+                ObjectId = BlueprintObjectId,
+                DisplayName = BlueprintDisplayName
+            });
+
+        var result = await BlueprintSelectionHelper.ResolveAsync(
+            lookupService, TenantId, BlueprintAppId, selectBlueprint: false, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeNull(
+            because: "the selection boundary must reject inconsistent identifiers even if the lookup layer regresses");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SelectBlueprint_ValidNumberedChoice_ResolvesChosenBlueprint()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        var listJson = $@"{{ ""value"": [
+            {{ ""id"": ""aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"", ""appId"": ""bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"", ""displayName"": ""First Blueprint"" }},
+            {{ ""id"": ""{BlueprintObjectId}"", ""appId"": ""{BlueprintAppId}"", ""displayName"": ""{BlueprintDisplayName}"" }}
+        ] }}";
+        graphApiService.GraphGetAsync(TenantId,
+                Arg.Is<string>(s => s.Contains("$top=100")),
+                Arg.Any<CancellationToken>(), null)
+            .Returns(System.Text.Json.JsonDocument.Parse(listJson));
+        graphApiService.GraphGetAsync(TenantId,
+                Arg.Is<string>(s => s.Contains("$filter=appId")),
+                Arg.Any<CancellationToken>(), null)
+            .Returns(ci => System.Text.Json.JsonDocument.Parse(
+                $@"{{ ""value"": [ {{ ""id"": ""{BlueprintObjectId}"", ""appId"": ""{BlueprintAppId}"", ""displayName"": ""{BlueprintDisplayName}"" }} ] }}"));
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        ConsoleHelper.ReadLineOverrideForTests.Value = () => "2";
+        try
+        {
+            var result = await BlueprintSelectionHelper.ResolveAsync(
+                lookupService, TenantId, blueprintId: null, selectBlueprint: true, NullLogger.Instance, CancellationToken.None);
+
+            result.Should().NotBeNull();
+            result!.AppId.Should().Be(BlueprintAppId, because: "choosing '2' must select the second listed blueprint");
+        }
+        finally
+        {
+            ConsoleHelper.ReadLineOverrideForTests.Value = null;
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SelectBlueprint_OutOfRangeChoice_ReturnsNull()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        var listJson = $@"{{ ""value"": [ {{ ""id"": ""{BlueprintObjectId}"", ""appId"": ""{BlueprintAppId}"", ""displayName"": ""{BlueprintDisplayName}"" }} ] }}";
+        graphApiService.GraphGetAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>(), null)
+            .Returns(System.Text.Json.JsonDocument.Parse(listJson));
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        ConsoleHelper.ReadLineOverrideForTests.Value = () => "99";
+        try
+        {
+            var result = await BlueprintSelectionHelper.ResolveAsync(
+                lookupService, TenantId, blueprintId: null, selectBlueprint: true, NullLogger.Instance, CancellationToken.None);
+
+            result.Should().BeNull(because: "a selection outside the printed numbered range must be rejected");
+        }
+        finally
+        {
+            ConsoleHelper.ReadLineOverrideForTests.Value = null;
+        }
+    }
+
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    [InlineData(null)]
+    public async Task ResolveAsync_SelectBlueprint_NonNumericOrMissingChoice_ReturnsNull(string? input)
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        var listJson = $@"{{ ""value"": [ {{ ""id"": ""{BlueprintObjectId}"", ""appId"": ""{BlueprintAppId}"", ""displayName"": ""{BlueprintDisplayName}"" }} ] }}";
+        graphApiService.GraphGetAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>(), null)
+            .Returns(System.Text.Json.JsonDocument.Parse(listJson));
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        ConsoleHelper.ReadLineOverrideForTests.Value = () => input;
+        try
+        {
+            var result = await BlueprintSelectionHelper.ResolveAsync(
+                lookupService, TenantId, blueprintId: null, selectBlueprint: true, NullLogger.Instance, CancellationToken.None);
+
+            result.Should().BeNull(
+                because: "interactive selection must reject input that is not one of the printed numbers");
+        }
+        finally
+        {
+            ConsoleHelper.ReadLineOverrideForTests.Value = null;
+        }
+    }
+
+    [Fact]
+    public async Task ResolveAsync_SelectBlueprint_EmptyTenant_ReturnsNull()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+        graphApiService.GraphGetAsync(TenantId, Arg.Any<string>(), Arg.Any<CancellationToken>(), null)
+            .Returns(System.Text.Json.JsonDocument.Parse(@"{""value"": []}"));
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSelectionHelper.ResolveAsync(
+            lookupService, TenantId, blueprintId: null, selectBlueprint: true, NullLogger.Instance, CancellationToken.None);
+
+        result.Should().BeNull(because: "there is nothing to choose from when the tenant has no blueprints");
+    }
+
+    // ApplyExplicitBlueprintSelection
+
+    [Fact]
+    public void ApplyExplicitBlueprintSelection_RerunOfSameBlueprint_PreservesCachedIdentityAndSecret()
+    {
+        // Arrange: config already has cached state from a prior run against this exact blueprint,
+        // for the exact same agent identity being provisioned again.
+        var config = new Agent365Config
+        {
+            TenantId = TenantId,
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintDisplayName = "Support Europe Blueprint", // stale derived name from bootstrap
+            AgentBlueprintId = BlueprintAppId,
+            AgentBlueprintObjectId = BlueprintObjectId,
+            AgentBlueprintServicePrincipalObjectId = "sp-object-id",
+            AgentBlueprintClientSecret = "cached-secret",
+            AgentBlueprintClientSecretProtected = true,
+            AgenticAppId = "agentic-app-id",
+            AgentRegistrationId = "registration-id",
+            ResourceConsents = [new ResourceConsent { ResourceAppId = "resource-app-id" }],
+        };
+        var blueprint = new BlueprintLookupResult { Found = true, AppId = BlueprintAppId, ObjectId = BlueprintObjectId, DisplayName = BlueprintDisplayName };
+
+        var updated = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+            config, blueprint, cachedAgentIdentityDisplayName: "Support Europe Identity");
+
+        updated.AgenticAppId.Should().Be("agentic-app-id",
+            because: "a rerun that selects the exact same blueprint for the exact same agent identity must reuse the existing agent identity, not recreate it");
+        updated.AgentRegistrationId.Should().Be("registration-id",
+            because: "a rerun that selects the exact same blueprint for the exact same agent identity must reuse the existing agent registration");
+        updated.AgentBlueprintClientSecret.Should().Be("cached-secret",
+            because: "the cached blueprint client secret must be preserved on a same-blueprint rerun");
+        updated.AgentBlueprintId.Should().Be(BlueprintAppId,
+            because: "the verified blueprint app ID must be applied on every rerun");
+        updated.AgentBlueprintObjectId.Should().Be(BlueprintObjectId,
+            because: "the verified blueprint object ID must be applied on every rerun");
+        updated.AgentBlueprintDisplayName.Should().Be(BlueprintDisplayName,
+            because: "discovery is display-name based, so it must always reflect the blueprint's real name");
+        config.AgentBlueprintDisplayName.Should().Be("Support Europe Blueprint",
+            because: "the original config instance passed in must not be mutated");
+        updated.ResourceConsents.Should().NotBeSameAs(config.ResourceConsents,
+            because: "the selected config must not share a mutable consent list with its source");
+        updated.ResourceConsents.Should().ContainSingle(
+            because: "a same-blueprint rerun must preserve the blueprint's resource consent state");
+    }
+
+    [Fact]
+    public void ApplyExplicitBlueprintSelection_SameBlueprint_RefreshesAuthoritativeObjectId()
+    {
+        var config = new Agent365Config
+        {
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintDisplayName = "Support Europe Blueprint",
+            AgentBlueprintId = BlueprintAppId,
+            AgentBlueprintObjectId = "55555555-5555-5555-5555-555555555555",
+            AgenticAppId = "agentic-app-id",
+        };
+        var blueprint = new BlueprintLookupResult
+        {
+            Found = true,
+            AppId = BlueprintAppId,
+            ObjectId = BlueprintObjectId,
+            DisplayName = BlueprintDisplayName
+        };
+
+        var updated = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+            config, blueprint, cachedAgentIdentityDisplayName: "Support Europe Identity");
+
+        updated.AgentBlueprintObjectId.Should().Be(BlueprintObjectId,
+            because: "tenant-verified identifiers must replace stale cached metadata");
+        updated.AgenticAppId.Should().Be("agentic-app-id",
+            because: "refreshing blueprint metadata must not recreate the same agent identity");
+    }
+
+    [Fact]
+    public void ApplyExplicitBlueprintSelection_SameBlueprintDifferentAgentIdentity_ResetsIdentityRegistrationButKeepsBlueprintState()
+    {
+        var config = new Agent365Config
+        {
+            TenantId = TenantId,
+            AgentIdentityDisplayName = "Agent B Identity", // the identity being provisioned NOW
+            AgentBlueprintDisplayName = "Agent B Blueprint", // stale derived name from bootstrap
+            AgentBlueprintId = BlueprintAppId, // merged in from Agent A's generated config
+            AgentBlueprintObjectId = BlueprintObjectId,
+            AgentBlueprintServicePrincipalObjectId = "sp-object-id",
+            AgentBlueprintClientSecret = "cached-secret",
+            AgentBlueprintClientSecretProtected = true,
+            AgenticAppId = "agent-a-agentic-app-id",
+            AgenticUserId = "agent-a-user-id",
+            AgentInstanceId = "agent-a-instance-id",
+            AgentRegistrationId = "agent-a-registration-id",
+            BotId = "agent-a-bot-id",
+            BotMsaAppId = "agent-a-bot-msa-app-id",
+            BotMessagingEndpoint = "https://agent-a.example.com/api/messages",
+            Completed = true,
+            CompletedAt = DateTime.UtcNow,
+        };
+        var blueprint = new BlueprintLookupResult { Found = true, AppId = BlueprintAppId, ObjectId = BlueprintObjectId, DisplayName = BlueprintDisplayName };
+
+        var updated = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+            config, blueprint, cachedAgentIdentityDisplayName: "Agent A Identity");
+
+        updated.AgenticAppId.Should().BeNull(
+            because: "a shared blueprint does not make another agent identity reusable");
+        updated.AgenticUserId.Should().BeNull();
+        updated.AgentInstanceId.Should().BeNull();
+        updated.AgentRegistrationId.Should().BeNull(
+            because: "Agent A's registration must not be handed to Agent B");
+        updated.BotId.Should().BeNull(because: "bot registration is agent-identity-scoped");
+        updated.BotMsaAppId.Should().BeNull(because: "bot registration is agent-identity-scoped");
+        updated.BotMessagingEndpoint.Should().BeNull(because: "bot registration is agent-identity-scoped");
+        updated.Completed.Should().BeFalse();
+        updated.CompletedAt.Should().BeNull();
+
+        updated.AgentBlueprintId.Should().Be(BlueprintAppId,
+            because: "the blueprint itself is genuinely shared by both agent identities");
+        updated.AgentBlueprintObjectId.Should().Be(BlueprintObjectId);
+        updated.AgentBlueprintServicePrincipalObjectId.Should().Be("sp-object-id");
+        updated.AgentBlueprintClientSecret.Should().Be("cached-secret",
+            because: "the blueprint's own client secret is shared by every agent identity hosted under it");
+        updated.AgentBlueprintDisplayName.Should().Be(BlueprintDisplayName);
+
+        config.AgenticAppId.Should().Be("agent-a-agentic-app-id",
+            because: "the original config instance passed in must not be mutated");
+    }
+
+    [Fact]
+    public void ApplyExplicitBlueprintSelection_DifferentBlueprintThanCached_ResetsIdentityRegistrationAndSecret()
+    {
+        var config = new Agent365Config
+        {
+            TenantId = TenantId,
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintDisplayName = "Support Europe Blueprint",
+            AgentBlueprintId = OtherBlueprintAppId,
+            AgentBlueprintObjectId = "other-object-id",
+            AgentBlueprintServicePrincipalObjectId = "other-sp-object-id",
+            AgentBlueprintClientSecret = "other-cached-secret",
+            AgentBlueprintClientSecretProtected = true,
+            AgenticAppId = "other-agentic-app-id",
+            AgentRegistrationId = "other-registration-id",
+        };
+        config.ResourceConsents.Add(new ResourceConsent { ResourceName = "Microsoft Graph", ResourceAppId = "other-resource-app-id" });
+        var blueprint = new BlueprintLookupResult { Found = true, AppId = BlueprintAppId, ObjectId = BlueprintObjectId, DisplayName = BlueprintDisplayName };
+
+        var updated = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(
+            config, blueprint, cachedAgentIdentityDisplayName: "Support Europe Identity");
+
+        updated.AgenticAppId.Should().BeNull(
+            because: "an agent identity created under a different blueprint must never be reused for the newly selected blueprint");
+        updated.AgentRegistrationId.Should().BeNull(
+            because: "an agent registration from a different blueprint/agent must never be reused for the newly selected blueprint");
+        updated.AgentBlueprintClientSecret.Should().BeNull(
+            because: "a client secret cached for a different blueprint cannot authenticate the selected blueprint");
+        updated.AgentBlueprintId.Should().Be(BlueprintAppId,
+            because: "the exact tenant-verified blueprint ID must be applied directly");
+        updated.AgentBlueprintObjectId.Should().Be(BlueprintObjectId,
+            because: "the exact tenant-verified blueprint object ID must be applied directly");
+        updated.AgentBlueprintServicePrincipalObjectId.Should().BeNull();
+        updated.ResourceConsents.Should().BeEmpty(
+            because: "resource consent records from a different blueprint/agent must not be carried over to the newly selected blueprint");
+        updated.AgentBlueprintDisplayName.Should().Be(BlueprintDisplayName,
+            because: "setup must discover/create resources under the explicitly selected blueprint's real display name");
+        config.AgenticAppId.Should().Be("other-agentic-app-id",
+            because: "the original config instance passed in must not be mutated");
+        config.ResourceConsents.Should().HaveCount(1,
+            because: "resetting the clone's ResourceConsents to a new list must not affect the original config's list (MemberwiseClone shallow-copies list references)");
+    }
+
+    [Fact]
+    public void ApplyExplicitBlueprintSelection_NoCachedBlueprint_ResetsToEmptyAndSetsDisplayName()
+    {
+        var config = new Agent365Config
+        {
+            TenantId = TenantId,
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintDisplayName = "Support Europe Blueprint",
+        };
+        var blueprint = new BlueprintLookupResult { Found = true, AppId = BlueprintAppId, ObjectId = BlueprintObjectId, DisplayName = BlueprintDisplayName };
+
+        var updated = BlueprintSelectionHelper.ApplyExplicitBlueprintSelection(config, blueprint);
+
+        updated.AgenticAppId.Should().BeNull();
+        updated.AgentRegistrationId.Should().BeNull();
+        updated.AgentBlueprintId.Should().Be(BlueprintAppId,
+            because: "with nothing cached, the exact resolved blueprint ID must still be applied directly");
+        updated.AgentBlueprintObjectId.Should().Be(BlueprintObjectId);
+        updated.AgentBlueprintDisplayName.Should().Be(BlueprintDisplayName);
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSubcommandDiscoveryTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupSubcommands/BlueprintSubcommandDiscoveryTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands.SetupSubcommands;
+
+/// <summary>
+/// Tests stable-ID blueprint discovery when display names are duplicated.
+/// </summary>
+public class BlueprintSubcommandDiscoveryTests
+{
+    private const string TenantId = "11111111-1111-1111-1111-111111111111";
+
+    private const string SharedDisplayName = "Contoso Support Blueprint";
+    private const string FirstDuplicateAppId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    private const string FirstDuplicateObjectId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    private const string SelectedAppId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    private const string SelectedObjectId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+
+    private static BlueprintLookupService CreateBlueprintLookupService(GraphApiService graphApiService) =>
+        new(NullLogger<BlueprintLookupService>.Instance, graphApiService);
+
+    private static GraphApiService CreateGraphApiServiceReturningDuplicateOnDisplayNameSearch()
+    {
+        var graphApiService = Substitute.For<GraphApiService>();
+
+        graphApiService.GraphGetAsync(
+                TenantId,
+                Arg.Is<string>(s => s.Contains("/beta/applications?$filter=")),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(JsonDocument.Parse(
+                $@"{{ ""value"": [
+                    {{ ""id"": ""{FirstDuplicateObjectId}"", ""appId"": ""{FirstDuplicateAppId}"", ""displayName"": ""{SharedDisplayName}"" }},
+                    {{ ""id"": ""some-other-object-id"", ""appId"": ""some-other-app-id"", ""displayName"": ""{SharedDisplayName}"" }}
+                ] }}"));
+
+        graphApiService.GraphGetAsync(
+                TenantId,
+                Arg.Is<string>(s =>
+                    s.Contains($"/beta/applications/{SelectedObjectId}/microsoft.graph.agentIdentityBlueprint")),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(JsonDocument.Parse(
+                $@"{{ ""value"": {{ ""id"": ""{SelectedObjectId}"", ""appId"": ""{SelectedAppId}"", ""displayName"": ""{SharedDisplayName}"" }} }}"));
+
+        return graphApiService;
+    }
+
+    [Fact]
+    public async Task ResolveExistingBlueprintAsync_WithCachedObjectId_UsesItAndNeverConsultsDisplayNameSearch()
+    {
+        var graphApiService = CreateGraphApiServiceReturningDuplicateOnDisplayNameSearch();
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSubcommand.ResolveExistingBlueprintAsync(
+            lookupService, TenantId, cachedObjectId: SelectedObjectId, SharedDisplayName, NullLogger.Instance, CancellationToken.None);
+
+        result.Found.Should().BeTrue(because: "the object-ID lookup must resolve when the cached ID is still valid in the tenant");
+        result.AppId.Should().Be(SelectedAppId,
+            because: "an authoritative cached object ID must take precedence over an ambiguous display-name search");
+        result.ObjectId.Should().Be(SelectedObjectId);
+
+        await graphApiService.DidNotReceive().GraphGetAsync(
+            TenantId,
+            Arg.Is<string>(s => s.Contains("/beta/applications?$filter=")),
+            Arg.Any<CancellationToken>(),
+            null);
+    }
+
+    [Fact]
+    public async Task ResolveExistingBlueprintAsync_WithDuplicateDisplayNames_SelectedBlueprintRemainsSelected()
+    {
+        var graphApiService = CreateGraphApiServiceReturningDuplicateOnDisplayNameSearch();
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSubcommand.ResolveExistingBlueprintAsync(
+            lookupService, TenantId, cachedObjectId: SelectedObjectId, SharedDisplayName, NullLogger.Instance, CancellationToken.None);
+
+        result.AppId.Should().Be(SelectedAppId,
+            because: "the explicitly selected blueprint (#2) must remain selected");
+        result.AppId.Should().NotBe(FirstDuplicateAppId,
+            because: "the first duplicate by display name must never silently override an explicit selection");
+    }
+
+    [Fact]
+    public async Task ResolveExistingBlueprintAsync_NoCachedObjectId_FallsBackToDisplayNameSearch()
+    {
+        var graphApiService = CreateGraphApiServiceReturningDuplicateOnDisplayNameSearch();
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSubcommand.ResolveExistingBlueprintAsync(
+            lookupService, TenantId, cachedObjectId: null, SharedDisplayName, NullLogger.Instance, CancellationToken.None);
+
+        result.Found.Should().BeTrue(because: "the display-name fallback must resolve when at least one match exists");
+        result.AppId.Should().Be(FirstDuplicateAppId,
+            because: "with no cached object ID, the default derive/create flow must still fall back to the pre-existing display-name-first discovery");
+        result.RequiresPersistence.Should().BeTrue(
+            because: "a display-name discovery result must be persisted so future runs use the faster/unambiguous object-ID path");
+    }
+
+    [Fact]
+    public async Task ResolveExistingBlueprintAsync_CachedObjectIdNoLongerResolves_FallsBackToDisplayNameSearch()
+    {
+        var graphApiService = CreateGraphApiServiceReturningDuplicateOnDisplayNameSearch();
+        var lookupService = CreateBlueprintLookupService(graphApiService);
+
+        var result = await BlueprintSubcommand.ResolveExistingBlueprintAsync(
+            lookupService, TenantId, cachedObjectId: "deleted-object-id", SharedDisplayName, NullLogger.Instance, CancellationToken.None);
+
+        result.Found.Should().BeTrue(
+            because: "a stale/deleted cached object ID must gracefully fall back to display-name discovery rather than reporting not-found");
+        result.AppId.Should().Be(FirstDuplicateAppId);
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Models/Agent365ConfigTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Models/Agent365ConfigTests.cs
@@ -1009,6 +1009,35 @@ public class Agent365ConfigTests
         cloned.NeedAzureOpenAI.Should().BeTrue();
     }
 
+    [Fact]
+    public void WithAgentBlueprintDisplayName_OverridesDisplayNameAndPreservesAllOtherFields()
+    {
+        var config = new Agent365Config
+        {
+            TenantId = "tenant-id",
+            ClientAppId = "client-app-id",
+            AgentIdentityDisplayName = "Support Europe Identity",
+            AgentBlueprintDisplayName = "Support Europe Blueprint",
+            AiTeammate = false,
+            UseBlueprint = true,
+        };
+        config.AgentBlueprintId = "cached-blueprint-id";
+        config.AgenticAppId = "cached-agentic-app-id";
+
+        var updated = config.WithAgentBlueprintDisplayName("Contoso Support Blueprint");
+
+        updated.AgentBlueprintDisplayName.Should().Be("Contoso Support Blueprint",
+            because: "the override must take effect on the returned instance");
+        updated.TenantId.Should().Be("tenant-id", because: "static fields must be preserved by the clone");
+        updated.AgentIdentityDisplayName.Should().Be("Support Europe Identity",
+            because: "static fields must be preserved by the clone");
+        updated.AgentBlueprintId.Should().Be("cached-blueprint-id", because: "dynamic fields must be preserved by the clone");
+        updated.AgenticAppId.Should().Be("cached-agentic-app-id",
+            because: "dynamic fields must be preserved by the clone via MemberwiseClone, not just the overridden display name");
+        config.AgentBlueprintDisplayName.Should().Be("Support Europe Blueprint",
+            because: "the original instance must not be mutated — AgentBlueprintDisplayName is init-only");
+    }
+
     #endregion
 
     #region ValidateNonDwMinimal Tests

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
@@ -183,6 +183,38 @@ public class Agent365ConfigServiceTests : IDisposable
         Assert.False(savedData.ContainsKey("appServicePlanName"));
     }
 
+    /// <summary>
+    /// Regression test: AgentBlueprintDisplayName must remain <c>init</c>-only (classified as a
+    /// static, user-configured field written to a365.config.json) — not a dynamic/generated field.
+    /// SaveStateAsync/ExtractDynamicProperties classify static vs. dynamic purely by reflecting on
+    /// the property's setter kind (see ConfigService.HasPublicSetter), so if this property is ever
+    /// changed to a plain mutable setter, it would silently be written to a365.generated.config.json
+    /// instead of a365.config.json, and a365.config.json's value would then be discarded/overwritten
+    /// on every SaveStateAsync call — corrupting the "a365.config.json is the source of truth for
+    /// displayName" invariant relied on by blueprint discovery (see BlueprintSubcommand.CreateAgentBlueprintAsync).
+    /// </summary>
+    [Fact]
+    public async Task SaveStateAsync_DoesNotIncludeAgentBlueprintDisplayName()
+    {
+        var statePath = Path.Combine(_testDirectory, "a365.generated.config.json");
+        var config = new Agent365Config
+        {
+            TenantId = "12345678-1234-1234-1234-123456789012",
+            AgentIdentityDisplayName = "Test Agent",
+            AgentBlueprintDisplayName = "Test Agent Blueprint",
+        };
+        config.AgentBlueprintId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        await _service.SaveStateAsync(config, statePath);
+
+        var json = await File.ReadAllTextAsync(statePath);
+        var savedData = JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json);
+
+        savedData.Should().NotBeNull();
+        savedData!.ContainsKey("agentBlueprintDisplayName").Should().BeFalse(
+            because: "agentBlueprintDisplayName is a static/user-configured field belonging in a365.config.json, not the generated/dynamic state file");
+    }
+
     [Fact]
     public async Task SaveStateAsync_OverwritesExistingFile()
     {
@@ -366,6 +398,114 @@ public class Agent365ConfigServiceTests : IDisposable
         Assert.NotNull(node);
         Assert.Equal("super-secret-value", node!["agentBlueprintClientSecret"]?.GetValue<string>());
         Assert.Equal(false, node["agentBlueprintClientSecretProtected"]?.GetValue<bool>());
+    }
+
+    #endregion
+
+    #region Static Config Update Tests
+
+    [Fact]
+    public async Task UpdateAgentBlueprintDisplayNameAsync_ReplacesOnlyExistingProperty()
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        const string original = """
+            {
+              // retained comment
+              "tenantId": "11111111-1111-1111-1111-111111111111",
+              "agentBlueprintDisplayName": "Old Blueprint",
+              "unknownSetting": "keep-me"
+            }
+            """;
+        await File.WriteAllTextAsync(configPath, original);
+
+        await _service.UpdateAgentBlueprintDisplayNameAsync("Selected Blueprint", configPath);
+
+        var updated = await File.ReadAllTextAsync(configPath);
+        updated.Should().Contain("\"agentBlueprintDisplayName\": \"Selected Blueprint\"",
+            because: "the explicit blueprint selection must become the static source of truth");
+        updated.Should().Contain("// retained comment",
+            because: "updating one known field must preserve user-managed comments");
+        updated.Should().Contain("\"unknownSetting\": \"keep-me\"",
+            because: "updating one known field must preserve unknown user-managed settings");
+        updated.Should().NotContain("Old Blueprint");
+    }
+
+    [Fact]
+    public async Task UpdateAgentBlueprintDisplayNameAsync_AddsMissingProperty()
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        await File.WriteAllTextAsync(configPath, """{"tenantId":"11111111-1111-1111-1111-111111111111","unknownSetting":"keep-me"}""");
+
+        await _service.UpdateAgentBlueprintDisplayNameAsync("Selected Blueprint", configPath);
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+        document.RootElement.GetProperty("agentBlueprintDisplayName").GetString().Should().Be(
+            "Selected Blueprint",
+            because: "older config files may not contain the static blueprint display-name field");
+        document.RootElement.GetProperty("unknownSetting").GetString().Should().Be(
+            "keep-me",
+            because: "adding the field must preserve unrelated settings");
+    }
+
+    [Theory]
+    [InlineData("Finance $1 Bot")]
+    [InlineData("Cost $$ Saver")]
+    [InlineData("Team $& Blueprint")]
+    [InlineData("Weird $` Name")]
+    public async Task UpdateAgentBlueprintDisplayNameAsync_ValueContainsRegexReplacementToken_WritesExactValue(
+        string displayName)
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        await File.WriteAllTextAsync(
+            configPath,
+            """{"agentBlueprintDisplayName":"Old Blueprint","unknownSetting":"keep-me"}""");
+
+        await _service.UpdateAgentBlueprintDisplayNameAsync(displayName, configPath);
+
+        using var document = JsonDocument.Parse(await File.ReadAllTextAsync(configPath));
+        document.RootElement.GetProperty("agentBlueprintDisplayName").GetString().Should().Be(
+            displayName,
+            because: "tenant-managed blueprint names must not be interpreted as regex replacement syntax");
+        document.RootElement.GetProperty("unknownSetting").GetString().Should().Be(
+            "keep-me",
+            because: "persisting an arbitrary blueprint name must not corrupt adjacent settings");
+    }
+
+    [Fact]
+    public async Task UpdateAgentBlueprintDisplayNameAsync_ValueIsUnchanged_PreservesComments()
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        const string original = """
+            {
+              // retained comment
+              "agentBlueprintDisplayName": "Selected Blueprint",
+              "unknownSetting": "keep-me"
+            }
+            """;
+        await File.WriteAllTextAsync(configPath, original);
+
+        await _service.UpdateAgentBlueprintDisplayNameAsync("Selected Blueprint", configPath);
+
+        (await File.ReadAllTextAsync(configPath)).Should().Be(
+            original,
+            because: "an idempotent blueprint selection must not reformat the user-managed config");
+    }
+
+    [Fact]
+    public async Task UpdateAgentBlueprintDisplayNameAsync_WhenCancelled_PropagatesCancellation()
+    {
+        var configPath = Path.Combine(_testDirectory, "a365.config.json");
+        await File.WriteAllTextAsync(configPath, """{"agentBlueprintDisplayName":"Old Blueprint"}""");
+        using var cancellationSource = new CancellationTokenSource();
+        cancellationSource.Cancel();
+
+        var act = () => _service.UpdateAgentBlueprintDisplayNameAsync(
+            "Selected Blueprint",
+            configPath,
+            cancellationSource.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "cancellation must stop static configuration mutation");
     }
 
     #endregion

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BlueprintLookupServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BlueprintLookupServiceTests.cs
@@ -26,21 +26,26 @@ public class BlueprintLookupServiceTests
         _graphApiService = Substitute.For<GraphApiService>();
         _service = new BlueprintLookupService(_logger, _graphApiService);
     }
-
     [Fact]
     public async Task GetApplicationByObjectIdAsync_WhenBlueprintExists_ReturnsFoundWithDetails()
     {
         // Arrange
-        var jsonResponse = $@"{{
-            ""id"": ""{TestObjectId}"",
-            ""appId"": ""{TestAppId}"",
-            ""displayName"": ""{TestDisplayName}""
-        }}";
+        var jsonResponse = $$"""
+            {
+              "value": {
+                "id": "{{TestObjectId}}",
+                "appId": "{{TestAppId}}",
+                "displayName": "{{TestDisplayName}}"
+              }
+            }
+            """;
         var jsonDoc = JsonDocument.Parse(jsonResponse);
 
         _graphApiService.GraphGetAsync(
             TestTenantId,
-            $"/beta/applications/{TestObjectId}",
+            Arg.Is<string>(s =>
+                s.Contains($"/beta/applications/{TestObjectId}/microsoft.graph.agentIdentityBlueprint") &&
+                !s.Contains("$filter")),
             Arg.Any<CancellationToken>(),
             null)
             .Returns(jsonDoc);
@@ -59,12 +64,40 @@ public class BlueprintLookupServiceTests
     }
 
     [Fact]
+    public async Task GetApplicationByObjectIdAsync_WhenGraphReturnsMismatchedObjectId_ReturnsNotFound()
+    {
+        var mismatchedObjectId = "99999999-9999-9999-9999-999999999999";
+        _graphApiService.GraphGetAsync(
+                TestTenantId,
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(JsonDocument.Parse($$"""
+                {
+                  "value": {
+                    "id": "{{mismatchedObjectId}}",
+                    "appId": "{{TestAppId}}",
+                    "displayName": "{{TestDisplayName}}"
+                  }
+                }
+                """));
+
+        var result = await _service.GetApplicationByObjectIdAsync(TestTenantId, TestObjectId);
+
+        result.Found.Should().BeFalse(
+            because: "a Graph result for another object must not satisfy exact blueprint verification");
+        result.ErrorMessage.Should().Contain(
+            "incomplete or inconsistent",
+            because: "the caller must be able to distinguish a mismatched response from an absent blueprint");
+    }
+
+    [Fact]
     public async Task GetApplicationByObjectIdAsync_WhenBlueprintNotFound_ReturnsNotFound()
     {
         // Arrange
         _graphApiService.GraphGetAsync(
             TestTenantId,
-            $"/beta/applications/{TestObjectId}",
+            Arg.Is<string>(s => s.Contains($"/beta/applications/{TestObjectId}/microsoft.graph.agentIdentityBlueprint")),
             Arg.Any<CancellationToken>())
             .Returns((JsonDocument?)null);
 
@@ -75,6 +108,20 @@ public class BlueprintLookupServiceTests
         result.Should().NotBeNull();
         result.Found.Should().BeFalse();
         result.LookupMethod.Should().Be("objectId");
+    }
+
+    [Fact]
+    public async Task GetApplicationByObjectIdAsync_WhenObjectIdIsNotAGuid_ReturnsNotFoundWithoutCallingGraph()
+    {
+        var result = await _service.GetApplicationByObjectIdAsync(TestTenantId, "not-a-guid");
+
+        result.Found.Should().BeFalse(
+            because: "malformed cached object IDs must be rejected before any Graph call");
+        await _graphApiService.DidNotReceiveWithAnyArgs().GraphGetAsync(
+            default!,
+            default!,
+            default,
+            default);
     }
 
     [Fact]
@@ -221,7 +268,7 @@ public class BlueprintLookupServiceTests
         // Arrange
         _graphApiService.GraphGetAsync(
             TestTenantId,
-            $"/beta/applications/{TestObjectId}",
+            Arg.Is<string>(s => s.Contains($"/beta/applications/{TestObjectId}/microsoft.graph.agentIdentityBlueprint")),
             Arg.Any<CancellationToken>())
             .Returns(Task.FromException<JsonDocument?>(new Exception("Graph API error")));
 
@@ -232,6 +279,22 @@ public class BlueprintLookupServiceTests
         result.Should().NotBeNull();
         result.Found.Should().BeFalse();
         result.ErrorMessage.Should().Contain("Graph API error");
+    }
+
+    [Fact]
+    public async Task GetApplicationByObjectIdAsync_WhenCancelled_PropagatesCancellation()
+    {
+        _graphApiService.GraphGetAsync(
+                TestTenantId,
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(Task.FromException<JsonDocument?>(new OperationCanceledException()));
+
+        var act = async () => await _service.GetApplicationByObjectIdAsync(TestTenantId, TestObjectId);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "cancellation must not be converted into a not-found result");
     }
 
     [Fact]
@@ -304,5 +367,229 @@ public class BlueprintLookupServiceTests
         result.Found.Should().BeFalse("searching by new displayName should not find old cached blueprint");
         result.LookupMethod.Should().Be("displayName");
         result.RequiresPersistence.Should().BeFalse("no blueprint found means nothing to persist");
+    }
+
+    // -----------------------------------------------------------------------
+    // ListBlueprintsAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ListBlueprintsAsync_WhenBlueprintsExist_ReturnsAllWithDetails()
+    {
+        var jsonResponse = $@"{{
+            ""value"": [
+                {{ ""id"": ""{TestObjectId}"", ""appId"": ""{TestAppId}"", ""displayName"": ""{TestDisplayName}"" }},
+                {{ ""id"": ""22222222-2222-2222-2222-222222222222"", ""appId"": ""33333333-3333-3333-3333-333333333333"", ""displayName"": ""Second Blueprint"" }}
+            ]
+        }}";
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Is<string>(s => s.Contains("/beta/applications/microsoft.graph.agentIdentityBlueprint")),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(jsonResponse));
+
+        var result = await _service.ListBlueprintsAsync(TestTenantId);
+
+        result.Should().HaveCount(2, because: "both blueprints returned by Graph must be included");
+        result[0].Found.Should().BeTrue();
+        result[0].AppId.Should().Be(TestAppId);
+        result[0].DisplayName.Should().Be(TestDisplayName);
+        result[1].AppId.Should().Be("33333333-3333-3333-3333-333333333333");
+    }
+
+    [Fact]
+    public async Task ListBlueprintsAsync_WhenTenantHasNoBlueprints_ReturnsEmptyList()
+    {
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(@"{""value"": []}"));
+
+        var result = await _service.ListBlueprintsAsync(TestTenantId);
+
+        result.Should().BeEmpty(because: "an empty tenant must be reported as a successful empty list, not an error");
+    }
+
+    [Fact]
+    public async Task ListBlueprintsAsync_FollowsODataNextLinkPagination()
+    {
+        var page1 = $@"{{
+            ""value"": [ {{ ""id"": ""{TestObjectId}"", ""appId"": ""{TestAppId}"", ""displayName"": ""Page1 Blueprint"" }} ],
+            ""@odata.nextLink"": ""https://graph.microsoft.com/beta/applications/microsoft.graph.agentIdentityBlueprint?$skiptoken=abc""
+        }}";
+        var page2 = @"{""value"": [ { ""id"": ""44444444-4444-4444-4444-444444444444"", ""appId"": ""55555555-5555-5555-5555-555555555555"", ""displayName"": ""Page2 Blueprint"" } ] }";
+
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Is<string>(s => s.Contains("$top=100") && !s.Contains("skiptoken")),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(page1));
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Is<string>(s => s.Contains("skiptoken")),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(page2));
+
+        var result = await _service.ListBlueprintsAsync(TestTenantId);
+
+        result.Should().HaveCount(2, because: "both pages of results must be aggregated");
+        result.Select(r => r.DisplayName).Should().Contain(["Page1 Blueprint", "Page2 Blueprint"]);
+    }
+
+    [Fact]
+    public async Task ListBlueprintsAsync_WhenGraphQueryFails_ThrowsInvalidOperationException()
+    {
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns((JsonDocument?)null);
+
+        var act = async () => await _service.ListBlueprintsAsync(TestTenantId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "an auth/query failure must surface as an exception so the caller returns a non-zero exit code instead of reporting an empty list as success");
+    }
+
+    // -----------------------------------------------------------------------
+    // GetBlueprintByAppIdAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenBlueprintExists_ReturnsFoundWithDetails()
+    {
+        var jsonResponse = $@"{{
+            ""value"": [ {{ ""id"": ""{TestObjectId}"", ""appId"": ""{TestAppId}"", ""displayName"": ""{TestDisplayName}"" }} ]
+        }}";
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Is<string>(s => s.Contains("/beta/applications/microsoft.graph.agentIdentityBlueprint") && s.Contains(TestAppId)),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(jsonResponse));
+
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        result.Found.Should().BeTrue();
+        result.ObjectId.Should().Be(TestObjectId);
+        result.AppId.Should().Be(TestAppId);
+        result.DisplayName.Should().Be(TestDisplayName);
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenGraphReturnsMismatchedAppId_ReturnsNotFound()
+    {
+        var mismatchedAppId = "99999999-9999-9999-9999-999999999999";
+        _graphApiService.GraphGetAsync(
+                TestTenantId,
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(JsonDocument.Parse($$"""
+                {
+                  "value": [
+                    {
+                      "id": "{{TestObjectId}}",
+                      "appId": "{{mismatchedAppId}}",
+                      "displayName": "{{TestDisplayName}}"
+                    }
+                  ]
+                }
+                """));
+
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        result.Found.Should().BeFalse(
+            because: "a Graph result for another app must not satisfy exact tenant verification");
+        result.ErrorMessage.Should().Contain(
+            "incomplete or inconsistent",
+            because: "the caller must be able to distinguish a mismatched response from an absent blueprint");
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenGraphReturnsMissingDisplayName_ReturnsNotFound()
+    {
+        _graphApiService.GraphGetAsync(
+                TestTenantId,
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(JsonDocument.Parse($$"""
+                {
+                  "value": [
+                    {
+                      "id": "{{TestObjectId}}",
+                      "appId": "{{TestAppId}}"
+                    }
+                  ]
+                }
+                """));
+
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        result.Found.Should().BeFalse(
+            because: "an incomplete Graph record must not be persisted as an authoritative blueprint");
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenNotFoundInTenant_ReturnsNotFound()
+    {
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns(JsonDocument.Parse(@"{""value"": []}"));
+
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        result.Found.Should().BeFalse(
+            because: "a blueprint that does not exist in this tenant (e.g. belongs to a different tenant) must not be treated as found");
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenAppIdIsNotAGuid_ReturnsNotFoundWithoutCallingGraph()
+    {
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, "not-a-guid");
+
+        result.Found.Should().BeFalse(because: "malformed input must be rejected before any Graph call is made");
+        await _graphApiService.DidNotReceiveWithAnyArgs().GraphGetAsync(default!, default!, default, default);
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_OnGraphFailure_ReturnsNotFound()
+    {
+        _graphApiService.GraphGetAsync(
+            TestTenantId,
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>(),
+            null)
+            .Returns((JsonDocument?)null);
+
+        var result = await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        result.Found.Should().BeFalse(because: "a query failure must not be misreported as a successful not-found result being confused with success");
+    }
+
+    [Fact]
+    public async Task GetBlueprintByAppIdAsync_WhenCancelled_PropagatesCancellation()
+    {
+        _graphApiService.GraphGetAsync(
+                TestTenantId,
+                Arg.Any<string>(),
+                Arg.Any<CancellationToken>(),
+                null)
+            .Returns(Task.FromException<JsonDocument?>(new OperationCanceledException()));
+
+        var act = async () => await _service.GetBlueprintByAppIdAsync(TestTenantId, TestAppId);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "cancellation must not be converted into a failed lookup");
     }
 }


### PR DESCRIPTION
## Summary
- add read-only discovery for existing Agent Identity Blueprints
- allow `setup all` to select a blueprint interactively or by application/client ID
- isolate blueprint-scoped and agent-identity-scoped cached state
- preserve static configuration comments and unknown properties when persisting blueprint selection

## Validation
- release build succeeds
- 1,996 tests pass; 12 skipped
- independent correctness and test-coverage reviews completed