### PR TITLE
Use first-party Agent 365 CLI app for setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- The first-party Agent 365 CLI app now uses device code authentication when Windows Account Manager is unavailable, avoiding unsupported browser-response errors in WSL, macOS, and Linux.
 - `setup all --authmode s2s` no longer prints spurious "Action Required" PowerShell steps when the agent identity already inherits its app roles from the blueprint, and now retries the grant automatically before falling back to manual steps (#460).
 - `a365 develop get-token` now falls back to device code when the Windows WAM broker rejects Exchange Graph scopes with `ApiContractViolation`, instead of failing with an opaque MSAL error.
 - `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically, and ends with a setup summary whose Action Required block surfaces the admin-consent URL for non-admins to hand off (#452).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 **Option B — CLI** (`a365 setup admin`) has been removed in this release. Use Option A above, or copy the PowerShell instructions printed in the `a365 setup all` summary output.
 
 ### Added
-- Setup and bootstrap now default to Microsoft's first-party Agent 365 CLI application, validate its tenant service principal and delegated scopes without modifying Microsoft's registration or requiring a tenant-local consent grant, and retain the custom-app fallback.
+- Setup and bootstrap now use Microsoft's first-party Agent 365 CLI application when it is present in your tenant, validating it without changing Microsoft's app registration, and fall back to a tenant-owned "Agent 365 CLI" app when it is not (#489).
 - Log separator written at the start of each CLI invocation now redacts values for secret-bearing options (e.g. `--idp-client-secret`) so they are not written to the log file in plain text.
 - Authentication context (tenant and user) is now logged at the `Information` level whenever the resolved sign-in identity changes, giving operators a clear audit trail in the log file of who the CLI is acting as, without exposing credentials.
 - `a365 develop-mcp evaluate` command for evaluating MCP server tool schema quality — runs deterministic and semantic checks (via GitHub Copilot or Claude Code CLIs), computes maturity scoring, and generates an interactive HTML report
@@ -59,7 +59,8 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
-- The first-party Agent 365 CLI app now uses device code authentication when Windows Account Manager is unavailable, avoiding unsupported browser-response errors in WSL, macOS, and Linux.
+- Setup no longer fails to detect the Agent 365 CLI application in tenants where it is not yet provisioned, and reports lookup errors instead of silently switching your configured client app (#489).
+- The first-party Agent 365 CLI app now uses device code authentication when Windows Account Manager is unavailable, avoiding unsupported browser-response errors in WSL, macOS, and Linux (#489).
 - `setup all --authmode s2s` no longer prints spurious "Action Required" PowerShell steps when the agent identity already inherits its app roles from the blueprint, and now retries the grant automatically before falling back to manual steps (#460).
 - `a365 develop get-token` now falls back to device code when the Windows WAM broker rejects Exchange Graph scopes with `ApiContractViolation`, instead of failing with an opaque MSAL error.
 - `setup blueprint` now configures the blueprint's inheritable Microsoft Graph permissions even when the signed-in user is not a Global Administrator, no longer aborts with a misleading "Failed to configure inheritable permissions" error when the tenant-wide consent grant cannot be made programmatically, and ends with a setup summary whose Action Required block surfaces the admin-consent URL for non-admins to hand off (#452).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 **Option B — CLI** (`a365 setup admin`) has been removed in this release. Use Option A above, or copy the PowerShell instructions printed in the `a365 setup all` summary output.
 
 ### Added
+- Setup and bootstrap now default to Microsoft's first-party Agent 365 CLI application, validate its tenant service principal and delegated scopes without modifying Microsoft's registration or requiring a tenant-local consent grant, and retain the custom-app fallback.
 - Log separator written at the start of each CLI invocation now redacts values for secret-bearing options (e.g. `--idp-client-secret`) so they are not written to the log file in plain text.
 - Authentication context (tenant and user) is now logged at the `Information` level whenever the resolved sign-in identity changes, giving operators a clear audit trail in the log file of who the CLI is acting as, without exposing credentials.
 - `a365 develop-mcp evaluate` command for evaluating MCP server tool schema quality — runs deterministic and semantic checks (via GitHub Copilot or Claude Code CLIs), computes maturity scoring, and generates an interactive HTML report

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/CleanupCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/CleanupCommand.cs
@@ -1339,7 +1339,7 @@ public class CleanupCommand
 
         // Step 2: Resolve client app ID.
         // Prefer a365.config.json when it exists locally and its tenant matches the current tenant.
-        // Fall back to Entra lookup by well-known display name if the static config is absent or stale.
+        // Otherwise prefer the first-party service principal, then the named custom-app fallback.
         var clientAppId = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
             tenantId,
             graphApiService,

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/AllSubcommand.cs
@@ -127,7 +127,8 @@ internal static class AllSubcommand
             description: "Agent base name (e.g. \"MyAgent\"). When provided, no config file is required.\n" +
                         "Derives AgentIdentityDisplayName=\"<name> Identity\" and AgentBlueprintDisplayName=\"<name> Blueprint\".\n" +
                         "TenantId is auto-detected from 'az account show' (override with --tenant-id).\n" +
-                        $"ClientAppId is resolved by looking up \"{Constants.AuthenticationConstants.WellKnownClientAppDisplayName}\" in your tenant.");
+                        "ClientAppId defaults to the first-party Agent 365 CLI enterprise application, " +
+                        $"then falls back to a tenant-owned \"{Constants.AuthenticationConstants.WellKnownClientAppDisplayName}\" app.");
 
         var tenantIdOption = new Option<string?>(
             "--tenant-id",
@@ -1035,7 +1036,7 @@ internal static class AllSubcommand
     /// requiring an <c>a365.config.json</c> file on disk.
     /// <list type="bullet">
     ///   <item>TenantId: from <paramref name="tenantIdFlag"/> or auto-detected via <c>az account show</c></item>
-    ///   <item>ClientAppId: resolved by searching Entra for <see cref="AuthenticationConstants.WellKnownClientAppDisplayName"/></item>
+    ///   <item>ClientAppId: the first-party app when its service principal exists, otherwise the named custom-app fallback</item>
     /// </list>
     /// Returns <c>null</c> and logs errors if validation fails.
     /// </summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/NonDwBlueprintSetupOrchestrator.cs
@@ -186,6 +186,13 @@ internal static class NonDwBlueprintSetupOrchestrator
         if (string.IsNullOrWhiteSpace(clientAppId) || string.IsNullOrWhiteSpace(tenantId))
             return;
 
+        if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+        {
+            ctx.Logger.LogDebug(
+                "Skipping tenant-local consent mutation for the first-party Agent 365 CLI application.");
+            return;
+        }
+
         List<string> unconsented;
         try
         {

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
@@ -46,22 +46,12 @@ internal static class RequirementsSubcommand
             ["--verbose", "-v"],
             description: "Enable verbose logging");
 
-        var firstPartyOption = new Option<bool>(
-            ["--first-party"],
-            description: "Validate the client app as Microsoft's first-party Agent 365 CLI application: " +
-                "verifies service principal presence and required token scopes, but never PATCHes " +
-                "permissions, redirect URIs, public-client settings, optional claims, or consent " +
-                "configuration on the Entra app registration. Applied automatically when the resolved " +
-                "clientAppId is the well-known first-party application, even without this flag.");
-
         command.AddOption(categoryOption);
         command.AddOption(verboseOption);
-        command.AddOption(firstPartyOption);
 
         command.SetHandler(async (InvocationContext context) =>
         {
             var category = context.ParseResult.GetValueForOption(categoryOption);
-            var firstParty = context.ParseResult.GetValueForOption(firstPartyOption);
             var ct = context.GetCancellationToken();
 
             logger.LogInformation("Agent 365 Requirements Check");
@@ -87,12 +77,7 @@ internal static class RequirementsSubcommand
                 // Pre-filter by category so we can emit a single warning if nothing matches,
                 // and skip the Entra bootstrap entirely when only system checks match.
                 var systemChecks = FilterByCategory(GetSystemRequirementChecks(), category);
-                var configChecks = FilterByCategory(GetConfigRequirementChecks(authValidator, clientAppValidator, firstParty), category);
-
-                if (firstParty)
-                {
-                    logger.LogInformation("First-party mode: the Agent 365 CLI application registration will not be modified.");
-                }
+                var configChecks = FilterByCategory(GetConfigRequirementChecks(authValidator, clientAppValidator), category);
 
                 if (systemChecks.Count == 0 && configChecks.Count == 0 && !string.IsNullOrWhiteSpace(category))
                 {
@@ -158,7 +143,9 @@ internal static class RequirementsSubcommand
         var localConfigPath = Path.Combine(Directory.GetCurrentDirectory(), ConfigConstants.DefaultConfigFileName);
         if (File.Exists(localConfigPath))
         {
-            return await configService.LoadAsync(localConfigPath);
+            var localConfig = await configService.LoadAsync(localConfigPath);
+            graphApiService.CustomClientAppId = localConfig.ClientAppId;
+            return localConfig;
         }
 
         // No config file — try to synthesize a minimal config from the Azure CLI context.
@@ -177,6 +164,7 @@ internal static class RequirementsSubcommand
             return null;
         }
 
+        graphApiService.CustomClientAppId = clientAppId;
         return new Agent365Config
         {
             TenantId = tenantId,
@@ -273,10 +261,10 @@ internal static class RequirementsSubcommand
     /// Gets all available requirement checks.
     /// Derived from the union of system and config checks to keep a single source of truth.
     /// </summary>
-    public static List<IRequirementCheck> GetRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator, bool firstParty = false)
+    public static List<IRequirementCheck> GetRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator)
     {
         return GetSystemRequirementChecks()
-            .Concat(GetConfigRequirementChecks(authValidator, clientAppValidator, firstParty))
+            .Concat(GetConfigRequirementChecks(authValidator, clientAppValidator))
             .ToList();
     }
 
@@ -299,7 +287,7 @@ internal static class RequirementsSubcommand
     /// <summary>
     /// Gets configuration-dependent requirement checks that must run after the configuration is loaded.
     /// </summary>
-    private static List<IRequirementCheck> GetConfigRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator, bool firstParty = false)
+    private static List<IRequirementCheck> GetConfigRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator)
     {
         return new List<IRequirementCheck>
         {
@@ -307,7 +295,7 @@ internal static class RequirementsSubcommand
             new AzureAuthRequirementCheck(authValidator),
 
             // Client app configuration validation (checks all required Graph permissions incl. UpdateAuthProperties.All)
-            new ClientAppRequirementCheck(clientAppValidator, firstParty),
+            new ClientAppRequirementCheck(clientAppValidator),
         };
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/RequirementsSubcommand.cs
@@ -46,12 +46,22 @@ internal static class RequirementsSubcommand
             ["--verbose", "-v"],
             description: "Enable verbose logging");
 
+        var firstPartyOption = new Option<bool>(
+            ["--first-party"],
+            description: "Validate the client app as Microsoft's first-party Agent 365 CLI application: " +
+                "verifies service principal presence and required token scopes, but never PATCHes " +
+                "permissions, redirect URIs, public-client settings, optional claims, or consent " +
+                "configuration on the Entra app registration. Applied automatically when the resolved " +
+                "clientAppId is the well-known first-party application, even without this flag.");
+
         command.AddOption(categoryOption);
         command.AddOption(verboseOption);
+        command.AddOption(firstPartyOption);
 
         command.SetHandler(async (InvocationContext context) =>
         {
             var category = context.ParseResult.GetValueForOption(categoryOption);
+            var firstParty = context.ParseResult.GetValueForOption(firstPartyOption);
             var ct = context.GetCancellationToken();
 
             logger.LogInformation("Agent 365 Requirements Check");
@@ -77,7 +87,12 @@ internal static class RequirementsSubcommand
                 // Pre-filter by category so we can emit a single warning if nothing matches,
                 // and skip the Entra bootstrap entirely when only system checks match.
                 var systemChecks = FilterByCategory(GetSystemRequirementChecks(), category);
-                var configChecks = FilterByCategory(GetConfigRequirementChecks(authValidator, clientAppValidator), category);
+                var configChecks = FilterByCategory(GetConfigRequirementChecks(authValidator, clientAppValidator, firstParty), category);
+
+                if (firstParty)
+                {
+                    logger.LogInformation("First-party mode: the Agent 365 CLI application registration will not be modified.");
+                }
 
                 if (systemChecks.Count == 0 && configChecks.Count == 0 && !string.IsNullOrWhiteSpace(category))
                 {
@@ -128,9 +143,9 @@ internal static class RequirementsSubcommand
     /// <summary>
     /// Resolves the <see cref="Agent365Config"/> used by config-dependent requirement checks.
     /// If <c>a365.config.json</c> is present, it is loaded and returned as-is. Otherwise a
-    /// minimal bootstrap config is synthesized from the current Azure CLI context plus a
-    /// well-known-name lookup for the Agent 365 CLI client app. Returns <c>null</c> when
-    /// the tenant cannot be determined or the well-known client app cannot be resolved —
+    /// minimal bootstrap config is synthesized from the current Azure CLI context and the
+    /// first-party service principal or custom-app fallback. Returns <c>null</c> when
+    /// the tenant cannot be determined or no client app can be resolved —
     /// in which case config-dependent checks should be skipped.
     /// </summary>
     private static async Task<Agent365Config?> ResolveConfigForChecksAsync(
@@ -158,7 +173,7 @@ internal static class RequirementsSubcommand
         var clientAppId = await SetupHelpers.ResolveBootstrapClientAppIdAsync(tenantId, graphApiService, logger, ct);
         if (string.IsNullOrWhiteSpace(clientAppId))
         {
-            logger.LogInformation("Agent 365 CLI app not found in tenant — client app validation skipped.");
+            logger.LogInformation("No Agent 365 CLI enterprise application or custom client app was found — client app validation skipped.");
             return null;
         }
 
@@ -258,10 +273,10 @@ internal static class RequirementsSubcommand
     /// Gets all available requirement checks.
     /// Derived from the union of system and config checks to keep a single source of truth.
     /// </summary>
-    public static List<IRequirementCheck> GetRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator)
+    public static List<IRequirementCheck> GetRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator, bool firstParty = false)
     {
         return GetSystemRequirementChecks()
-            .Concat(GetConfigRequirementChecks(authValidator, clientAppValidator))
+            .Concat(GetConfigRequirementChecks(authValidator, clientAppValidator, firstParty))
             .ToList();
     }
 
@@ -284,7 +299,7 @@ internal static class RequirementsSubcommand
     /// <summary>
     /// Gets configuration-dependent requirement checks that must run after the configuration is loaded.
     /// </summary>
-    private static List<IRequirementCheck> GetConfigRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator)
+    private static List<IRequirementCheck> GetConfigRequirementChecks(AzureAuthValidator authValidator, IClientAppValidator clientAppValidator, bool firstParty = false)
     {
         return new List<IRequirementCheck>
         {
@@ -292,7 +307,7 @@ internal static class RequirementsSubcommand
             new AzureAuthRequirementCheck(authValidator),
 
             // Client app configuration validation (checks all required Graph permissions incl. UpdateAuthProperties.All)
-            new ClientAppRequirementCheck(clientAppValidator),
+            new ClientAppRequirementCheck(clientAppValidator, firstParty),
         };
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/SetupSubcommands/SetupHelpers.cs
@@ -181,8 +181,9 @@ internal static class SetupHelpers
 
     /// <summary>
     /// Resolves the client app ID for config-free bootstrap flows.
-    /// Optionally prefers a matching local <c>a365.config.json</c> value before falling back to
-    /// the well-known Entra display name lookup.
+    /// Optionally prefers a matching local <c>a365.config.json</c> value, then the well-known
+    /// first-party Agent 365 CLI application (<see cref="AuthenticationConstants.WellKnownClientAppId"/>),
+    /// before falling back to a tenant-owned custom app discovered by well-known display name.
     /// </summary>
     internal static async Task<string?> ResolveBootstrapClientAppIdAsync(
         string tenantId,
@@ -198,6 +199,32 @@ internal static class SetupHelpers
             clientAppId = await TryGetLocalClientAppIdAsync(tenantId, logger, ct);
             if (!string.IsNullOrWhiteSpace(clientAppId))
                 logger.LogDebug("Using client app ID from local a365.config.json (tenant matches).");
+        }
+
+        // Prefer the well-known first-party Agent 365 CLI application. A customer tenant may
+        // contain only the manager-created service principal for this app (no local application
+        // object), so resolve/validate its presence via /servicePrincipals — never
+        // /applications — to avoid incorrectly falling through to the custom-app creation prompt.
+        if (string.IsNullOrWhiteSpace(clientAppId) && graphApiService != null)
+        {
+            logger.LogDebug("Checking for the first-party Agent 365 CLI application ({AppId})...",
+                AuthenticationConstants.WellKnownClientAppId);
+            var firstPartyLookup = await graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppId, ct);
+            if (firstPartyLookup is null || !firstPartyLookup.IsSuccess)
+            {
+                throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                    AuthenticationConstants.WellKnownClientAppId,
+                    tenantId,
+                    firstPartyLookup?.FailureReason ?? "Service-principal lookup returned no result.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(firstPartyLookup.ServicePrincipalId))
+            {
+                logger.LogInformation("Using the first-party Agent 365 CLI application ({AppId}).",
+                    AuthenticationConstants.WellKnownClientAppId);
+                return AuthenticationConstants.WellKnownClientAppId;
+            }
         }
 
         if (string.IsNullOrWhiteSpace(clientAppId) && graphApiService != null)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Constants/AuthenticationConstants.cs
@@ -72,11 +72,24 @@ public static class AuthenticationConstants
     }
 
     /// <summary>
-    /// Well-known display name for the Agent 365 CLI client app registration in the tenant.
-    /// Used to resolve the clientAppId automatically when --agent-name is provided without a config file.
-    /// Tenants must register an Entra app with this exact display name and grant it the required permissions.
+    /// Display name used to discover a tenant-owned custom client app when the first-party
+    /// Agent 365 CLI service principal is unavailable.
     /// </summary>
     public const string WellKnownClientAppDisplayName = "Agent 365 CLI";
+
+    /// <summary>
+    /// Well-known first-party Agent 365 CLI application ID used by setup/bootstrap by default.
+    /// </summary>
+    public const string WellKnownClientAppId = "f54280f4-395e-4ea8-9e48-bf2d4952aa14";
+
+    private static readonly Guid WellKnownClientAppGuid = Guid.Parse(WellKnownClientAppId);
+
+    /// <summary>
+    /// Returns whether <paramref name="clientAppId"/> identifies the first-party Agent 365 CLI app.
+    /// </summary>
+    public static bool IsWellKnownFirstPartyClientApp(string? clientAppId) =>
+        Guid.TryParse(clientAppId, out var parsedClientAppId) &&
+        parsedClientAppId == WellKnownClientAppGuid;
 
     /// <summary>
     /// Application name for cache directory
@@ -213,6 +226,11 @@ public static class AuthenticationConstants
     public const string AgentIdUserReadWriteAllScope = "AgentIdUser.ReadWrite.All";
 
     /// <summary>
+    /// Delegated scope required to create and delete agent registrations.
+    /// </summary>
+    public const string AgentRegistrationReadWriteAllScope = "AgentRegistration.ReadWrite.All";
+
+    /// <summary>
     /// Required delegated permissions for the custom client app used by a365 CLI.
     /// These permissions enable the CLI to manage Entra ID applications and agent blueprints.
     /// All permissions require admin consent.
@@ -224,7 +242,7 @@ public static class AuthenticationConstants
     {
         "AgentIdentityBlueprint.ReadWrite.All",    // Umbrella — covers blueprint creation, UpdateAuthProperties, AddRemoveCreds, DeleteRestore sub-scopes
         "AgentIdentityBlueprintPrincipal.Create",  // Required for POST /v1.0/serviceprincipals/graph.agentIdentityBlueprintPrincipal — separate from ReadWrite.All (different resource)
-        "AgentRegistration.ReadWrite.All",  // Required for POST/DELETE /beta/copilot/agentRegistrations (agent registration)
+        AgentRegistrationReadWriteAllScope,  // Required for POST/DELETE /beta/copilot/agentRegistrations (agent registration)
         "AgentIdentity.Read.All",       // Required for GET /beta/servicePrincipals/microsoft.graph.agentIdentity?$filter=agentIdentityBlueprintId (idempotency check)
         "AgentIdentity.DeleteRestore.All",  // Required for 'a365 cleanup' to delete the Agent Identity service principal
         "Application.Read.All",         // Narrower replacement for Directory.Read.All — covers SP lookups by appId
@@ -238,7 +256,7 @@ public static class AuthenticationConstants
     /// an MSAL consent error with no actionable guidance.
     /// </summary>
     public static readonly string[] BlueprintOperationScopes = RequiredClientAppPermissions
-        .Where(s => s != "AgentRegistration.ReadWrite.All")
+        .Where(s => s != AgentRegistrationReadWriteAllScope)
         .ToArray();
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
@@ -80,6 +80,119 @@ public sealed class ClientAppValidationException : Agent365Exception
     }
 
     /// <summary>
+    /// Creates an exception when the first-party enterprise application is absent from the tenant.
+    /// </summary>
+    public static ClientAppValidationException FirstPartyServicePrincipalNotFound(
+        string clientAppId,
+        string tenantId)
+    {
+        return new ClientAppValidationException(
+            issueDescription: "First-party client app service principal not found in tenant",
+            errorDetails:
+            [
+                $"The Agent 365 CLI enterprise application '{clientAppId}' is not present in tenant '{tenantId}'."
+            ],
+            mitigationSteps:
+            [
+                "Ensure you are signed in to the intended tenant with 'az login'.",
+                "Ask a tenant administrator to provision or enable the Microsoft Agent 365 CLI enterprise application.",
+                "Do not create or modify a tenant-local app registration for this Microsoft-owned application.",
+                $"See setup guide: {ConfigConstants.Agent365CliDocumentationUrl}"
+            ],
+            context: new Dictionary<string, string>
+            {
+                ["clientAppId"] = clientAppId,
+                ["tenantId"] = tenantId
+            });
+    }
+
+    /// <summary>
+    /// Creates an exception when first-party service-principal lookup fails.
+    /// </summary>
+    public static ClientAppValidationException FirstPartyServicePrincipalLookupFailed(
+        string clientAppId,
+        string tenantId,
+        string reason)
+    {
+        return new ClientAppValidationException(
+            issueDescription: "Unable to verify the first-party client app service principal",
+            errorDetails:
+            [
+                reason,
+                $"Service-principal lookup failed in tenant '{tenantId}'."
+            ],
+            mitigationSteps:
+            [
+                "Confirm network connectivity and sign in to the intended tenant with 'az login'.",
+                "Ask a tenant administrator to verify that the Microsoft Agent 365 CLI enterprise application is available.",
+                "Do not create or modify a tenant-local app registration for this Microsoft-owned application.",
+                $"See setup guide: {ConfigConstants.Agent365CliDocumentationUrl}"
+            ],
+            context: new Dictionary<string, string>
+            {
+                ["clientAppId"] = clientAppId,
+                ["tenantId"] = tenantId
+            });
+    }
+
+    /// <summary>
+    /// Creates an exception when first-party token acquisition cannot verify delegated authorization.
+    /// </summary>
+    public static ClientAppValidationException FirstPartyAuthorizationFailed(
+        string clientAppId,
+        IEnumerable<string> requiredScopes,
+        string reason)
+    {
+        var scopes = requiredScopes.ToList();
+        return new ClientAppValidationException(
+            issueDescription: "Unable to validate first-party client app authorization from the access token",
+            errorDetails:
+            [
+                reason,
+                $"Scopes being validated: {string.Join(", ", scopes)}"
+            ],
+            mitigationSteps:
+            [
+                "Run 'az logout', then 'az login', and retry the requirements check.",
+                "Ask a tenant administrator to verify that the Microsoft Agent 365 CLI enterprise application is authorized.",
+                "Do not add permissions to a tenant-local app registration for this Microsoft-owned application.",
+                $"See setup guide: {ConfigConstants.Agent365CliDocumentationUrl}"
+            ],
+            context: new Dictionary<string, string>
+            {
+                ["clientAppId"] = clientAppId,
+                ["requiredScopes"] = string.Join(", ", scopes)
+            });
+    }
+
+    /// <summary>
+    /// Creates an exception when an acquired first-party token omits required delegated scopes.
+    /// </summary>
+    public static ClientAppValidationException FirstPartyMissingPermissions(
+        string clientAppId,
+        List<string> missingPermissions)
+    {
+        return new ClientAppValidationException(
+            issueDescription: "First-party client app token is missing required delegated scopes",
+            errorDetails:
+            [
+                $"Missing scopes in token 'scp' claim: {string.Join(", ", missingPermissions)}"
+            ],
+            mitigationSteps:
+            [
+                "Run 'az logout', then 'az login', and retry the requirements check.",
+                "Ask a tenant administrator to verify that the Microsoft Agent 365 CLI enterprise application is authorized for the required scopes.",
+                "Do not add permissions to a tenant-local app registration for this Microsoft-owned application.",
+                $"See setup guide: {ConfigConstants.Agent365CliDocumentationUrl}"
+            ],
+            context: new Dictionary<string, string>
+            {
+                ["clientAppId"] = clientAppId,
+                ["missingPermissions"] = string.Join(", ", missingPermissions)
+            });
+    }
+
+    /// <summary>
     /// Creates exception for missing admin consent.
     /// Includes a direct admin consent URL that a Global Administrator can open to grant consent.
     /// </summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Models/Agent365Config.cs
@@ -29,7 +29,7 @@ public class Agent365Config
         if (string.IsNullOrWhiteSpace(TenantId)) errors.Add("tenantId is required.");
         if (string.IsNullOrWhiteSpace(ClientAppId))
         {
-            errors.Add($"clientAppId is required. This must be a client app you create in your tenant with specific permissions. See {ConfigConstants.Agent365CliDocumentationUrl} for setup instructions.");
+            errors.Add($"clientAppId is required. Use the default Agent 365 CLI application or configure a tenant-owned custom client app. See {ConfigConstants.Agent365CliDocumentationUrl} for setup instructions.");
         }
         else
         {
@@ -78,7 +78,7 @@ public class Agent365Config
 
         if (string.IsNullOrWhiteSpace(TenantId)) errors.Add("tenantId is required.");
         if (string.IsNullOrWhiteSpace(ClientAppId))
-            errors.Add($"clientAppId could not be resolved. Ensure an Entra app named \"{AuthenticationConstants.WellKnownClientAppDisplayName}\" exists in your tenant.");
+            errors.Add("clientAppId could not be resolved. Ensure the Agent 365 CLI enterprise application exists or configure a tenant-owned custom client app.");
         else
             ValidateGuid(ClientAppId, nameof(ClientAppId), errors);
         if (string.IsNullOrWhiteSpace(AgentIdentityDisplayName)) errors.Add("agentIdentityDisplayName is required.");

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Program.cs
@@ -243,8 +243,6 @@ class Program
                     await next(context);
                 }, MiddlewareOrder.ErrorReporting);
 
-            // Validate the configured clientAppId still exists in the tenant before any command runs.
-            // If not found, falls back to the well-known display name and patches a365.config.json.
             // Skip for help/version/show-secret — these never make Graph calls and must work offline.
             var isHelpOrVersion = args.Length == 0
                 || args.Any(a => a is "--help" or "-h" or "--version");
@@ -442,4 +440,3 @@ class Program
             .Replace("_", "-");
     }
 }
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -37,15 +37,12 @@ public sealed class ClientAppValidator : IClientAppValidator
     /// <param name="tenantId">The tenant ID where the app should exist</param>
     /// <param name="skipConfirmation">When true, applies any required app registration fixes without prompting the user.
     /// Use for non-interactive or CI scenarios. Defaults to false (prompt before modifying the app registration).</param>
-    /// <param name="isFirstParty">When true, validates a Microsoft first-party application without
-    /// mutating its Entra app registration — see <see cref="EnsureValidFirstPartyClientAppAsync"/>.</param>
     /// <param name="ct">Cancellation token</param>
     /// <exception cref="ClientAppValidationException">Thrown when validation fails</exception>
     public async Task EnsureValidClientAppAsync(
         string clientAppId,
         string tenantId,
         bool skipConfirmation = false,
-        bool isFirstParty = false,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(clientAppId);
@@ -71,7 +68,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             // Never run tenant-owned mutation logic against Microsoft's application registration.
-            if (isFirstParty || AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+            if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
             {
                 await EnsureValidFirstPartyClientAppAsync(parsedClientAppId.ToString("D"), tenantId, ct);
                 return;
@@ -357,8 +354,9 @@ public sealed class ClientAppValidator : IClientAppValidator
         GraphApiService.ServicePrincipalLookupResult lookup;
         try
         {
+            _graphApiService.CustomClientAppId = clientAppId;
             lookup = await _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
-                tenantId, clientAppId, ct);
+                tenantId, clientAppId, ct, GraphAuthenticationMode.ResolvedClientApp);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -1036,6 +1034,31 @@ public sealed class ClientAppValidator : IClientAppValidator
         return hasWids;
     }
 
+    /// <inheritdoc />
+    public async Task<bool?> HasWidsClaimOnIssuedAccessTokenAsync(
+        string clientAppId,
+        string tenantId,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientAppId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        string? token;
+        try
+        {
+            // User.Read matches the scope set used by the role check, so the token is served from
+            // the provider cache instead of triggering a second interactive sign-in.
+            token = await _graphApiService.GetClientAppAccessTokenAsync(
+                tenantId, clientAppId, [AuthenticationConstants.UserReadScope], ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException || !ct.IsCancellationRequested)
+        {
+            _logger.LogDebug(ex, "Could not acquire an access token for {ClientAppId} to inspect the 'wids' claim.", clientAppId);
+            return null;
+        }
+
+        return JwtHelper.ClaimExists(token, "wids");
+    }
 
     /// <summary>
     /// Read-only check: returns the redirect URIs that are missing from the app registration

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -37,19 +37,22 @@ public sealed class ClientAppValidator : IClientAppValidator
     /// <param name="tenantId">The tenant ID where the app should exist</param>
     /// <param name="skipConfirmation">When true, applies any required app registration fixes without prompting the user.
     /// Use for non-interactive or CI scenarios. Defaults to false (prompt before modifying the app registration).</param>
+    /// <param name="isFirstParty">When true, validates a Microsoft first-party application without
+    /// mutating its Entra app registration — see <see cref="EnsureValidFirstPartyClientAppAsync"/>.</param>
     /// <param name="ct">Cancellation token</param>
     /// <exception cref="ClientAppValidationException">Thrown when validation fails</exception>
     public async Task EnsureValidClientAppAsync(
         string clientAppId,
         string tenantId,
         bool skipConfirmation = false,
+        bool isFirstParty = false,
         CancellationToken ct = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(clientAppId);
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
 
         // Step 1: Validate GUID format
-        if (!Guid.TryParse(clientAppId, out _))
+        if (!Guid.TryParse(clientAppId, out var parsedClientAppId))
         {
             throw ClientAppValidationException.ValidationFailed(
                 $"clientAppId must be a valid GUID format (received: {clientAppId})",
@@ -67,6 +70,13 @@ public sealed class ClientAppValidator : IClientAppValidator
 
         try
         {
+            // Never run tenant-owned mutation logic against Microsoft's application registration.
+            if (isFirstParty || AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+            {
+                await EnsureValidFirstPartyClientAppAsync(parsedClientAppId.ToString("D"), tenantId, ct);
+                return;
+            }
+
             // Step 2: Verify app exists (token acquisition is handled inside GraphApiService)
             var appInfo = await GetClientAppInfoAsync(clientAppId, tenantId, ct);
             if (appInfo == null)
@@ -340,6 +350,98 @@ public sealed class ClientAppValidator : IClientAppValidator
     }
 
     /// <summary>
+    /// Validates first-party service-principal presence and delegated token scopes without mutation.
+    /// </summary>
+    private async Task EnsureValidFirstPartyClientAppAsync(string clientAppId, string tenantId, CancellationToken ct)
+    {
+        GraphApiService.ServicePrincipalLookupResult lookup;
+        try
+        {
+            lookup = await _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                tenantId, clientAppId, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                clientAppId, tenantId, ex.Message);
+        }
+
+        if (lookup is null || !lookup.IsSuccess)
+        {
+            throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                clientAppId,
+                tenantId,
+                lookup?.FailureReason ?? "Service-principal lookup returned no result.");
+        }
+
+        if (string.IsNullOrWhiteSpace(lookup.ServicePrincipalId))
+        {
+            throw ClientAppValidationException.FirstPartyServicePrincipalNotFound(clientAppId, tenantId);
+        }
+
+        _logger.LogDebug(
+            "First-party service principal {SpId} found for {ClientAppId} — no app-registration mutations will be attempted.",
+            lookup.ServicePrincipalId, clientAppId);
+
+        // Keep the registration scope separate because Entra can reject a combined request before
+        // returning a token whose scp claim identifies the unavailable permission.
+        await ValidateFirstPartyTokenScopesAsync(
+            clientAppId,
+            tenantId,
+            AuthenticationConstants.BlueprintOperationScopes,
+            ct);
+        await ValidateFirstPartyTokenScopesAsync(
+            clientAppId,
+            tenantId,
+            [AuthenticationConstants.AgentRegistrationReadWriteAllScope],
+            ct);
+
+        _logger.LogDebug(
+            "First-party client app validation successful for {ClientAppId} — all required scopes present on delegated tokens.",
+            clientAppId);
+    }
+
+    private async Task ValidateFirstPartyTokenScopesAsync(
+        string clientAppId,
+        string tenantId,
+        IReadOnlyCollection<string> requiredScopes,
+        CancellationToken ct)
+    {
+        string? token;
+        try
+        {
+            token = await _graphApiService.GetClientAppAccessTokenAsync(tenantId, clientAppId, requiredScopes, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw ClientAppValidationException.FirstPartyAuthorizationFailed(
+                clientAppId, requiredScopes, ex.Message);
+        }
+
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            throw ClientAppValidationException.FirstPartyAuthorizationFailed(
+                clientAppId, requiredScopes, "Token acquisition returned no result.");
+        }
+
+        if (!JwtHelper.TryDecodeSpaceDelimitedClaim(
+                token,
+                "scp",
+                out var grantedScopes,
+                out var decodeFailureReason))
+        {
+            throw ClientAppValidationException.FirstPartyAuthorizationFailed(
+                clientAppId, requiredScopes, decodeFailureReason);
+        }
+
+        var missingScopes = requiredScopes.Where(s => !grantedScopes.Contains(s)).ToList();
+        if (missingScopes.Count > 0)
+        {
+            throw ClientAppValidationException.FirstPartyMissingPermissions(clientAppId, missingScopes);
+        }
+    }
+
+    /// <summary>
     /// Ensures the client app has required redirect URIs configured for Microsoft Graph PowerShell SDK.
     /// Automatically adds missing redirect URIs if needed (self-healing).
     /// </summary>
@@ -353,6 +455,12 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(clientAppId);
         ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+        {
+            _logger.LogDebug("Skipping redirect URI mutation for the first-party Agent 365 CLI application.");
+            return;
+        }
 
         try
         {
@@ -878,13 +986,18 @@ public sealed class ClientAppValidator : IClientAppValidator
 
     /// <summary>
     /// Returns the subset of <see cref="AuthenticationConstants.RequiredClientAppPermissions"/>
-    /// that are not yet present in the client app's oauth2PermissionGrant (i.e. not consented).
+    /// missing from a custom app's grant; first-party authorization is token-based and returns empty.
     /// </summary>
     public async Task<List<string>> GetUnconsentedRequiredPermissionsAsync(
         string clientAppId,
         string tenantId,
         CancellationToken ct = default)
     {
+        if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+        {
+            return [];
+        }
+
         var consented = await GetConsentedPermissionsAsync(clientAppId, tenantId, ct);
         return AuthenticationConstants.RequiredClientAppPermissions
             .Where(p => !consented.Contains(p, StringComparer.OrdinalIgnoreCase))
@@ -892,7 +1005,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     }
 
     /// <summary>
-    /// Extends the client app's oauth2PermissionGrant to include the specified permissions.
+    /// Extends a custom client app's oauth2PermissionGrant to include the specified permissions.
     /// Call after the user has confirmed they want to grant admin consent.
     /// </summary>
     public Task GrantConsentForPermissionsAsync(
@@ -900,7 +1013,15 @@ public sealed class ClientAppValidator : IClientAppValidator
         List<string> permissions,
         string tenantId,
         CancellationToken ct = default)
-        => TryExtendConsentGrantScopesAsync(clientAppId, permissions, tenantId, ct);
+    {
+        if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId))
+        {
+            throw new InvalidOperationException(
+                "Tenant-local consent grants cannot be modified for the first-party Agent 365 CLI application.");
+        }
+
+        return TryExtendConsentGrantScopesAsync(clientAppId, permissions, tenantId, ct);
+    }
 
     /// <inheritdoc />
     public async Task<bool> HasWidsAccessTokenOptionalClaimAsync(

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -563,19 +563,92 @@ public class ConfigService : IConfigService
                 return;
             }
 
-            // If a clientAppId is configured, validate it still exists.
+            // Guard against OData injection: configuredId comes from a user-editable file, so it
+            // must be a valid GUID before it is interpolated into any Graph $filter query below.
+            if (!string.IsNullOrWhiteSpace(configuredId) && !Guid.TryParse(configuredId, out _))
+            {
+                _logger?.LogWarning("Configured clientAppId '{Id}' in a365.config.json is not a valid GUID — ignoring.", configuredId);
+                configuredId = null;
+            }
+
+            // If a clientAppId is configured, validate it still exists. The well-known first-party
+            // application is validated via /servicePrincipals (a customer tenant may contain only
+            // the manager-created service principal, with no tenant-local application object);
+            // any other (custom) app ID keeps the original /applications-based existence check.
             if (!string.IsNullOrWhiteSpace(configuredId))
             {
-                var exists = await graphApiService.ApplicationExistsByAppIdAsync(tenantId, configuredId, ct);
+                bool exists;
+                if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(configuredId))
+                {
+                    var lookup = await graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                        tenantId, AuthenticationConstants.WellKnownClientAppId, ct);
+                    if (lookup is null || !lookup.IsSuccess)
+                    {
+                        throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                            AuthenticationConstants.WellKnownClientAppId,
+                            tenantId,
+                            lookup?.FailureReason ?? "Service-principal lookup returned no result.");
+                    }
+
+                    exists = !string.IsNullOrWhiteSpace(lookup.ServicePrincipalId);
+                }
+                else
+                {
+                    var applicationLookup = await graphApiService.LookupApplicationByAppIdWithResponseAsync(
+                        tenantId, configuredId, ct);
+                    if (applicationLookup is null || !applicationLookup.IsSuccess)
+                    {
+                        _logger?.LogWarning(
+                            "Could not verify configured clientAppId {Id}; preserving the existing configuration. {Reason}",
+                            configuredId,
+                            applicationLookup?.FailureReason ?? "Application lookup returned no result.");
+                        return;
+                    }
+
+                    exists = !string.IsNullOrWhiteSpace(applicationLookup.ApplicationId);
+                }
+
                 if (exists)
                 {
+                    if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(configuredId) &&
+                        !string.Equals(configuredId, AuthenticationConstants.WellKnownClientAppId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        await PatchClientAppIdInConfigFileAsync(
+                            configPath, AuthenticationConstants.WellKnownClientAppId, ct);
+                    }
+
                     _logger?.LogDebug("Configured clientAppId {Id} is valid.", configuredId);
                     return;
                 }
 
                 _logger?.LogInformation(
-                    "Configured clientAppId {Id} was not found in the tenant. Looking up by display name '{Name}'...",
-                    configuredId, AuthenticationConstants.WellKnownClientAppDisplayName);
+                    "Configured clientAppId {Id} was not found in the tenant. Looking up a replacement...",
+                    configuredId);
+            }
+
+            // Prefer the well-known first-party Agent 365 CLI application before falling back to a
+            // tenant-owned custom app discovered by display name — preserves existing custom-app
+            // behavior for tenants that registered their own "Agent 365 CLI" app.
+            if (!AuthenticationConstants.IsWellKnownFirstPartyClientApp(configuredId))
+            {
+                var firstPartyLookup = await graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, ct);
+                if (firstPartyLookup is null || !firstPartyLookup.IsSuccess)
+                {
+                    throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                        AuthenticationConstants.WellKnownClientAppId,
+                        tenantId,
+                        firstPartyLookup?.FailureReason ?? "Service-principal lookup returned no result.");
+                }
+
+                if (!string.IsNullOrWhiteSpace(firstPartyLookup.ServicePrincipalId))
+                {
+                    await PatchClientAppIdInConfigFileAsync(configPath, AuthenticationConstants.WellKnownClientAppId, ct);
+                    _logger?.LogInformation(
+                        "clientAppId updated to {NewId} (first-party Agent 365 CLI application). a365.config.json has been updated.",
+                        AuthenticationConstants.WellKnownClientAppId);
+                    return;
+                }
             }
 
             // Look up by well-known display name.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ConfigService.cs
@@ -584,10 +584,10 @@ public class ConfigService : IConfigService
                         tenantId, AuthenticationConstants.WellKnownClientAppId, ct);
                     if (lookup is null || !lookup.IsSuccess)
                     {
-                        throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
-                            AuthenticationConstants.WellKnownClientAppId,
-                            tenantId,
+                        LogInconclusiveClientAppLookup(
+                            configuredId,
                             lookup?.FailureReason ?? "Service-principal lookup returned no result.");
+                        return;
                     }
 
                     exists = !string.IsNullOrWhiteSpace(lookup.ServicePrincipalId);
@@ -598,8 +598,7 @@ public class ConfigService : IConfigService
                         tenantId, configuredId, ct);
                     if (applicationLookup is null || !applicationLookup.IsSuccess)
                     {
-                        _logger?.LogWarning(
-                            "Could not verify configured clientAppId {Id}; preserving the existing configuration. {Reason}",
+                        LogInconclusiveClientAppLookup(
                             configuredId,
                             applicationLookup?.FailureReason ?? "Application lookup returned no result.");
                         return;
@@ -635,10 +634,10 @@ public class ConfigService : IConfigService
                     tenantId, AuthenticationConstants.WellKnownClientAppId, ct);
                 if (firstPartyLookup is null || !firstPartyLookup.IsSuccess)
                 {
-                    throw ClientAppValidationException.FirstPartyServicePrincipalLookupFailed(
+                    LogInconclusiveClientAppLookup(
                         AuthenticationConstants.WellKnownClientAppId,
-                        tenantId,
                         firstPartyLookup?.FailureReason ?? "Service-principal lookup returned no result.");
+                    return;
                 }
 
                 if (!string.IsNullOrWhiteSpace(firstPartyLookup.ServicePrincipalId))
@@ -683,6 +682,19 @@ public class ConfigService : IConfigService
         {
             _logger?.LogDebug(ex, "Client app ID resolution skipped due to error: {Message}", ex.Message);
         }
+    }
+
+    /// <summary>
+    /// Reports a client app lookup that could neither confirm nor disprove the app's presence.
+    /// The existing configuration is preserved — a failed lookup is not evidence of absence.
+    /// </summary>
+    private void LogInconclusiveClientAppLookup(string clientAppId, string reason)
+    {
+        _logger?.LogWarning(
+            "Could not verify client app {Id}; no configuration changes were made. {Reason} " +
+            "Run 'a365 setup requirements' for full diagnostics if commands fail.",
+            clientAppId,
+            reason);
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/DelegatedConsentService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/DelegatedConsentService.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 
 /// <summary>
-/// Ensures oauth2PermissionGrant exists for the custom client application.
+/// Ensures oauth2PermissionGrant exists for a tenant-owned custom client application.
 /// Validates that AgentIdentityBlueprint.ReadWrite.All permission is granted, which is required for creating and managing Agent Blueprints.
 /// </summary>
 public sealed class DelegatedConsentService
@@ -69,6 +69,13 @@ public sealed class DelegatedConsentService
             {
                 _logger.LogError("Invalid Tenant ID format: {TenantId}", tenantId);
                 return false;
+            }
+
+            if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(callingAppId))
+            {
+                _logger.LogDebug(
+                    "Skipping tenant-local delegated consent grant for the first-party Agent 365 CLI application.");
+                return true;
             }
 
             // Get Graph access token with required scopes

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -75,6 +75,30 @@ public class GraphApiService
         public JsonDocument? Json { get; init; }
     }
 
+    /// <summary>
+    /// Status-bearing result for a service-principal lookup. A successful result with a null
+    /// <see cref="ServicePrincipalId"/> means Graph completed the query and found no match.
+    /// </summary>
+    public sealed record ServicePrincipalLookupResult
+    {
+        public bool IsSuccess { get; init; }
+        public string? ServicePrincipalId { get; init; }
+        public int StatusCode { get; init; }
+        public string FailureReason { get; init; } = string.Empty;
+    }
+
+    /// <summary>
+    /// Status-bearing result for an application lookup. A successful result with a null
+    /// <see cref="ApplicationId"/> means Graph completed the query and found no match.
+    /// </summary>
+    public sealed record ApplicationLookupResult
+    {
+        public bool IsSuccess { get; init; }
+        public string? ApplicationId { get; init; }
+        public int StatusCode { get; init; }
+        public string FailureReason { get; init; } = string.Empty;
+    }
+
     // Allow injecting a custom HttpMessageHandler for unit testing.
     // loginHintResolver: optional override for login-hint resolution.
     // Pass () => Task.FromResult<string?>(null) in unit tests to skip login-hint resolution.
@@ -170,7 +194,36 @@ public class GraphApiService
     }
 
 
-    private async Task<bool> EnsureGraphHeadersAsync(string tenantId, bool forceRefresh = false, IEnumerable<string>? scopes = null, CancellationToken ct = default)
+    /// <summary>
+    /// Acquires a delegated access token for a client app so its own claims (e.g. 'scp') can be
+    /// inspected directly. Returns null if no token provider is configured; other failures propagate.
+    /// </summary>
+    public virtual async Task<string?> GetClientAppAccessTokenAsync(
+        string tenantId, string clientAppId, IEnumerable<string> scopes, CancellationToken ct = default)
+    {
+        if (_tokenProvider == null)
+        {
+            _logger.LogDebug("Cannot acquire an access token for client app {ClientAppId} — no token provider configured.", clientAppId);
+            return null;
+        }
+
+        var loginHint = await ResolveLoginHintAsync();
+        return await _tokenProvider.GetMgGraphAccessTokenAsync(
+            tenantId,
+            scopes,
+            useDeviceCode: false,
+            clientAppId: clientAppId,
+            ct: ct,
+            loginHint: loginHint,
+            forceRefresh: false);
+    }
+
+    private async Task<bool> EnsureGraphHeadersAsync(
+        string tenantId,
+        bool forceRefresh = false,
+        IEnumerable<string>? scopes = null,
+        CancellationToken ct = default,
+        string? authenticationClientAppId = null)
     {
         // Authentication strategy:
         //
@@ -195,7 +248,10 @@ public class GraphApiService
 
         string? token;
         bool hasScopes = scopes?.Any() == true;
-        bool hasCustomApp = !string.IsNullOrWhiteSpace(CustomClientAppId);
+        var effectiveClientAppId = string.IsNullOrWhiteSpace(authenticationClientAppId)
+            ? CustomClientAppId
+            : authenticationClientAppId;
+        bool hasCustomApp = !string.IsNullOrWhiteSpace(effectiveClientAppId);
 
         // Use the token provider when the caller passed explicit scopes (the call site is asking
         // for a scoped token — clientId can be null until config resolves; production callers that
@@ -208,9 +264,10 @@ public class GraphApiService
             var effectiveScopes = hasScopes ? scopes! : [AuthenticationConstants.UserReadScope];
             _logger.LogDebug(
                 "Acquiring Graph token via token provider (clientId: {AppId}, scopes: {Scopes})",
-                CustomClientAppId, string.Join(", ", effectiveScopes));
+                effectiveClientAppId, string.Join(", ", effectiveScopes));
             var loginHint = await ResolveLoginHintAsync();
-            token = await _tokenProvider.GetMgGraphAccessTokenAsync(tenantId, effectiveScopes, false, CustomClientAppId, ct, loginHint, forceRefresh);
+            token = await _tokenProvider.GetMgGraphAccessTokenAsync(
+                tenantId, effectiveScopes, false, effectiveClientAppId, ct, loginHint, forceRefresh);
 
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -337,9 +394,20 @@ public class GraphApiService
     /// Use this instead of GraphGetAsync when the caller needs to distinguish auth failures
     /// (401) from transient server errors (503, 429, network exceptions).
     /// </summary>
-    public virtual async Task<GraphResponse> GraphGetWithResponseAsync(string tenantId, string relativePath, bool forceRefresh = false, IEnumerable<string>? scopes = null, CancellationToken ct = default)
+    public virtual async Task<GraphResponse> GraphGetWithResponseAsync(
+        string tenantId,
+        string relativePath,
+        bool forceRefresh = false,
+        IEnumerable<string>? scopes = null,
+        CancellationToken ct = default,
+        string? authenticationClientAppId = null)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, forceRefresh: forceRefresh, scopes: scopes, ct: ct))
+        if (!await EnsureGraphHeadersAsync(
+                tenantId,
+                forceRefresh: forceRefresh,
+                scopes: scopes,
+                ct: ct,
+                authenticationClientAppId: authenticationClientAppId))
             return new GraphResponse { IsSuccess = false, StatusCode = 0, ReasonPhrase = "NoAuth", Body = "Failed to acquire token" };
 
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
@@ -354,7 +422,14 @@ public class GraphApiService
                 JsonDocument? json = null;
                 if (resp.IsSuccessStatusCode && !string.IsNullOrWhiteSpace(body))
                 {
-                    try { json = JsonDocument.Parse(body); } catch { /* ignore parse errors */ }
+                    try
+                    {
+                        json = JsonDocument.Parse(body);
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogDebug(ex, "Graph GET {Url} returned invalid JSON", url);
+                    }
                 }
 
                 if (!resp.IsSuccessStatusCode)
@@ -371,7 +446,7 @@ public class GraphApiService
                 };
             }, cancellationToken: ct);
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             if (NetworkHelper.IsConnectionResetByProxy(ex))
                 _logger.LogWarning(NetworkHelper.ConnectionResetWarning);
@@ -553,7 +628,7 @@ public class GraphApiService
     public virtual async Task<string?> LookupServicePrincipalByAppIdAsync(
         string tenantId, string appId, CancellationToken ct = default, IEnumerable<string>? scopes = null)
     {
-        // $filter=appId eq is "Default+Advanced" per Graph docs -� no ConsistencyLevel header required.
+        // $filter=appId eq is "Default+Advanced" per Graph docs - no ConsistencyLevel header required.
         // The token must have Application.Read.All; pass scopes to ensure MSAL token is used when needed.
         using var doc = await GraphGetAsync(
             tenantId,
@@ -563,6 +638,97 @@ public class GraphApiService
         if (doc == null) return null;
         if (!doc.RootElement.TryGetProperty("value", out var value) || value.GetArrayLength() == 0) return null;
         return value[0].GetProperty("id").GetString();
+    }
+
+    /// <summary>
+    /// Looks up a service principal by application ID while preserving the distinction between
+    /// a successful empty result and an authentication, HTTP, network, or response-format failure.
+    /// Requests the delegated <c>Application.Read.All</c> scope required by this Graph query.
+    /// </summary>
+    public virtual async Task<ServicePrincipalLookupResult> LookupServicePrincipalByAppIdWithResponseAsync(
+        string tenantId,
+        string appId,
+        CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(appId, out var validAppId))
+        {
+            return new ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                FailureReason = $"Invalid service-principal appId '{appId}'. Expected a GUID."
+            };
+        }
+
+        var normalizedAppId = validAppId.ToString("D");
+        var authenticationClientAppId =
+            AuthenticationConstants.IsWellKnownFirstPartyClientApp(normalizedAppId)
+                ? AuthenticationConstants.WellKnownClientAppId
+                : null;
+        var response = await GraphGetWithResponseAsync(
+            tenantId,
+            $"/v1.0/servicePrincipals?$filter=appId eq '{normalizedAppId}'&$select=id",
+            scopes: [AuthenticationConstants.ApplicationReadAllScope],
+            ct: ct,
+            authenticationClientAppId: authenticationClientAppId);
+        using var responseJson = response.Json;
+
+        if (!response.IsSuccess)
+        {
+            var status = response.StatusCode > 0
+                ? $"HTTP {response.StatusCode} {response.ReasonPhrase}".TrimEnd()
+                : response.ReasonPhrase;
+            return new ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = string.IsNullOrWhiteSpace(status)
+                    ? "Microsoft Graph service-principal lookup failed before a response was received."
+                    : $"Microsoft Graph service-principal lookup failed: {status}."
+            };
+        }
+
+        if (responseJson is null ||
+            responseJson.RootElement.ValueKind != JsonValueKind.Object ||
+            !responseJson.RootElement.TryGetProperty("value", out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            return new ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = "Microsoft Graph returned an invalid service-principal lookup response."
+            };
+        }
+
+        if (value.GetArrayLength() == 0)
+        {
+            return new ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = response.StatusCode
+            };
+        }
+
+        var firstResult = value[0];
+        if (firstResult.ValueKind != JsonValueKind.Object ||
+            !firstResult.TryGetProperty("id", out var id) ||
+            id.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(id.GetString()))
+        {
+            return new ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = "Microsoft Graph returned a service-principal result without a valid object ID."
+            };
+        }
+
+        return new ServicePrincipalLookupResult
+        {
+            IsSuccess = true,
+            ServicePrincipalId = id.GetString(),
+            StatusCode = response.StatusCode
+        };
     }
 
     /// <summary>
@@ -585,22 +751,96 @@ public class GraphApiService
     }
 
     /// <summary>
-    /// Checks whether an Entra application with the given appId exists in the tenant.
-    /// Uses the default az CLI token — does not require CustomClientAppId to be set.
-    /// Returns false on any error so callers can fall back gracefully.
+    /// Looks up an Entra application by appId while preserving the distinction between absence
+    /// and an authentication, HTTP, network, or response-format failure.
     /// Virtual to allow mocking in unit tests.
+    /// </summary>
+    public virtual async Task<ApplicationLookupResult> LookupApplicationByAppIdWithResponseAsync(
+        string tenantId, string appId, CancellationToken ct = default)
+    {
+        if (!Guid.TryParse(appId, out var validGuid))
+        {
+            return new ApplicationLookupResult
+            {
+                IsSuccess = false,
+                FailureReason = $"Invalid application appId '{appId}'. Expected a GUID."
+            };
+        }
+
+        var response = await GraphGetWithResponseAsync(
+            tenantId,
+            $"/v1.0/applications?$filter=appId eq '{validGuid:D}'&$select=appId&$top=1",
+            ct: ct);
+        using var responseJson = response.Json;
+
+        if (!response.IsSuccess)
+        {
+            var status = response.StatusCode > 0
+                ? $"HTTP {response.StatusCode} {response.ReasonPhrase}".TrimEnd()
+                : response.ReasonPhrase;
+            return new ApplicationLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = string.IsNullOrWhiteSpace(status)
+                    ? "Microsoft Graph application lookup failed before a response was received."
+                    : $"Microsoft Graph application lookup failed: {status}."
+            };
+        }
+
+        if (responseJson is null ||
+            responseJson.RootElement.ValueKind != JsonValueKind.Object ||
+            !responseJson.RootElement.TryGetProperty("value", out var value) ||
+            value.ValueKind != JsonValueKind.Array)
+        {
+            return new ApplicationLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = "Microsoft Graph returned an invalid application lookup response."
+            };
+        }
+
+        if (value.GetArrayLength() == 0)
+        {
+            return new ApplicationLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = response.StatusCode
+            };
+        }
+
+        var firstResult = value[0];
+        if (firstResult.ValueKind != JsonValueKind.Object ||
+            !firstResult.TryGetProperty("appId", out var returnedAppId) ||
+            returnedAppId.ValueKind != JsonValueKind.String ||
+            string.IsNullOrWhiteSpace(returnedAppId.GetString()))
+        {
+            return new ApplicationLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = response.StatusCode,
+                FailureReason = "Microsoft Graph returned an application result without a valid appId."
+            };
+        }
+
+        return new ApplicationLookupResult
+        {
+            IsSuccess = true,
+            ApplicationId = returnedAppId.GetString(),
+            StatusCode = response.StatusCode
+        };
+    }
+
+    /// <summary>
+    /// Checks whether an Entra application with the given appId exists in the tenant.
+    /// Returns false when the app is absent or the lookup is inconclusive.
     /// </summary>
     public virtual async Task<bool> ApplicationExistsByAppIdAsync(
         string tenantId, string appId, CancellationToken ct = default)
     {
-        if (!Guid.TryParse(appId, out var validGuid)) return false;
-
-        using var doc = await GraphGetAsync(
-            tenantId,
-            $"/v1.0/applications?$filter=appId eq '{validGuid:D}'&$select=appId&$top=1",
-            ct);
-        if (doc == null) return false;
-        return doc.RootElement.TryGetProperty("value", out var value) && value.GetArrayLength() > 0;
+        var result = await LookupApplicationByAppIdWithResponseAsync(tenantId, appId, ct);
+        return result.IsSuccess && !string.IsNullOrWhiteSpace(result.ApplicationId);
     }
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -223,7 +223,7 @@ public class GraphApiService
         bool forceRefresh = false,
         IEnumerable<string>? scopes = null,
         CancellationToken ct = default,
-        string? authenticationClientAppId = null)
+        GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.ResolvedClientApp)
     {
         // Authentication strategy:
         //
@@ -244,14 +244,16 @@ public class GraphApiService
         //    that need claims from the custom-app JWT (e.g. CheckDirectoryRoleAsync) must guard
         //    for both `_tokenProvider == null` and an empty `CustomClientAppId` themselves.
         //
+        // 4. GraphAuthenticationMode.Ambient: the caller is probing whether a client app exists.
+        //    Authenticating as that app would make its own absence unverifiable, so the resolved
+        //    client app and requested scopes are ignored and the bootstrap path below is used.
+        //
         // All paths go through MSAL — no az CLI subprocess involved.
 
         string? token;
-        bool hasScopes = scopes?.Any() == true;
-        var effectiveClientAppId = string.IsNullOrWhiteSpace(authenticationClientAppId)
-            ? CustomClientAppId
-            : authenticationClientAppId;
-        bool hasCustomApp = !string.IsNullOrWhiteSpace(effectiveClientAppId);
+        bool useAmbient = authenticationMode == GraphAuthenticationMode.Ambient;
+        bool hasScopes = !useAmbient && scopes?.Any() == true;
+        bool hasCustomApp = !useAmbient && !string.IsNullOrWhiteSpace(CustomClientAppId);
 
         // Use the token provider when the caller passed explicit scopes (the call site is asking
         // for a scoped token — clientId can be null until config resolves; production callers that
@@ -264,10 +266,10 @@ public class GraphApiService
             var effectiveScopes = hasScopes ? scopes! : [AuthenticationConstants.UserReadScope];
             _logger.LogDebug(
                 "Acquiring Graph token via token provider (clientId: {AppId}, scopes: {Scopes})",
-                effectiveClientAppId, string.Join(", ", effectiveScopes));
+                CustomClientAppId, string.Join(", ", effectiveScopes));
             var loginHint = await ResolveLoginHintAsync();
             token = await _tokenProvider.GetMgGraphAccessTokenAsync(
-                tenantId, effectiveScopes, false, effectiveClientAppId, ct, loginHint, forceRefresh);
+                tenantId, effectiveScopes, false, CustomClientAppId, ct, loginHint, forceRefresh);
 
             if (string.IsNullOrWhiteSpace(token))
             {
@@ -400,14 +402,14 @@ public class GraphApiService
         bool forceRefresh = false,
         IEnumerable<string>? scopes = null,
         CancellationToken ct = default,
-        string? authenticationClientAppId = null)
+        GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.ResolvedClientApp)
     {
         if (!await EnsureGraphHeadersAsync(
                 tenantId,
                 forceRefresh: forceRefresh,
                 scopes: scopes,
                 ct: ct,
-                authenticationClientAppId: authenticationClientAppId))
+                authenticationMode: authenticationMode))
             return new GraphResponse { IsSuccess = false, StatusCode = 0, ReasonPhrase = "NoAuth", Body = "Failed to acquire token" };
 
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
@@ -446,7 +448,13 @@ public class GraphApiService
                 };
             }, cancellationToken: ct);
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+        // Only caller-requested cancellation propagates; an HttpClient timeout surfaces as a
+        // TaskCanceledException with no cancellation requested and is a lookup failure, not a cancel.
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
         {
             if (NetworkHelper.IsConnectionResetByProxy(ex))
                 _logger.LogWarning(NetworkHelper.ConnectionResetWarning);
@@ -643,12 +651,14 @@ public class GraphApiService
     /// <summary>
     /// Looks up a service principal by application ID while preserving the distinction between
     /// a successful empty result and an authentication, HTTP, network, or response-format failure.
-    /// Requests the delegated <c>Application.Read.All</c> scope required by this Graph query.
+    /// Defaults to ambient authentication because the app being probed may itself be absent.
+    /// Callers validating an already-resolved app can request resolved-client authentication.
     /// </summary>
     public virtual async Task<ServicePrincipalLookupResult> LookupServicePrincipalByAppIdWithResponseAsync(
         string tenantId,
         string appId,
-        CancellationToken ct = default)
+        CancellationToken ct = default,
+        GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.Ambient)
     {
         if (!Guid.TryParse(appId, out var validAppId))
         {
@@ -660,16 +670,14 @@ public class GraphApiService
         }
 
         var normalizedAppId = validAppId.ToString("D");
-        var authenticationClientAppId =
-            AuthenticationConstants.IsWellKnownFirstPartyClientApp(normalizedAppId)
-                ? AuthenticationConstants.WellKnownClientAppId
-                : null;
         var response = await GraphGetWithResponseAsync(
             tenantId,
             $"/v1.0/servicePrincipals?$filter=appId eq '{normalizedAppId}'&$select=id",
-            scopes: [AuthenticationConstants.ApplicationReadAllScope],
+            scopes: authenticationMode == GraphAuthenticationMode.ResolvedClientApp
+                ? [AuthenticationConstants.ApplicationReadAllScope]
+                : null,
             ct: ct,
-            authenticationClientAppId: authenticationClientAppId);
+            authenticationMode: authenticationMode);
         using var responseJson = response.Json;
 
         if (!response.IsSuccess)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Services;
+
+/// <summary>
+/// Selects which identity a Microsoft Graph request authenticates as.
+/// </summary>
+public enum GraphAuthenticationMode
+{
+    /// <summary>
+    /// Authenticate as the resolved client app (<see cref="GraphApiService.CustomClientAppId"/>)
+    /// when it is available, otherwise fall back to the ambient bootstrap identity.
+    /// </summary>
+    ResolvedClientApp = 0,
+
+    /// <summary>
+    /// Force the ambient bootstrap identity, ignoring the resolved client app and any requested
+    /// scopes. Required when probing whether a client app exists: authenticating as the app being
+    /// probed makes its own absence unverifiable.
+    /// </summary>
+    Ambient = 1
+}

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/JwtHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/JwtHelper.cs
@@ -39,4 +39,86 @@ internal static class JwtHelper
             return null;
         }
     }
+
+    /// <summary>
+    /// Attempts to decode a space-delimited claim (e.g. the v2.0 <c>scp</c> delegated-scope
+    /// claim) into a case-insensitive set. Malformed tokens, invalid JSON, absent claims, and
+    /// non-string claims return a failure reason instead of being conflated with an empty claim.
+    /// </summary>
+    internal static bool TryDecodeSpaceDelimitedClaim(
+        string? jwt,
+        string claimName,
+        out HashSet<string> values,
+        out string failureReason)
+    {
+        values = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(jwt))
+        {
+            failureReason = "The acquired access token was empty.";
+            return false;
+        }
+
+        var parts = jwt.Split('.');
+        if (parts.Length != 3 || string.IsNullOrWhiteSpace(parts[1]))
+        {
+            failureReason = "The acquired access token is not a valid compact JWT.";
+            return false;
+        }
+
+        byte[] payloadBytes;
+        try
+        {
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
+            payload = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+            payloadBytes = Convert.FromBase64String(payload);
+        }
+        catch (FormatException)
+        {
+            failureReason = "The acquired access token contains an invalid Base64Url payload.";
+            return false;
+        }
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(payloadBytes);
+        }
+        catch (JsonException)
+        {
+            failureReason = "The acquired access token payload is not valid JSON.";
+            return false;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                failureReason = "The acquired access token payload is not a JSON object.";
+                return false;
+            }
+
+            if (!document.RootElement.TryGetProperty(claimName, out var claim))
+            {
+                failureReason = $"The acquired access token does not contain a '{claimName}' claim.";
+                return false;
+            }
+
+            if (claim.ValueKind != JsonValueKind.String)
+            {
+                failureReason = $"The acquired access token '{claimName}' claim is not a string.";
+                return false;
+            }
+
+            var raw = claim.GetString();
+            if (!string.IsNullOrWhiteSpace(raw))
+            {
+                values = raw.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            }
+        }
+
+        failureReason = string.Empty;
+        return true;
+    }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/JwtHelper.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Helpers/JwtHelper.cs
@@ -121,4 +121,31 @@ internal static class JwtHelper
         failureReason = string.Empty;
         return true;
     }
+
+    /// <summary>
+    /// Returns whether <paramref name="claimName"/> is present in the JWT payload, or null when
+    /// the token cannot be decoded — an undecodable token proves nothing about the claim.
+    /// </summary>
+    internal static bool? ClaimExists(string? jwt, string claimName)
+    {
+        if (string.IsNullOrWhiteSpace(jwt)) return null;
+        try
+        {
+            var parts = jwt.Split('.');
+            if (parts.Length < 2 || string.IsNullOrWhiteSpace(parts[1])) return null;
+            var payload = parts[1].Replace('-', '+').Replace('_', '/');
+            payload = payload.PadRight(payload.Length + (4 - payload.Length % 4) % 4, '=');
+            using var doc = JsonDocument.Parse(Convert.FromBase64String(payload));
+            if (doc.RootElement.ValueKind != JsonValueKind.Object) return null;
+            return doc.RootElement.TryGetProperty(claimName, out _);
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IClientAppValidator.cs
@@ -17,9 +17,11 @@ public interface IClientAppValidator
     /// <param name="tenantId">The tenant ID where the app should exist</param>
     /// <param name="skipConfirmation">When true, applies any required app registration fixes without prompting the user.
     /// Use for non-interactive or CI scenarios. Defaults to false (prompt before modifying the app registration).</param>
+    /// <param name="isFirstParty">When true, validates a first-party app (e.g. Agent 365 CLI) without
+    /// mutating its Entra registration — presence via /servicePrincipals, scopes via token 'scp' claim.</param>
     /// <param name="ct">Cancellation token</param>
     /// <exception cref="Exceptions.ClientAppValidationException">Thrown when validation fails</exception>
-    Task EnsureValidClientAppAsync(string clientAppId, string tenantId, bool skipConfirmation = false, CancellationToken ct = default);
+    Task EnsureValidClientAppAsync(string clientAppId, string tenantId, bool skipConfirmation = false, bool isFirstParty = false, CancellationToken ct = default);
 
     /// <summary>
     /// Ensures the client app has required redirect URIs configured for Microsoft Graph PowerShell SDK.
@@ -32,13 +34,14 @@ public interface IClientAppValidator
 
     /// <summary>
     /// Returns the subset of required permissions that are not yet present in the client app's
-    /// oauth2PermissionGrant (i.e. not consented). Used to prompt the user before granting.
+    /// oauth2PermissionGrant; returns empty for the Microsoft first-party app.
     /// </summary>
     Task<List<string>> GetUnconsentedRequiredPermissionsAsync(string clientAppId, string tenantId, CancellationToken ct = default);
 
     /// <summary>
-    /// Extends the client app's oauth2PermissionGrant to include the given permissions.
+    /// Extends a custom client app's oauth2PermissionGrant to include the given permissions.
     /// </summary>
+    /// <exception cref="InvalidOperationException">The client app is Microsoft's first-party app.</exception>
     Task GrantConsentForPermissionsAsync(string clientAppId, List<string> permissions, string tenantId, CancellationToken ct = default);
 
     /// <summary>

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IClientAppValidator.cs
@@ -17,11 +17,11 @@ public interface IClientAppValidator
     /// <param name="tenantId">The tenant ID where the app should exist</param>
     /// <param name="skipConfirmation">When true, applies any required app registration fixes without prompting the user.
     /// Use for non-interactive or CI scenarios. Defaults to false (prompt before modifying the app registration).</param>
-    /// <param name="isFirstParty">When true, validates a first-party app (e.g. Agent 365 CLI) without
-    /// mutating its Entra registration — presence via /servicePrincipals, scopes via token 'scp' claim.</param>
     /// <param name="ct">Cancellation token</param>
     /// <exception cref="Exceptions.ClientAppValidationException">Thrown when validation fails</exception>
-    Task EnsureValidClientAppAsync(string clientAppId, string tenantId, bool skipConfirmation = false, bool isFirstParty = false, CancellationToken ct = default);
+    /// <remarks>The well-known first-party Agent 365 CLI app is validated without mutating its Entra
+    /// registration — presence via /servicePrincipals, scopes via the token 'scp' claim.</remarks>
+    Task EnsureValidClientAppAsync(string clientAppId, string tenantId, bool skipConfirmation = false, CancellationToken ct = default);
 
     /// <summary>
     /// Ensures the client app has required redirect URIs configured for Microsoft Graph PowerShell SDK.
@@ -53,4 +53,12 @@ public interface IClientAppValidator
     /// caller decides how to surface either case to the operator.
     /// </summary>
     Task<bool> HasWidsAccessTokenOptionalClaimAsync(string clientAppId, string tenantId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns whether an access token issued to the client app actually carries the <c>wids</c>
+    /// claim, or <c>null</c> when the token could not be acquired or decoded. Used for apps whose
+    /// registration cannot be read from the tenant (the Microsoft first-party app), where the
+    /// issued token is the only available evidence.
+    /// </summary>
+    Task<bool?> HasWidsClaimOnIssuedAccessTokenAsync(string clientAppId, string tenantId, CancellationToken ct = default);
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IConfigService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IConfigService.cs
@@ -98,8 +98,8 @@ public interface IConfigService
     Task InitializeStateAsync(string statePath = "a365.generated.config.json");
 
     /// <summary>
-    /// Validates the configured clientAppId still exists in the tenant and, if not, resolves
-    /// it by looking up the well-known display name "Agent 365 CLI".
+    /// Validates the configured clientAppId, preferring the first-party service principal before
+    /// resolving a tenant-owned custom app named "Agent 365 CLI".
     /// When a new ID is found it is written back to a365.config.json so subsequent LoadAsync
     /// calls return the correct value without manual config edits.
     /// Safe to call before any command — uses az CLI token, not MSAL.

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/LogRedactionService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/LogRedactionService.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using System.Text.RegularExpressions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 
@@ -61,6 +62,7 @@ public sealed class LogRedactionService : ILogRedactionService
         "9b975845-388f-4429-889e-eab1ef63949c", // Agent 365 Observability API
         "8578e004-a5c6-46e7-913e-12f58912df43", // Power Platform API (Connectivity)
         "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1", // Agent 365 Tools (MCP audience, production)
+        AuthenticationConstants.WellKnownClientAppId, // Agent 365 CLI (well-known first-party application)
     };
 
     public LogRedactionResult Redact(string logContent, string sourceFilePath)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -37,11 +37,120 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 /// </summary>
 public sealed class MsalBrowserCredential : TokenCredential
 {
-    private readonly IPublicClientApplication _publicClientApp;
+    internal enum InteractiveAuthenticationMode
+    {
+        Wam,
+        SystemBrowser,
+        DeviceCode
+    }
+
+    internal interface IMsalTokenAcquirer
+    {
+        Task<IReadOnlyList<IAccount>> GetAccountsAsync();
+        Task<AccessToken> AcquireTokenSilentAsync(
+            string[] scopes,
+            IAccount account,
+            bool forceRefresh,
+            CancellationToken cancellationToken);
+        Task<AccessToken> AcquireOperatingSystemAccountSilentAsync(
+            string[] scopes,
+            bool forceRefresh,
+            CancellationToken cancellationToken);
+        Task<AccessToken> AcquireWamAsync(
+            string[] scopes,
+            IAccount? account,
+            string? loginHint,
+            CancellationToken cancellationToken);
+        Task<AccessToken> AcquireSystemBrowserAsync(
+            string[] scopes,
+            string? loginHint,
+            CancellationToken cancellationToken);
+        Task<AccessToken> AcquireDeviceCodeAsync(
+            string[] scopes,
+            ILogger? logger,
+            CancellationToken cancellationToken);
+    }
+
+    private sealed class MsalTokenAcquirer(IPublicClientApplication app) : IMsalTokenAcquirer
+    {
+        public async Task<IReadOnlyList<IAccount>> GetAccountsAsync() =>
+            (await app.GetAccountsAsync()).ToList();
+
+        public async Task<AccessToken> AcquireTokenSilentAsync(
+            string[] scopes,
+            IAccount account,
+            bool forceRefresh,
+            CancellationToken cancellationToken)
+        {
+            var result = await app
+                .AcquireTokenSilent(scopes, account)
+                .WithForceRefresh(forceRefresh)
+                .ExecuteAsync(cancellationToken);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        public async Task<AccessToken> AcquireOperatingSystemAccountSilentAsync(
+            string[] scopes,
+            bool forceRefresh,
+            CancellationToken cancellationToken)
+        {
+            var result = await app
+                .AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount)
+                .WithForceRefresh(forceRefresh)
+                .ExecuteAsync(cancellationToken);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        public async Task<AccessToken> AcquireWamAsync(
+            string[] scopes,
+            IAccount? account,
+            string? loginHint,
+            CancellationToken cancellationToken)
+        {
+            var builder = app.AcquireTokenInteractive(scopes);
+            if (account != null && !string.IsNullOrWhiteSpace(loginHint))
+                builder = builder.WithAccount(account);
+            else if (!string.IsNullOrWhiteSpace(loginHint))
+                builder = builder.WithLoginHint(loginHint);
+            else
+                builder = builder.WithPrompt(Prompt.SelectAccount);
+
+            var result = await builder.ExecuteAsync(cancellationToken);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        public async Task<AccessToken> AcquireSystemBrowserAsync(
+            string[] scopes,
+            string? loginHint,
+            CancellationToken cancellationToken)
+        {
+            var builder = app
+                .AcquireTokenInteractive(scopes)
+                .WithUseEmbeddedWebView(false);
+            if (!string.IsNullOrWhiteSpace(loginHint))
+                builder = builder.WithLoginHint(loginHint);
+
+            var result = await builder.ExecuteAsync(cancellationToken);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+
+        public async Task<AccessToken> AcquireDeviceCodeAsync(
+            string[] scopes,
+            ILogger? logger,
+            CancellationToken cancellationToken)
+        {
+            var result = await app
+                .AcquireTokenWithDeviceCode(scopes, MsalHelper.CreateDeviceCodeCallback(logger))
+                .ExecuteAsync(cancellationToken);
+            return new AccessToken(result.AccessToken, result.ExpiresOn);
+        }
+    }
+
+    private readonly IMsalTokenAcquirer _tokenAcquirer;
     private readonly ILogger? _logger;
     private readonly string _clientAppId;
     private readonly string _tenantId;
-    private readonly bool _useWam;
+    private InteractiveAuthenticationMode _authenticationMode;
     private readonly IntPtr _windowHandle;
     private readonly string? _loginHint;
     private readonly bool _forceRefresh;
@@ -122,9 +231,13 @@ public sealed class MsalBrowserCredential : TokenCredential
         // Get window handle for WAM on Windows
         // Try multiple sources: console window, foreground window, or desktop window
         _windowHandle = IntPtr.Zero;
-        _useWam = useWam && OperatingSystem.IsWindows();
+        _authenticationMode = SelectAuthenticationMode(
+            clientId,
+            useWam,
+            OperatingSystem.IsWindows());
         
-        if (OperatingSystem.IsWindows() && _useWam)
+        if (OperatingSystem.IsWindows() &&
+            _authenticationMode == InteractiveAuthenticationMode.Wam)
         {
             try
             {
@@ -134,8 +247,14 @@ public sealed class MsalBrowserCredential : TokenCredential
             catch (Exception ex)
             {
                 _logger?.LogDebug(ex, "Failed to get window handle");
-                _logger?.LogWarning("Failed to get window handle, falling back to system browser");
-                _useWam = false;
+                _authenticationMode = AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientId)
+                    ? InteractiveAuthenticationMode.DeviceCode
+                    : InteractiveAuthenticationMode.SystemBrowser;
+                _logger?.LogWarning(
+                    "Failed to get a WAM window handle; falling back to {AuthenticationMode}.",
+                    _authenticationMode == InteractiveAuthenticationMode.DeviceCode
+                        ? "device code authentication"
+                        : "the system browser");
             }
         }
 
@@ -147,7 +266,7 @@ public sealed class MsalBrowserCredential : TokenCredential
                 .Create(clientId)
                 .WithAuthority(authority);
 
-        if (_useWam)
+        if (_authenticationMode == InteractiveAuthenticationMode.Wam)
         {
             // Use WAM broker on Windows for native authentication experience
             // WAM provides SSO with Windows accounts and doesn't require browser
@@ -163,6 +282,12 @@ public sealed class MsalBrowserCredential : TokenCredential
                 .WithParentActivityOrWindow(() => _windowHandle)
                 .WithRedirectUri($"ms-appx-web://microsoft.aad.brokerplugin/{clientId}");
         }
+        else if (_authenticationMode == InteractiveAuthenticationMode.DeviceCode)
+        {
+            // The Microsoft-managed CLI app uses WAM on Windows and publishes no localhost
+            // reply URL, so browser callbacks are not valid when WAM is unavailable.
+            _logger?.LogDebug("Configuring device code authentication for the first-party Agent 365 CLI application");
+        }
         else
         {
             // Use system browser on non-Windows platforms or when WAM isn't available
@@ -171,11 +296,47 @@ public sealed class MsalBrowserCredential : TokenCredential
             builder = builder.WithRedirectUri(effectiveRedirectUri);
         }
 
-        _publicClientApp = builder.Build();
+        var publicClientApp = builder.Build();
 
         // Register persistent token cache to share tokens across all MsalBrowserCredential instances.
         // This is crucial for reducing multiple WAM prompts during 'a365 setup all' operations.
-        RegisterPersistentCache(_publicClientApp, _logger);
+        RegisterPersistentCache(publicClientApp, _logger);
+        _tokenAcquirer = new MsalTokenAcquirer(publicClientApp);
+    }
+
+    internal MsalBrowserCredential(
+        string clientId,
+        string tenantId,
+        InteractiveAuthenticationMode authenticationMode,
+        IMsalTokenAcquirer tokenAcquirer,
+        ILogger? logger = null,
+        string? loginHint = null,
+        bool forceRefresh = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(clientId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(tenantId);
+
+        _clientAppId = clientId;
+        _tenantId = tenantId;
+        _authenticationMode = authenticationMode;
+        _tokenAcquirer = tokenAcquirer ?? throw new ArgumentNullException(nameof(tokenAcquirer));
+        _logger = logger;
+        _loginHint = loginHint;
+        _forceRefresh = forceRefresh;
+        _windowHandle = IntPtr.Zero;
+    }
+
+    internal static InteractiveAuthenticationMode SelectAuthenticationMode(
+        string clientId,
+        bool useWam,
+        bool isWindows)
+    {
+        if (useWam && isWindows)
+            return InteractiveAuthenticationMode.Wam;
+
+        return AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientId)
+            ? InteractiveAuthenticationMode.DeviceCode
+            : InteractiveAuthenticationMode.SystemBrowser;
     }
 
     /// <summary>
@@ -364,7 +525,7 @@ public sealed class MsalBrowserCredential : TokenCredential
             // When a login hint is provided, only attempt silent acquisition for the matching account.
             // Do NOT fall back to any other cached account — that would silently return a token for
             // the wrong user (e.g. sellak's cached token when sellakdev is the CLI identity).
-            var accounts = (await _publicClientApp.GetAccountsAsync()).ToList();
+            var accounts = (await _tokenAcquirer.GetAccountsAsync()).ToList();
             IAccount? account;
             if (!string.IsNullOrWhiteSpace(_loginHint))
             {
@@ -382,13 +543,14 @@ public sealed class MsalBrowserCredential : TokenCredential
                 try
                 {
                     _logger?.LogDebug("Attempting to acquire token silently from cache...");
-                    var silentResult = await _publicClientApp
-                        .AcquireTokenSilent(scopes, account)
-                        .WithForceRefresh(_forceRefresh)
-                        .ExecuteAsync(cancellationToken);
+                    var silentResult = await _tokenAcquirer.AcquireTokenSilentAsync(
+                        scopes,
+                        account,
+                        _forceRefresh,
+                        cancellationToken);
 
                     _logger?.LogDebug("Successfully acquired token from cache.");
-                    return new AccessToken(silentResult.AccessToken, silentResult.ExpiresOn);
+                    return silentResult;
                 }
                 catch (MsalUiRequiredException ex)
                 {
@@ -401,21 +563,21 @@ public sealed class MsalBrowserCredential : TokenCredential
             // Before showing interactive WAM: probe silently using the OS account.
             // WAM can detect "Need admin approval" (consent required) without showing any dialog.
             // If detected, print the admin consent URL and exit — WAM dialog is never shown.
-            if (_useWam)
+            if (_authenticationMode == InteractiveAuthenticationMode.Wam)
             {
                 try
                 {
                     _logger?.LogDebug("Probing consent status silently via WAM OS account...");
-                    var probeResult = await _publicClientApp
-                        .AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount)
-                        .WithForceRefresh(_forceRefresh)
-                        .ExecuteAsync(cancellationToken);
+                    var probeResult = await _tokenAcquirer.AcquireOperatingSystemAccountSilentAsync(
+                        scopes,
+                        _forceRefresh,
+                        cancellationToken);
                     _logger?.LogDebug("WAM OS account probe succeeded — consent is granted.");
                     // Only return the OS account token when no login hint is set.
                     // When a hint is provided, the caller wants a specific identity — fall through
                     // to interactive WAM with the hint so the correct user is authenticated.
                     if (string.IsNullOrWhiteSpace(_loginHint))
-                        return new AccessToken(probeResult.AccessToken, probeResult.ExpiresOn);
+                        return probeResult;
                     _logger?.LogDebug("Login hint set — skipping OS account token, proceeding to interactive WAM for {LoginHint}.", _loginHint);
                 }
                 catch (MsalUiRequiredException ex) when (
@@ -432,53 +594,31 @@ public sealed class MsalBrowserCredential : TokenCredential
             // Acquire token interactively.
             // When a login hint is provided, WAM and browser auth will pre-select that identity
             // instead of defaulting to the Windows account or cached account picker.
-            AuthenticationResult interactiveResult;
+            if (_authenticationMode == InteractiveAuthenticationMode.DeviceCode)
+            {
+                return await AcquireTokenWithDeviceCodeFallbackAsync(
+                    scopes,
+                    cancellationToken,
+                    trySilentFirst: false);
+            }
 
-            if (_useWam)
+            if (_authenticationMode == InteractiveAuthenticationMode.Wam)
             {
                 // WAM on Windows - native authentication dialog, no browser needed
                 _logger?.LogInformation("Authenticating via Windows Account Manager...");
-                var builder = _publicClientApp.AcquireTokenInteractive(scopes);
-                if (account != null && !string.IsNullOrWhiteSpace(_loginHint))
-                {
-                    // Caller explicitly identified this account via loginHint and MSAL found it in
-                    // cache — WithAccount is more reliable than WithLoginHint for WAM because it
-                    // passes the internal WAM account reference, not just a UPN.
-                    builder = builder.WithAccount(account);
-                }
-                else if (!string.IsNullOrWhiteSpace(_loginHint))
-                {
-                    // Hint provided (e.g. resolved from az account show) but this account is not
-                    // yet in the MSAL cache (e.g. first sign-in or cache cleared).
-                    // WithLoginHint asks WAM to pre-select this identity in the dialog; WAM honors
-                    // it for registered Work/School accounts so the user only needs to confirm,
-                    // rather than searching for the right account in a blank picker.
-                    builder = builder.WithLoginHint(_loginHint);
-                }
-                else
-                {
-                    // No hint at all — show the account picker so the user can select or add the
-                    // correct account. Using WithAccount for a first-cached "best guess" would lock
-                    // WAM to a stale identity (e.g. an old account from a previous session) with no
-                    // way to switch.
-                    builder = builder.WithPrompt(Prompt.SelectAccount);
-                }
-                interactiveResult = await builder.ExecuteAsync(cancellationToken);
-            }
-            else
-            {
-                // System browser on Mac/Linux
-                _logger?.LogInformation("Opening browser for authentication...");
-                var builder = _publicClientApp
-                    .AcquireTokenInteractive(scopes)
-                    .WithUseEmbeddedWebView(false);
-                if (!string.IsNullOrWhiteSpace(_loginHint))
-                    builder = builder.WithLoginHint(_loginHint);
-                interactiveResult = await builder.ExecuteAsync(cancellationToken);
+                return await _tokenAcquirer.AcquireWamAsync(
+                    scopes,
+                    account,
+                    _loginHint,
+                    cancellationToken);
             }
 
-            _logger?.LogDebug("Successfully acquired token via interactive authentication.");
-            return new AccessToken(interactiveResult.AccessToken, interactiveResult.ExpiresOn);
+            // System browser for tenant-owned custom applications.
+            _logger?.LogInformation("Opening browser for authentication...");
+            return await _tokenAcquirer.AcquireSystemBrowserAsync(
+                scopes,
+                _loginHint,
+                cancellationToken);
         }
         catch (PlatformNotSupportedException ex)
         {
@@ -594,13 +734,16 @@ public sealed class MsalBrowserCredential : TokenCredential
 
     private async Task<AccessToken> AcquireTokenWithDeviceCodeFallbackAsync(
         string[] scopes,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool trySilentFirst = true)
     {
         // Before showing a device code, try to get a cached token.
         // On Linux, the shared in-process cache may already hold a token from an earlier
         // authentication step in the same CLI invocation (e.g., blueprint creation),
         // which can be reused silently without prompting the user again.
-        var accountsList = (await _publicClientApp.GetAccountsAsync()).ToList();
+        var accountsList = trySilentFirst
+            ? (await _tokenAcquirer.GetAccountsAsync()).ToList()
+            : [];
         // Filter by tenant to avoid silently authenticating as the wrong identity when multiple accounts are cached.
         // If multiple accounts share the same tenant (rare), FirstOrDefault picks the first match; this is acceptable
         // since MSAL will re-prompt if the silent acquisition fails for the wrong account.
@@ -616,11 +759,13 @@ public sealed class MsalBrowserCredential : TokenCredential
             try
             {
                 _logger?.LogDebug("Attempting silent token acquisition before device code...");
-                var silentResult = await _publicClientApp
-                    .AcquireTokenSilent(scopes, cachedAccount)
-                    .ExecuteAsync(cancellationToken);
+                var silentResult = await _tokenAcquirer.AcquireTokenSilentAsync(
+                    scopes,
+                    cachedAccount,
+                    forceRefresh: false,
+                    cancellationToken);
                 _logger?.LogDebug("Acquired token silently, skipping device code prompt.");
-                return new AccessToken(silentResult.AccessToken, silentResult.ExpiresOn);
+                return silentResult;
             }
             catch (MsalUiRequiredException)
             {
@@ -637,17 +782,21 @@ public sealed class MsalBrowserCredential : TokenCredential
             }
         }
 
-        _logger?.LogInformation("Falling back to device code authentication...");
+        _logger?.LogInformation(
+            trySilentFirst
+                ? "Falling back to device code authentication..."
+                : "Using device code authentication...");
         _logger?.LogInformation("Please sign in with your Microsoft account");
 
         try
         {
-            var deviceCodeResult = await _publicClientApp
-                .AcquireTokenWithDeviceCode(scopes, MsalHelper.CreateDeviceCodeCallback(_logger))
-                .ExecuteAsync(cancellationToken);
+            var deviceCodeResult = await _tokenAcquirer.AcquireDeviceCodeAsync(
+                scopes,
+                _logger,
+                cancellationToken);
 
             _logger?.LogDebug("Successfully acquired token via device code authentication.");
-            return new AccessToken(deviceCodeResult.AccessToken, deviceCodeResult.ExpiresOn);
+            return deviceCodeResult;
         }
         catch (MsalException msalEx) when (
             msalEx.Message.Contains("AADSTS7000218", StringComparison.Ordinal) ||

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/MsalBrowserCredential.cs
@@ -284,8 +284,8 @@ public sealed class MsalBrowserCredential : TokenCredential
         }
         else if (_authenticationMode == InteractiveAuthenticationMode.DeviceCode)
         {
-            // The Microsoft-managed CLI app uses WAM on Windows and publishes no localhost
-            // reply URL, so browser callbacks are not valid when WAM is unavailable.
+            // The Microsoft-managed CLI app uses WAM on Windows. Its MSAL system-browser flow
+            // is rejected with AADSTS70007 in WSL/non-Windows environments, so use device code.
             _logger?.LogDebug("Configuring device code authentication for the first-party Agent 365 CLI application");
         }
         else

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Extensions.Logging;
@@ -8,23 +9,27 @@ using Microsoft.Extensions.Logging;
 namespace Microsoft.Agents.A365.DevTools.Cli.Services.Requirements.RequirementChecks;
 
 /// <summary>
-/// Requirement check that validates the custom client app configuration
-/// Verifies that the app exists, has required permissions, and admin consent is granted
+/// Validates first-party or custom client-app presence and Microsoft Graph authorization.
 /// </summary>
 public class ClientAppRequirementCheck : RequirementCheck
 {
     private readonly IClientAppValidator _clientAppValidator;
+    private readonly bool _firstParty;
 
-    public ClientAppRequirementCheck(IClientAppValidator clientAppValidator)
+    /// <param name="clientAppValidator">The validator used to check the client app configuration.</param>
+    /// <param name="firstParty">Forces first-party validation semantics; also auto-applied when
+    /// <c>config.ClientAppId</c> is the well-known first-party app, regardless of this flag.</param>
+    public ClientAppRequirementCheck(IClientAppValidator clientAppValidator, bool firstParty = false)
     {
         _clientAppValidator = clientAppValidator ?? throw new ArgumentNullException(nameof(clientAppValidator));
+        _firstParty = firstParty;
     }
 
     /// <inheritdoc />
     public override string Name => "Client App Configuration";
 
     /// <inheritdoc />
-    public override string Description => "Validates that the custom client app exists, has required Microsoft Graph permissions, and admin consent is granted";
+    public override string Description => "Validates that the first-party or custom client app exists and has the required Microsoft Graph authorization";
 
     /// <inheritdoc />
     public override string Category => "Authentication";
@@ -62,10 +67,17 @@ public class ClientAppRequirementCheck : RequirementCheck
 
         try
         {
+            // Automatically apply first-party semantics whenever the resolved client app is
+            // Microsoft's well-known Agent 365 CLI application, in addition to any explicit
+            // --first-party override — Microsoft's own application registration must never be
+            // PATCHed regardless of how the check was invoked.
+            var isFirstParty = _firstParty || AuthenticationConstants.IsWellKnownFirstPartyClientApp(config.ClientAppId);
+
             // Validate the client app using the validator
             await _clientAppValidator.EnsureValidClientAppAsync(
                 config.ClientAppId,
                 config.TenantId,
+                isFirstParty: isFirstParty,
                 ct: cancellationToken
             );
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Extensions.Logging;
@@ -14,15 +13,11 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Services.Requirements.RequirementCh
 public class ClientAppRequirementCheck : RequirementCheck
 {
     private readonly IClientAppValidator _clientAppValidator;
-    private readonly bool _firstParty;
 
     /// <param name="clientAppValidator">The validator used to check the client app configuration.</param>
-    /// <param name="firstParty">Forces first-party validation semantics; also auto-applied when
-    /// <c>config.ClientAppId</c> is the well-known first-party app, regardless of this flag.</param>
-    public ClientAppRequirementCheck(IClientAppValidator clientAppValidator, bool firstParty = false)
+    public ClientAppRequirementCheck(IClientAppValidator clientAppValidator)
     {
         _clientAppValidator = clientAppValidator ?? throw new ArgumentNullException(nameof(clientAppValidator));
-        _firstParty = firstParty;
     }
 
     /// <inheritdoc />
@@ -67,17 +62,11 @@ public class ClientAppRequirementCheck : RequirementCheck
 
         try
         {
-            // Automatically apply first-party semantics whenever the resolved client app is
-            // Microsoft's well-known Agent 365 CLI application, in addition to any explicit
-            // --first-party override — Microsoft's own application registration must never be
-            // PATCHed regardless of how the check was invoked.
-            var isFirstParty = _firstParty || AuthenticationConstants.IsWellKnownFirstPartyClientApp(config.ClientAppId);
-
-            // Validate the client app using the validator
+            // First-party semantics are keyed off the well-known app ID inside the validator, so
+            // Microsoft's own registration is never PATCHed regardless of the call site.
             await _clientAppValidator.EnsureValidClientAppAsync(
                 config.ClientAppId,
                 config.TenantId,
-                isFirstParty: isFirstParty,
                 ct: cancellationToken
             );
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Extensions.Logging;
 
@@ -60,6 +61,12 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
                 errorMessage: "tenantId is not configured",
                 resolutionGuidance: "Configure tenantId in a365.config.json or pass --tenant-id.",
                 details: "The wids optional claim check requires a tenantId to query Graph.");
+        }
+
+        if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(config.ClientAppId))
+        {
+            return RequirementCheckResult.Success(
+                details: "The first-party Agent 365 CLI token configuration is Microsoft-managed; no tenant-local optional-claim changes are required.");
         }
 
         bool hasWids;

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/WidsOptionalClaimRequirementCheck.cs
@@ -65,8 +65,7 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
 
         if (AuthenticationConstants.IsWellKnownFirstPartyClientApp(config.ClientAppId))
         {
-            return RequirementCheckResult.Success(
-                details: "The first-party Agent 365 CLI token configuration is Microsoft-managed; no tenant-local optional-claim changes are required.");
+            return await CheckFirstPartyWidsClaimAsync(config, cancellationToken);
         }
 
         bool hasWids;
@@ -104,6 +103,43 @@ public class WidsOptionalClaimRequirementCheck : RequirementCheck
             resolutionGuidance: manualPatch,
             details: "Without 'wids' in the access token, IsCurrentUserAdminAsync returns Unknown for every user — " +
                 "the orchestrator collapses Unknown to 'not GA' and skips Phase 2b.");
+    }
+
+    /// <summary>
+    /// Verifies <c>wids</c> for the Microsoft first-party app from a token actually issued to it —
+    /// its registration is not readable from the tenant, so the token is the only evidence.
+    /// </summary>
+    private async Task<RequirementCheckResult> CheckFirstPartyWidsClaimAsync(
+        Agent365Config config,
+        CancellationToken cancellationToken)
+    {
+        const string FirstPartyGuidance =
+            "The 'wids' claim is configured by Microsoft on the Agent 365 CLI application and cannot be changed in your tenant. " +
+            "It is also absent when the signed-in account holds no directory role assignment. " +
+            "Sign in with an account that holds Global Administrator (az logout && az login) and re-run this check. " +
+            "If it remains absent, run 'a365 setup blueprint' as a Global Administrator so the blueprint permission grants are not skipped.";
+
+        var hasWids = await _clientAppValidator.HasWidsClaimOnIssuedAccessTokenAsync(
+            config.ClientAppId, config.TenantId, cancellationToken);
+
+        if (hasWids == true)
+        {
+            return RequirementCheckResult.Success(
+                details: $"'wids' is present on an access token issued to {config.ClientAppId}");
+        }
+
+        if (hasWids == false)
+        {
+            return RequirementCheckResult.Warning(
+                message: $"'wids' is not present on the access token issued to the first-party Agent 365 CLI application {config.ClientAppId}. " +
+                    "Global Administrator detection will return Unknown, so blueprint-level AllPrincipals grants may be skipped.",
+                details: FirstPartyGuidance);
+        }
+
+        return RequirementCheckResult.Warning(
+            message: $"Could not verify the 'wids' claim for the first-party Agent 365 CLI application {config.ClientAppId} — " +
+                "no access token was available to inspect.",
+            details: FirstPartyGuidance);
     }
 
     private static string BuildManualPatchInstructions(string clientAppId, string tenantId)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/NonDwBlueprintSetupOrchestratorExecuteTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
@@ -167,6 +168,28 @@ public class NonDwBlueprintSetupOrchestratorExecuteTests
 
         // Blueprint fails → exit 1, but NOT due to requirements check
         exitCode.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FirstPartyClientApp_DoesNotReadOrMutateTenantConsentGrants()
+    {
+        var ctx = BuildContext(new Agent365Config
+        {
+            AiTeammate = false,
+            TenantId = "tenant-id",
+            AgentIdentityDisplayName = "Test Agent",
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+        });
+
+        await NonDwBlueprintSetupOrchestrator.ExecuteAsync(ctx);
+
+        var consentCalls = ctx.ClientAppValidator.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name is
+                nameof(IClientAppValidator.GetUnconsentedRequiredPermissionsAsync) or
+                nameof(IClientAppValidator.GrantConsentForPermissionsAsync))
+            .ToList();
+        consentCalls.Should().BeEmpty(
+            because: "setup must trust validated first-party token preauthorization instead of reading or mutating a tenant-local oauth2PermissionGrant");
     }
 
     /// <summary>

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/RequirementsSubcommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/RequirementsSubcommandTests.cs
@@ -12,8 +12,7 @@ using Microsoft.Agents.A365.DevTools.Cli.Tests.TestHelpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
-using System.CommandLine.Builder;
-using System.CommandLine.IO;
+using System.CommandLine;
 using System.CommandLine.Parsing;
 using Xunit;
 
@@ -291,27 +290,10 @@ public class RequirementsSubcommandTests
 
     #endregion
 
-    #region ClientAppRequirementCheck First-Party Mode Tests
+    #region ClientAppRequirementCheck First-Party Detection Tests
 
     [Fact]
-    public async Task ClientAppRequirementCheck_ExplicitFirstPartyTrue_PassesIsFirstPartyTrueToValidator()
-    {
-        var mockValidator = Substitute.For<IClientAppValidator>();
-        var check = new ClientAppRequirementCheck(mockValidator, firstParty: true);
-        var config = new Agent365Config
-        {
-            ClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
-            TenantId = "12345678-1234-1234-1234-123456789012"
-        };
-
-        await check.CheckAsync(config, _mockLogger);
-
-        await mockValidator.Received(1).EnsureValidClientAppAsync(
-            config.ClientAppId, config.TenantId, isFirstParty: true, ct: Arg.Any<CancellationToken>());
-    }
-
-    [Fact]
-    public async Task ClientAppRequirementCheck_DefaultFirstPartyFalse_WithCustomAppId_PassesIsFirstPartyFalse()
+    public async Task ClientAppRequirementCheck_WithCustomAppId_DelegatesToValidatorUnchanged()
     {
         var mockValidator = Substitute.For<IClientAppValidator>();
         var check = new ClientAppRequirementCheck(mockValidator);
@@ -324,15 +306,15 @@ public class RequirementsSubcommandTests
         await check.CheckAsync(config, _mockLogger);
 
         await mockValidator.Received(1).EnsureValidClientAppAsync(
-            config.ClientAppId, config.TenantId, isFirstParty: false, ct: Arg.Any<CancellationToken>());
+            config.ClientAppId, config.TenantId, ct: Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task ClientAppRequirementCheck_DefaultFirstPartyFalse_WithWellKnownClientAppId_AutoAppliesIsFirstPartyTrue()
+    public async Task ClientAppRequirementCheck_WithWellKnownClientAppId_DelegatesTheWellKnownIdToValidator()
     {
-        // Even without the explicit --first-party flag, resolving to Microsoft's well-known
-        // first-party application must automatically apply first-party semantics — the CLI must
-        // never PATCH Microsoft's own app registration regardless of how the check was invoked.
+        // First-party semantics are derived from the resolved client app ID alone — there is no
+        // caller-supplied override — so the check must pass the ID through untouched and let the
+        // validator apply the non-mutating first-party path.
         var mockValidator = Substitute.For<IClientAppValidator>();
         var check = new ClientAppRequirementCheck(mockValidator);
         var config = new Agent365Config
@@ -344,19 +326,14 @@ public class RequirementsSubcommandTests
         await check.CheckAsync(config, _mockLogger);
 
         await mockValidator.Received(1).EnsureValidClientAppAsync(
-            config.ClientAppId, config.TenantId, isFirstParty: true, ct: Arg.Any<CancellationToken>());
+            AuthenticationConstants.WellKnownClientAppId, config.TenantId, ct: Arg.Any<CancellationToken>());
     }
 
-    #endregion
-
-    #region --first-party CLI Option Tests
-
     [Fact]
-    public async Task Command_WithFirstPartyFlag_ParsesOptionAndLogsFirstPartyMode()
+    public void Command_DoesNotExposeAFirstPartyOption()
     {
-        // Arrange: use a category that matches nothing, so the command short-circuits right
-        // after building the (firstParty-aware) check lists and logging the first-party notice,
-        // without needing a real Azure/Graph bootstrap.
+        // First-party validation is selected by the resolved client app ID, never by a flag: a flag
+        // could force weak first-party validation onto a tenant-owned custom app.
         var mockConfigService = Substitute.For<IConfigService>();
         var mockExecutor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
         var mockAuthValidator = Substitute.ForPartsOf<AzureAuthValidator>(NullLogger<AzureAuthValidator>.Instance, mockExecutor);
@@ -366,19 +343,13 @@ public class RequirementsSubcommandTests
 
         var command = RequirementsSubcommand.CreateCommand(
             _mockLogger, mockConfigService, mockAuthValidator, mockClientAppValidator, mockExecutor, mockGraphApiService);
-        var parser = new CommandLineBuilder(command).Build();
-        var testConsole = new TestConsole();
 
-        var exitCode = await parser.InvokeAsync("--first-party --category NoSuchCategory", testConsole);
+        command.Options.Should().NotContain(
+            option => option.Aliases.Contains("--first-party"),
+            because: "the CLI contract must not offer a flag that applies first-party validation to a tenant-owned custom app");
 
-        exitCode.Should().Be(0,
-            because: "a non-matching --category must short-circuit with a warning, not a failure exit code");
-        _mockLogger.Received().Log(
-            LogLevel.Information,
-            Arg.Any<EventId>(),
-            Arg.Is<object>(o => o.ToString()!.Contains("First-party mode")),
-            Arg.Any<Exception>(),
-            Arg.Any<Func<object, Exception?, string>>());
+        command.Parse("--first-party").Errors.Should().NotBeEmpty(
+            because: "an unrecognized option must be rejected rather than silently ignored");
     }
 
     #endregion

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/RequirementsSubcommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/RequirementsSubcommandTests.cs
@@ -3,6 +3,7 @@
 
 using FluentAssertions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Requirements;
@@ -11,6 +12,9 @@ using Microsoft.Agents.A365.DevTools.Cli.Tests.TestHelpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using System.CommandLine.Builder;
+using System.CommandLine.IO;
+using System.CommandLine.Parsing;
 using Xunit;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
@@ -283,6 +287,98 @@ public class RequirementsSubcommandTests
         allPassed.Should().BeFalse();
         failedCount.Should().Be(2);
         results.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region ClientAppRequirementCheck First-Party Mode Tests
+
+    [Fact]
+    public async Task ClientAppRequirementCheck_ExplicitFirstPartyTrue_PassesIsFirstPartyTrueToValidator()
+    {
+        var mockValidator = Substitute.For<IClientAppValidator>();
+        var check = new ClientAppRequirementCheck(mockValidator, firstParty: true);
+        var config = new Agent365Config
+        {
+            ClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
+            TenantId = "12345678-1234-1234-1234-123456789012"
+        };
+
+        await check.CheckAsync(config, _mockLogger);
+
+        await mockValidator.Received(1).EnsureValidClientAppAsync(
+            config.ClientAppId, config.TenantId, isFirstParty: true, ct: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClientAppRequirementCheck_DefaultFirstPartyFalse_WithCustomAppId_PassesIsFirstPartyFalse()
+    {
+        var mockValidator = Substitute.For<IClientAppValidator>();
+        var check = new ClientAppRequirementCheck(mockValidator);
+        var config = new Agent365Config
+        {
+            ClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6",
+            TenantId = "12345678-1234-1234-1234-123456789012"
+        };
+
+        await check.CheckAsync(config, _mockLogger);
+
+        await mockValidator.Received(1).EnsureValidClientAppAsync(
+            config.ClientAppId, config.TenantId, isFirstParty: false, ct: Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ClientAppRequirementCheck_DefaultFirstPartyFalse_WithWellKnownClientAppId_AutoAppliesIsFirstPartyTrue()
+    {
+        // Even without the explicit --first-party flag, resolving to Microsoft's well-known
+        // first-party application must automatically apply first-party semantics — the CLI must
+        // never PATCH Microsoft's own app registration regardless of how the check was invoked.
+        var mockValidator = Substitute.For<IClientAppValidator>();
+        var check = new ClientAppRequirementCheck(mockValidator);
+        var config = new Agent365Config
+        {
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+            TenantId = "12345678-1234-1234-1234-123456789012"
+        };
+
+        await check.CheckAsync(config, _mockLogger);
+
+        await mockValidator.Received(1).EnsureValidClientAppAsync(
+            config.ClientAppId, config.TenantId, isFirstParty: true, ct: Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region --first-party CLI Option Tests
+
+    [Fact]
+    public async Task Command_WithFirstPartyFlag_ParsesOptionAndLogsFirstPartyMode()
+    {
+        // Arrange: use a category that matches nothing, so the command short-circuits right
+        // after building the (firstParty-aware) check lists and logging the first-party notice,
+        // without needing a real Azure/Graph bootstrap.
+        var mockConfigService = Substitute.For<IConfigService>();
+        var mockExecutor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
+        var mockAuthValidator = Substitute.ForPartsOf<AzureAuthValidator>(NullLogger<AzureAuthValidator>.Instance, mockExecutor);
+        var mockClientAppValidator = Substitute.For<IClientAppValidator>();
+        var mockGraphApiService = Substitute.ForPartsOf<GraphApiService>(
+            Substitute.For<ILogger<GraphApiService>>(), mockExecutor, (Func<Task<string?>>)(() => Task.FromResult<string?>(null)));
+
+        var command = RequirementsSubcommand.CreateCommand(
+            _mockLogger, mockConfigService, mockAuthValidator, mockClientAppValidator, mockExecutor, mockGraphApiService);
+        var parser = new CommandLineBuilder(command).Build();
+        var testConsole = new TestConsole();
+
+        var exitCode = await parser.InvokeAsync("--first-party --category NoSuchCategory", testConsole);
+
+        exitCode.Should().Be(0,
+            because: "a non-matching --category must short-circuit with a warning, not a failure exit code");
+        _mockLogger.Received().Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(o => o.ToString()!.Contains("First-party mode")),
+            Arg.Any<Exception>(),
+            Arg.Any<Func<object, Exception?, string>>());
     }
 
     #endregion

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/SetupCommandTests.cs
@@ -369,6 +369,13 @@ public class SetupCommandTests
 
         // NSubstitute returns null by default for Task<string?> — FindApplicationByDisplayNameAsync
         // returns null, simulating the app not existing in Entra.
+        _mockGraphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
 
         var command = SetupCommand.CreateCommand(
             _mockLogger, _mockConfigService, _mockExecutor, _mockBackendConfigurator,

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/AuthenticationConstantsTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Constants/AuthenticationConstantsTests.cs
@@ -95,4 +95,27 @@ public class AuthenticationConstantsTests
                 because: "the consent-required path keys on the 0xcaa prefix; the declined-scopes signature " +
                          "must not overlap with it or the fallback would trigger on consent errors");
     }
+
+    [Fact]
+    public void WellKnownClientAppId_ShouldBeExpectedFirstPartyGuid()
+    {
+        AuthenticationConstants.WellKnownClientAppId.Should().Be("f54280f4-395e-4ea8-9e48-bf2d4952aa14",
+            because: "setup/bootstrap flows must resolve this exact well-known first-party application " +
+                     "ID as the default client app before falling back to any tenant-owned custom app");
+        Guid.TryParse(AuthenticationConstants.WellKnownClientAppId, out _).Should().BeTrue(
+            because: "the default client app ID must be a valid GUID accepted by Agent365Config.Validate()");
+    }
+
+    [Theory]
+    [InlineData("f54280f4-395e-4ea8-9e48-bf2d4952aa14", true)]
+    [InlineData("F54280F4-395E-4EA8-9E48-BF2D4952AA14", true)]
+    [InlineData("{f54280f4-395e-4ea8-9e48-bf2d4952aa14}", true)]
+    [InlineData("a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6", false)]
+    [InlineData(null, false)]
+    [InlineData("", false)]
+    public void IsWellKnownFirstPartyClientApp_ReturnsExpected(string? clientAppId, bool expected)
+    {
+        AuthenticationConstants.IsWellKnownFirstPartyClientApp(clientAppId).Should().Be(expected,
+            because: "first-party detection must match the well-known ID case-insensitively and reject any other value");
+    }
 }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
@@ -4,6 +4,7 @@
 using FluentAssertions;
 using Microsoft.Agents.A365.DevTools.Cli.Commands.SetupSubcommands;
 using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,22 @@ public class SetupHelpersBootstrapTests : IDisposable
         _mockExecutor = Substitute.For<CommandExecutor>(execLogger);
 
         _mockGraph = Substitute.ForPartsOf<GraphApiService>();
+
+        // Default: the well-known first-party application's service principal is not present.
+        // This preserves the pre-existing custom-app (display-name lookup) behavior exercised by
+        // most tests in this file. Tests that specifically cover the new first-party default path
+        // override this per-test with Arg.Is<string>(id => id == AuthenticationConstants.WellKnownClientAppId).
+        // Configuring this default here (rather than leaving it unmocked) is required: ResolveBootstrapClientAppIdAsync
+        // now checks the first-party service principal before the display-name lookup, and this is a
+        // partial substitute (Substitute.ForPartsOf) — an unconfigured virtual call falls through to the
+        // real GraphApiService implementation, which would attempt a real Graph/MSAL token acquisition.
+        _mockGraph.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
     }
 
     public void Dispose()
@@ -240,6 +257,116 @@ public class SetupHelpersBootstrapTests : IDisposable
         // Assert
         result.Should().Be(clientAppId,
             because: "when Entra lookup succeeds the resolved app ID is returned");
+    }
+
+    // ── First-party default resolution ────────────────────────────────────────
+
+    [Fact]
+    public async Task ResolveBootstrapClientAppIdAsync_WhenFirstPartyServicePrincipalExists_ReturnsWellKnownIdWithoutDisplayNameLookup()
+    {
+        // Arrange: the well-known first-party application's service principal is present in the
+        // tenant (a customer tenant may have only this manager-created SP, no application object).
+        _mockGraph.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(id => id == AuthenticationConstants.WellKnownClientAppId),
+                Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "first-party-sp-object-id",
+                StatusCode = 200
+            });
+
+        // Act
+        var result = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
+            "tenant-id", _mockGraph, NullLogger.Instance, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(AuthenticationConstants.WellKnownClientAppId,
+            because: "the well-known first-party application must be the default identity whenever its service principal is present");
+
+        await _mockGraph.DidNotReceive().FindApplicationByDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _mockGraph.DidNotReceive().ApplicationExistsByAppIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveBootstrapClientAppIdAsync_ChecksFirstPartyIdentityViaServicePrincipalsNotApplications()
+    {
+        // Arrange
+        _mockGraph.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(),
+                Arg.Is<string>(id => id == AuthenticationConstants.WellKnownClientAppId),
+                Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = "first-party-sp-object-id",
+                StatusCode = 200
+            });
+
+        // Act
+        await SetupHelpers.ResolveBootstrapClientAppIdAsync(
+            "tenant-id", _mockGraph, NullLogger.Instance, CancellationToken.None);
+
+        // Assert: the well-known default identity must be resolved/validated via GET /v1.0/servicePrincipals,
+        // never GET /v1.0/applications — customer tenants may contain only the manager-created SP.
+        await _mockGraph.Received(1).LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-id",
+            AuthenticationConstants.WellKnownClientAppId,
+            Arg.Any<CancellationToken>());
+        await _mockGraph.DidNotReceive().ApplicationExistsByAppIdAsync(
+            Arg.Any<string>(), AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveBootstrapClientAppIdAsync_WhenFirstPartyServicePrincipalAbsent_FallsBackToCustomAppDisplayNameLookup()
+    {
+        // Arrange: first-party SP absent (default stub from constructor already returns null for
+        // any appId) — the legacy custom-app-by-display-name flow must still run unchanged.
+        const string customAppId = "custom-app-id";
+        _mockGraph.FindApplicationByDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(customAppId));
+
+        // Act
+        var result = await SetupHelpers.ResolveBootstrapClientAppIdAsync(
+            "tenant-id", _mockGraph, NullLogger.Instance, CancellationToken.None);
+
+        // Assert: preserves existing custom-app behavior when the first-party default is unavailable.
+        result.Should().Be(customAppId,
+            because: "when the first-party application's service principal is absent, resolution must fall back to the tenant-owned custom app discovered by display name");
+
+        await _mockGraph.Received(1).FindApplicationByDisplayNameAsync(
+            Arg.Any<string>(), AuthenticationConstants.WellKnownClientAppDisplayName, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ResolveBootstrapClientAppIdAsync_WhenFirstPartyLookupFails_DoesNotFallBackToCustomAppCreation()
+    {
+        _mockGraph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                AuthenticationConstants.WellKnownClientAppId,
+                Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = 503,
+                FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 503 Service Unavailable."
+            });
+
+        Func<Task> act = async () => await SetupHelpers.ResolveBootstrapClientAppIdAsync(
+            "tenant-id", _mockGraph, NullLogger.Instance, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<ClientAppValidationException>(
+            because: "an operational lookup failure must not be mistaken for an absent first-party service principal");
+        exception.Which.ErrorDetails.Should().Contain(
+            detail => detail.Contains("HTTP 503", StringComparison.Ordinal));
+        await _mockGraph.DidNotReceive().FindApplicationByDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _mockGraph.DidNotReceive().CreateCliClientAppAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Helpers/SetupHelpersBootstrapTests.cs
@@ -370,6 +370,34 @@ public class SetupHelpersBootstrapTests : IDisposable
     }
 
     [Fact]
+    public async Task ResolveBootstrapClientAppIdAsync_WhenFirstPartyLookupCannotAuthenticate_DoesNotFallBackSilently()
+    {
+        // "NoAuth" is what the presence probe reports when no Graph token could be acquired at all.
+        // That is an operational failure, not evidence that the first-party application is absent.
+        _mockGraph.LookupServicePrincipalByAppIdWithResponseAsync(
+                "tenant-id",
+                AuthenticationConstants.WellKnownClientAppId,
+                Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = 0,
+                FailureReason = "Microsoft Graph service-principal lookup failed: NoAuth."
+            });
+
+        Func<Task> act = async () => await SetupHelpers.ResolveBootstrapClientAppIdAsync(
+            "tenant-id", _mockGraph, NullLogger.Instance, CancellationToken.None);
+
+        var exception = await act.Should().ThrowAsync<ClientAppValidationException>(
+            because: "a token-acquisition failure must surface, not be downgraded to a silent custom-app fallback");
+        exception.Which.ErrorDetails.Should().Contain(
+            detail => detail.Contains("NoAuth", StringComparison.Ordinal),
+            because: "the operator needs to see that authentication, not app absence, blocked the lookup");
+        await _mockGraph.DidNotReceive().FindApplicationByDisplayNameAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ResolveBootstrapClientAppIdAsync_DoesNotMutateGraphServiceCustomClientAppId()
     {
         // Arrange: the side effect (graphApiService.CustomClientAppId = ...) was removed from the

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
@@ -7,6 +7,8 @@ using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
 using Xunit;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
@@ -620,6 +622,290 @@ public class Agent365ConfigServiceTests : IDisposable
         Assert.NotNull(state);
         Assert.True(state.ContainsKey("lastUpdated"));
         Assert.True(state.ContainsKey("cliVersion"));
+    }
+
+    #endregion
+
+    #region TryResolveClientAppIdAsync Tests
+
+    private static GraphApiService CreateMockGraphApiService()
+    {
+        var executor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
+        // Full mock (Substitute.For, not ForPartsOf): any unconfigured virtual call returns the
+        // default (null/false) rather than falling through to real Graph/MSAL calls.
+        return Substitute.For<GraphApiService>(Substitute.For<ILogger<GraphApiService>>(), executor);
+    }
+
+    private async Task<string> WriteConfigAndChdirAsync(string? tenantId, string? clientAppId)
+    {
+        var configPath = Path.Combine(_testDirectory, ConfigConstants.DefaultConfigFileName);
+        var json = clientAppId is null
+            ? $$"""{"tenantId":"{{tenantId}}"}"""
+            : $$"""{"tenantId":"{{tenantId}}","clientAppId":"{{clientAppId}}"}""";
+        await File.WriteAllTextAsync(configPath, json);
+        Environment.CurrentDirectory = _testDirectory;
+        return configPath;
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenConfiguredIsFirstPartyAndSpExists_ValidatesViaServicePrincipalsAndDoesNotPatch()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, AuthenticationConstants.WellKnownClientAppId);
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = true,
+                    ServicePrincipalId = "first-party-sp-object-id",
+                    StatusCode = 200
+                });
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(AuthenticationConstants.WellKnownClientAppId,
+                because: "the configured first-party clientAppId is already valid and must be left unchanged");
+
+            await graph.DidNotReceive().ApplicationExistsByAppIdAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await graph.Received(1).LookupServicePrincipalByAppIdWithResponseAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenNoConfiguredId_AndFirstPartyServicePrincipalExists_PatchesToWellKnownIdWithoutDisplayNameLookup()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, clientAppId: null);
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = true,
+                    ServicePrincipalId = "first-party-sp-object-id",
+                    StatusCode = 200
+                });
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(AuthenticationConstants.WellKnownClientAppId,
+                because: "with no configured clientAppId, the well-known first-party application must be written as the default");
+
+            await graph.DidNotReceive().FindApplicationByDisplayNameAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenCustomIdConfiguredAndValid_ValidatesViaApplicationsEndpointNotServicePrincipals()
+    {
+        // Preserves existing custom-app behavior: a non-well-known configured clientAppId must
+        // still be validated via the /applications endpoint, not /servicePrincipals.
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string customAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            await WriteConfigAndChdirAsync(tenantId, customAppId);
+            graph.LookupApplicationByAppIdWithResponseAsync(
+                    tenantId, customAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ApplicationLookupResult
+                {
+                    IsSuccess = true,
+                    ApplicationId = customAppId,
+                    StatusCode = 200
+                });
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            await graph.Received(1).LookupApplicationByAppIdWithResponseAsync(
+                tenantId, customAppId, Arg.Any<CancellationToken>());
+            await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenConfiguredIsFirstPartyButSpGone_FallsBackToDisplayNameWithoutRecheckingFirstParty()
+    {
+        // The configured clientAppId already IS the well-known first-party ID, but its service
+        // principal has since been removed from the tenant. Resolution must fall back to the
+        // custom-app display-name lookup without redundantly re-querying the same first-party SP
+        // a second time (the "prefer first-party" block is skipped once configuredId already
+        // equals the well-known ID and its existence check already failed).
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string resolvedCustomId = "resolved-custom-app-id";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, AuthenticationConstants.WellKnownClientAppId);
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = true,
+                    StatusCode = 200
+                });
+            graph.FindApplicationByDisplayNameAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppDisplayName, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<string?>(resolvedCustomId));
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(resolvedCustomId,
+                because: "when the configured first-party ID's service principal is gone, resolution must fall back to the custom-app display-name lookup");
+
+            await graph.Received(1).LookupServicePrincipalByAppIdWithResponseAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenCustomIdStale_AndFirstPartyAbsent_FallsBackToDisplayNameLookup()
+    {
+        // Preserves existing custom-app behavior when the first-party default is unavailable.
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string staleCustomId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+        const string resolvedCustomId = "resolved-custom-app-id";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, staleCustomId);
+            graph.LookupApplicationByAppIdWithResponseAsync(
+                    tenantId, staleCustomId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ApplicationLookupResult
+                {
+                    IsSuccess = true,
+                    StatusCode = 200
+                });
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = true,
+                    StatusCode = 200
+                });
+            graph.FindApplicationByDisplayNameAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppDisplayName, Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<string?>(resolvedCustomId));
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(resolvedCustomId,
+                because: "when the stale custom ID no longer exists and the first-party default is absent, the tenant-owned custom app found by display name must be used");
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenFirstPartyLookupFails_DoesNotReplaceConfigWithCustomApp()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string staleCustomId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, staleCustomId);
+            graph.LookupApplicationByAppIdWithResponseAsync(
+                    tenantId, staleCustomId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ApplicationLookupResult
+                {
+                    IsSuccess = true,
+                    StatusCode = 200
+                });
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId,
+                    Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = false,
+                    StatusCode = 429,
+                    FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 429 Too Many Requests."
+                });
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(staleCustomId,
+                because: "an operational first-party lookup failure must not be treated as proof that a custom app should replace the configured identity");
+            await graph.DidNotReceive().FindApplicationByDisplayNameAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenCustomAppLookupFails_PreservesConfiguredId()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string configuredCustomId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(tenantId, configuredCustomId);
+            graph.LookupApplicationByAppIdWithResponseAsync(
+                    tenantId, configuredCustomId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ApplicationLookupResult
+                {
+                    IsSuccess = false,
+                    StatusCode = 503,
+                    FailureReason = "Microsoft Graph application lookup failed: HTTP 503 Service Unavailable."
+                });
+
+            await _service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(configuredCustomId,
+                because: "a transient or authorization failure does not prove that the configured custom application is absent");
+            await graph.DidNotReceive().LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            await graph.DidNotReceive().FindApplicationByDisplayNameAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
     }
 
     #endregion

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ConfigServiceTests.cs
@@ -683,6 +683,51 @@ public class Agent365ConfigServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenConfiguredIsFirstPartyAndLookupFails_WarnsAndPreservesConfig()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        var logger = Substitute.For<ILogger<ConfigService>>();
+        var service = new ConfigService(logger);
+        try
+        {
+            var configPath = await WriteConfigAndChdirAsync(
+                tenantId, AuthenticationConstants.WellKnownClientAppId);
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId,
+                    AuthenticationConstants.WellKnownClientAppId,
+                    Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = false,
+                    StatusCode = 503,
+                    FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 503 Service Unavailable."
+                });
+
+            await service.TryResolveClientAppIdAsync(graph);
+
+            var jsonAfter = await File.ReadAllTextAsync(configPath);
+            jsonAfter.Should().Contain(
+                AuthenticationConstants.WellKnownClientAppId,
+                because: "an inconclusive lookup is not evidence that the configured first-party app should be replaced");
+            logger.Received().Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(state =>
+                    state.ToString()!.Contains("no configuration changes were made", StringComparison.Ordinal)),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>());
+            await graph.DidNotReceive().FindApplicationByDisplayNameAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
     public async Task TryResolveClientAppIdAsync_WhenNoConfiguredId_AndFirstPartyServicePrincipalExists_PatchesToWellKnownIdWithoutDisplayNameLookup()
     {
         const string tenantId = "12345678-1234-1234-1234-123456789012";
@@ -901,6 +946,55 @@ public class Agent365ConfigServiceTests : IDisposable
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
             await graph.DidNotReceive().FindApplicationByDisplayNameAsync(
                 Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+        finally
+        {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Fact]
+    public async Task TryResolveClientAppIdAsync_WhenFirstPartyLookupFails_WarnsInsteadOfSilentlySwallowing()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string staleCustomId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+        var originalCwd = Environment.CurrentDirectory;
+        var graph = CreateMockGraphApiService();
+        var logger = Substitute.For<ILogger<ConfigService>>();
+        var service = new ConfigService(logger);
+        try
+        {
+            await WriteConfigAndChdirAsync(tenantId, staleCustomId);
+            graph.LookupApplicationByAppIdWithResponseAsync(
+                    tenantId, staleCustomId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ApplicationLookupResult
+                {
+                    IsSuccess = true,
+                    StatusCode = 200
+                });
+            graph.LookupServicePrincipalByAppIdWithResponseAsync(
+                    tenantId, AuthenticationConstants.WellKnownClientAppId, Arg.Any<CancellationToken>())
+                .Returns(new GraphApiService.ServicePrincipalLookupResult
+                {
+                    IsSuccess = false,
+                    StatusCode = 429,
+                    FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 429 Too Many Requests."
+                });
+
+            await service.TryResolveClientAppIdAsync(graph);
+
+            logger.Received().Log(
+                LogLevel.Warning,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(state => state.ToString()!.Contains("Could not verify client app")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>());
+            logger.DidNotReceive().Log(
+                LogLevel.Debug,
+                Arg.Any<EventId>(),
+                Arg.Is<object>(state => state.ToString()!.Contains("resolution skipped due to error")),
+                Arg.Any<Exception>(),
+                Arg.Any<Func<object, Exception?, string>>());
         }
         finally
         {

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BootstrapConfigResolverTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/BootstrapConfigResolverTests.cs
@@ -37,6 +37,13 @@ public class BootstrapConfigResolverTests : IDisposable
             Substitute.For<ILogger<GraphApiService>>(),
             _executor,
             (Func<Task<string?>>)(() => Task.FromResult<string?>(null)));
+        _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
 
         _loggerFactory = NullLoggerFactory.Instance;
     }

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
@@ -253,6 +253,332 @@ public class ClientAppValidatorTests
 
     #endregion
 
+    #region EnsureValidClientAppAsync - First-Party Mode Tests
+
+    private static string BuildTokenWithScopes(params string[] scopes)
+    {
+        var header = Base64UrlEncode("""{"alg":"none","typ":"JWT"}""");
+        var payload = Base64UrlEncode($$"""{"scp":"{{string.Join(' ', scopes)}}"}""");
+        return $"{header}.{payload}.sig";
+    }
+
+    private static string Base64UrlEncode(string json)
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes(json);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    public static IEnumerable<object[]> UnreadableScopeClaimTokens()
+    {
+        var header = Base64UrlEncode("""{"alg":"none","typ":"JWT"}""");
+        yield return new object[] { $"{header}.%%%.sig", "invalid Base64Url" };
+        yield return new object[] { $"{header}.{Base64UrlEncode("not-json")}.sig", "not valid JSON" };
+        yield return new object[]
+        {
+            $"{header}.{Base64UrlEncode("""{"scp":["User.Read"]}""")}.sig",
+            "'scp' claim is not a string"
+        };
+    }
+
+    private void SetupFirstPartyServicePrincipalLookup(
+        string clientAppId = ValidClientAppId,
+        string? servicePrincipalId = SpObjId)
+    {
+        _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                ValidTenantId, clientAppId, Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                ServicePrincipalId = servicePrincipalId,
+                StatusCode = 200
+            });
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenServicePrincipalMissing_ThrowsAppNotFound()
+    {
+        SetupFirstPartyServicePrincipalLookup(servicePrincipalId: null);
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.IssueDescription.Should().Contain("not found",
+            because: "a missing first-party service principal must surface the same AppNotFound failure as a missing custom app");
+
+        // The identity must be resolved via /servicePrincipals — /applications must never be queried
+        // in first-party mode, since a customer tenant may have no local application object.
+        await _graphApiService.Received(1).LookupServicePrincipalByAppIdWithResponseAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>());
+        await _graphApiService.DidNotReceive().ApplicationExistsByAppIdAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenServicePrincipalLookupThrows_PreservesFirstPartyGuidance()
+    {
+        _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<GraphApiService.ServicePrincipalLookupResult>(
+                new HttpRequestException("service-principal lookup unavailable")));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(
+                ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.IssueDescription.Should().Contain("service principal",
+            because: "a Graph lookup failure must remain distinguishable from a missing service principal");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("lookup unavailable", StringComparison.Ordinal),
+            because: "the underlying Graph failure must remain visible for diagnosis");
+        exception.MitigationSteps.Should().NotContain(
+            step => step.Contains("App registrations", StringComparison.OrdinalIgnoreCase),
+            because: "lookup failures must never direct customers to modify Microsoft's application registration");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenServicePrincipalLookupReturnsHttpFailure_ReportsLookupFailure()
+    {
+        _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = false,
+                StatusCode = 403,
+                FailureReason = "Microsoft Graph service-principal lookup failed: HTTP 403 Forbidden."
+            });
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(
+                ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.IssueDescription.Should().Contain("Unable to verify",
+            because: "an HTTP failure must remain distinguishable from a successful lookup with no matching service principal");
+        exception.IssueDescription.Should().NotContain("not found",
+            because: "an authorization or transport failure must not be misreported as confirmed service-principal absence");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("HTTP 403", StringComparison.Ordinal),
+            because: "operators need the Graph status to diagnose authorization failures");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenTokenHasAllRequiredScopes_DoesNotThrowOrMutate()
+    {
+        SetupFirstPartyServicePrincipalLookup();
+
+        var token = BuildTokenWithScopes(AuthenticationConstants.RequiredClientAppPermissions);
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(token));
+
+        await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true);
+
+        // No app-registration mutation of any kind must be attempted on a first-party application.
+        await _graphApiService.DidNotReceive().GraphPatchAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+        await _graphApiService.DidNotReceive().GraphPostAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>());
+        // A tenant-local oauth2PermissionGrant must not be required when the token itself proves authorization.
+        await _graphApiService.DidNotReceive().GraphGetAsync(
+            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("oauth2PermissionGrants")), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_RequestsBlueprintAndRegistrationScopesSeparately()
+    {
+        SetupFirstPartyServicePrincipalLookup();
+
+        var requestedScopeSets = new List<string[]>();
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var scopes = callInfo.ArgAt<IEnumerable<string>>(2).ToArray();
+                requestedScopeSets.Add(scopes);
+                return Task.FromResult<string?>(BuildTokenWithScopes(scopes));
+            });
+
+        await _validator.EnsureValidClientAppAsync(
+            ValidClientAppId, ValidTenantId, isFirstParty: true);
+
+        requestedScopeSets.Should().HaveCount(2,
+            because: "the registration scope must be acquired separately so Entra can return a token whose scp claim identifies authorization for each operation group");
+        requestedScopeSets.Single(scopes =>
+                !scopes.Contains(AuthenticationConstants.AgentRegistrationReadWriteAllScope))
+            .Should().BeEquivalentTo(
+                AuthenticationConstants.BlueprintOperationScopes,
+            because: "every blueprint-operation scope must be validated from the token scp claim");
+        requestedScopeSets.Single(scopes =>
+                scopes.Contains(AuthenticationConstants.AgentRegistrationReadWriteAllScope))
+            .Should().Equal(
+                [AuthenticationConstants.AgentRegistrationReadWriteAllScope],
+            because: "AgentRegistration.ReadWrite.All must be validated without combining it with blueprint scopes");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenTokenMissingARequiredScope_ThrowsMissingPermissionsNamingIt()
+    {
+        SetupFirstPartyServicePrincipalLookup();
+
+        var grantedScopes = AuthenticationConstants.RequiredClientAppPermissions
+            .Where(s => s != "User.Read")
+            .ToArray();
+        var token = BuildTokenWithScopes(grantedScopes);
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(token));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.ErrorDetails.Should().Contain(d => d.Contains("User.Read"),
+            because: "every required scope must be checked individually so the operator knows exactly which scope the token is missing");
+        exception.MitigationSteps.Should().NotContain(
+            step => step.Contains("App registrations", StringComparison.OrdinalIgnoreCase),
+            because: "customers must not be told to modify Microsoft's first-party app registration");
+        exception.MitigationSteps.Should().Contain(
+            step => step.Contains("enterprise application", StringComparison.OrdinalIgnoreCase),
+            because: "first-party authorization failures must direct tenant administrators to the enterprise application");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenTokenAcquisitionFails_ThrowsClearValidationFailure()
+    {
+        SetupFirstPartyServicePrincipalLookup();
+
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(null));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.IssueDescription.Should().Contain("access token",
+            because: "a failed token acquisition must surface a clear, explicit failure rather than being silently swallowed as \'missing permissions\'");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenTokenAcquisitionThrows_SurfacesActionableFailure()
+    {
+        SetupFirstPartyServicePrincipalLookup();
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string?>(
+                new InvalidOperationException("interactive acquisition denied")));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(
+                ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains("interactive acquisition denied", StringComparison.Ordinal),
+            because: "token acquisition exceptions must remain visible as explicit validation failures");
+        exception.MitigationSteps.Should().NotContain(
+            step => step.Contains("App registrations", StringComparison.OrdinalIgnoreCase),
+            because: "a first-party token failure must never recommend changing Microsoft's application registration");
+    }
+
+    [Theory]
+    [MemberData(nameof(UnreadableScopeClaimTokens))]
+    public async Task EnsureValidClientAppAsync_FirstParty_WhenTokenScopeClaimCannotBeDecoded_ReportsAuthorizationFailure(
+        string token,
+        string expectedReason)
+    {
+        SetupFirstPartyServicePrincipalLookup();
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, ValidClientAppId,
+                Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(token));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(
+                ValidClientAppId, ValidTenantId, isFirstParty: true));
+
+        exception.IssueDescription.Should().Contain("access token",
+            because: "an unreadable token must be reported as an authorization-validation failure");
+        exception.ErrorDetails.Should().Contain(
+            detail => detail.Contains(expectedReason, StringComparison.Ordinal),
+            because: "the operator must be able to distinguish malformed token data from genuinely missing delegated scopes");
+        exception.ErrorDetails.Should().NotContain(
+            detail => detail.Contains("Missing scopes", StringComparison.Ordinal),
+            because: "missing-scope guidance is valid only after a string scp claim was decoded successfully");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WellKnownIdWithoutFlag_AutomaticallySkipsCustomAppMutationPath()
+    {
+        SetupFirstPartyServicePrincipalLookup(AuthenticationConstants.WellKnownClientAppId);
+        _graphApiService.GetClientAppAccessTokenAsync(
+            ValidTenantId, AuthenticationConstants.WellKnownClientAppId,
+            Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var scopes = callInfo.ArgAt<IEnumerable<string>>(2).ToArray();
+                return Task.FromResult<string?>(BuildTokenWithScopes(scopes));
+            });
+
+        await _validator.EnsureValidClientAppAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId);
+
+        var mutationCalls = _graphApiService.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name is nameof(GraphApiService.GraphPatchAsync) or nameof(GraphApiService.GraphPostAsync))
+            .ToList();
+        mutationCalls.Should().BeEmpty(
+            because: "the well-known Microsoft application must be protected even when a caller omits the explicit first-party flag");
+    }
+
+    [Fact]
+    public async Task GetUnconsentedRequiredPermissionsAsync_FirstParty_ReturnsEmptyWithoutQueryingGrants()
+    {
+        var result = await _validator.GetUnconsentedRequiredPermissionsAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId);
+
+        result.Should().BeEmpty(
+            because: "the acquired token scp claim, not a tenant-local oauth2PermissionGrant, proves first-party authorization");
+        _graphApiService.ReceivedCalls().Should().BeEmpty(
+            because: "first-party preauthorization must not trigger any tenant grant or service-principal query");
+    }
+
+    [Fact]
+    public async Task GrantConsentForPermissionsAsync_FirstParty_ThrowsWithoutPatchingGrant()
+    {
+        Func<Task> act = async () => await _validator.GrantConsentForPermissionsAsync(
+            AuthenticationConstants.WellKnownClientAppId, ["User.Read"], ValidTenantId);
+
+        await act.Should().ThrowAsync<InvalidOperationException>(
+            because: "tenant-local consent configuration must never be mutated for Microsoft's first-party application");
+        var mutationCalls = _graphApiService.ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name is nameof(GraphApiService.GraphPatchAsync) or nameof(GraphApiService.GraphPostAsync))
+            .ToList();
+        mutationCalls.Should().BeEmpty(
+            because: "rejecting the operation must happen before any Graph consent mutation");
+    }
+
+    [Fact]
+    public async Task EnsureRedirectUrisAsync_FirstParty_ReturnsWithoutReadingOrPatchingApplication()
+    {
+        await _validator.EnsureRedirectUrisAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId);
+
+        _graphApiService.ReceivedCalls().Should().BeEmpty(
+            because: "customers cannot read or modify redirect URIs on Microsoft's first-party application object");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_CustomApp_DefaultIsFirstPartyFalse_PreservesExistingMutationBehavior()
+    {
+        // Regression guard: omitting isFirstParty must preserve the full custom-app validation
+        // path (existence via /applications, permission/consent self-healing), unchanged.
+        SetupAppInfoWithAllPermissions(ValidClientAppId);
+        SetupPermissionResolution();
+
+        await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId);
+
+        await _graphApiService.Received().GraphGetWithResponseAsync(
+            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("displayName")), Arg.Any<bool>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
     #region EnsureValidClientAppAsync - Exception Detail Tests
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
@@ -26,6 +26,9 @@ public class ClientAppValidatorTests
     private readonly ClientAppValidator _validator;
 
     private const string ValidClientAppId = "a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6";
+
+    // The well-known Microsoft app ID is the only trigger for the non-mutating first-party path.
+    private const string FirstPartyClientAppId = AuthenticationConstants.WellKnownClientAppId;
     private const string ValidTenantId = "12345678-1234-1234-1234-123456789012";
     private const string InvalidGuid = "not-a-guid";
     private const string AppObjId = "object-id-123";
@@ -253,7 +256,7 @@ public class ClientAppValidatorTests
 
     #endregion
 
-    #region EnsureValidClientAppAsync - First-Party Mode Tests
+    #region EnsureValidClientAppAsync - First-Party App Tests
 
     private static string BuildTokenWithScopes(params string[] scopes)
     {
@@ -281,11 +284,14 @@ public class ClientAppValidatorTests
     }
 
     private void SetupFirstPartyServicePrincipalLookup(
-        string clientAppId = ValidClientAppId,
+        string clientAppId = FirstPartyClientAppId,
         string? servicePrincipalId = SpObjId)
     {
         _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
-                ValidTenantId, clientAppId, Arg.Any<CancellationToken>())
+                ValidTenantId,
+                clientAppId,
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.ResolvedClientApp)
             .Returns(new GraphApiService.ServicePrincipalLookupResult
             {
                 IsSuccess = true,
@@ -300,7 +306,7 @@ public class ClientAppValidatorTests
         SetupFirstPartyServicePrincipalLookup(servicePrincipalId: null);
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
-            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+            () => _validator.EnsureValidClientAppAsync(FirstPartyClientAppId, ValidTenantId));
 
         exception.IssueDescription.Should().Contain("not found",
             because: "a missing first-party service principal must surface the same AppNotFound failure as a missing custom app");
@@ -308,7 +314,10 @@ public class ClientAppValidatorTests
         // The identity must be resolved via /servicePrincipals — /applications must never be queried
         // in first-party mode, since a customer tenant may have no local application object.
         await _graphApiService.Received(1).LookupServicePrincipalByAppIdWithResponseAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>());
+            ValidTenantId,
+            FirstPartyClientAppId,
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.ResolvedClientApp);
         await _graphApiService.DidNotReceive().ApplicationExistsByAppIdAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -317,13 +326,16 @@ public class ClientAppValidatorTests
     public async Task EnsureValidClientAppAsync_FirstParty_WhenServicePrincipalLookupThrows_PreservesFirstPartyGuidance()
     {
         _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
-                ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>())
+                ValidTenantId,
+                FirstPartyClientAppId,
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.ResolvedClientApp)
             .Returns(Task.FromException<GraphApiService.ServicePrincipalLookupResult>(
                 new HttpRequestException("service-principal lookup unavailable")));
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
             () => _validator.EnsureValidClientAppAsync(
-                ValidClientAppId, ValidTenantId, isFirstParty: true));
+                FirstPartyClientAppId, ValidTenantId));
 
         exception.IssueDescription.Should().Contain("service principal",
             because: "a Graph lookup failure must remain distinguishable from a missing service principal");
@@ -339,7 +351,10 @@ public class ClientAppValidatorTests
     public async Task EnsureValidClientAppAsync_FirstParty_WhenServicePrincipalLookupReturnsHttpFailure_ReportsLookupFailure()
     {
         _graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
-                ValidTenantId, ValidClientAppId, Arg.Any<CancellationToken>())
+                ValidTenantId,
+                FirstPartyClientAppId,
+                Arg.Any<CancellationToken>(),
+                GraphAuthenticationMode.ResolvedClientApp)
             .Returns(new GraphApiService.ServicePrincipalLookupResult
             {
                 IsSuccess = false,
@@ -349,7 +364,7 @@ public class ClientAppValidatorTests
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
             () => _validator.EnsureValidClientAppAsync(
-                ValidClientAppId, ValidTenantId, isFirstParty: true));
+                FirstPartyClientAppId, ValidTenantId));
 
         exception.IssueDescription.Should().Contain("Unable to verify",
             because: "an HTTP failure must remain distinguishable from a successful lookup with no matching service principal");
@@ -367,10 +382,10 @@ public class ClientAppValidatorTests
 
         var token = BuildTokenWithScopes(AuthenticationConstants.RequiredClientAppPermissions);
         _graphApiService.GetClientAppAccessTokenAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>(token));
 
-        await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true);
+        await _validator.EnsureValidClientAppAsync(FirstPartyClientAppId, ValidTenantId);
 
         // No app-registration mutation of any kind must be attempted on a first-party application.
         await _graphApiService.DidNotReceive().GraphPatchAsync(
@@ -389,7 +404,7 @@ public class ClientAppValidatorTests
 
         var requestedScopeSets = new List<string[]>();
         _graphApiService.GetClientAppAccessTokenAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
                 var scopes = callInfo.ArgAt<IEnumerable<string>>(2).ToArray();
@@ -398,7 +413,7 @@ public class ClientAppValidatorTests
             });
 
         await _validator.EnsureValidClientAppAsync(
-            ValidClientAppId, ValidTenantId, isFirstParty: true);
+            FirstPartyClientAppId, ValidTenantId);
 
         requestedScopeSets.Should().HaveCount(2,
             because: "the registration scope must be acquired separately so Entra can return a token whose scp claim identifies authorization for each operation group");
@@ -424,11 +439,11 @@ public class ClientAppValidatorTests
             .ToArray();
         var token = BuildTokenWithScopes(grantedScopes);
         _graphApiService.GetClientAppAccessTokenAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>(token));
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
-            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+            () => _validator.EnsureValidClientAppAsync(FirstPartyClientAppId, ValidTenantId));
 
         exception.ErrorDetails.Should().Contain(d => d.Contains("User.Read"),
             because: "every required scope must be checked individually so the operator knows exactly which scope the token is missing");
@@ -446,11 +461,11 @@ public class ClientAppValidatorTests
         SetupFirstPartyServicePrincipalLookup();
 
         _graphApiService.GetClientAppAccessTokenAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>(null));
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
-            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, isFirstParty: true));
+            () => _validator.EnsureValidClientAppAsync(FirstPartyClientAppId, ValidTenantId));
 
         exception.IssueDescription.Should().Contain("access token",
             because: "a failed token acquisition must surface a clear, explicit failure rather than being silently swallowed as \'missing permissions\'");
@@ -461,13 +476,13 @@ public class ClientAppValidatorTests
     {
         SetupFirstPartyServicePrincipalLookup();
         _graphApiService.GetClientAppAccessTokenAsync(
-            ValidTenantId, ValidClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromException<string?>(
                 new InvalidOperationException("interactive acquisition denied")));
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
             () => _validator.EnsureValidClientAppAsync(
-                ValidClientAppId, ValidTenantId, isFirstParty: true));
+                FirstPartyClientAppId, ValidTenantId));
 
         exception.ErrorDetails.Should().Contain(
             detail => detail.Contains("interactive acquisition denied", StringComparison.Ordinal),
@@ -485,13 +500,13 @@ public class ClientAppValidatorTests
     {
         SetupFirstPartyServicePrincipalLookup();
         _graphApiService.GetClientAppAccessTokenAsync(
-                ValidTenantId, ValidClientAppId,
+                ValidTenantId, FirstPartyClientAppId,
                 Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<string?>(token));
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
             () => _validator.EnsureValidClientAppAsync(
-                ValidClientAppId, ValidTenantId, isFirstParty: true));
+                FirstPartyClientAppId, ValidTenantId));
 
         exception.IssueDescription.Should().Contain("access token",
             because: "an unreadable token must be reported as an authorization-validation failure");
@@ -504,7 +519,7 @@ public class ClientAppValidatorTests
     }
 
     [Fact]
-    public async Task EnsureValidClientAppAsync_WellKnownIdWithoutFlag_AutomaticallySkipsCustomAppMutationPath()
+    public async Task EnsureValidClientAppAsync_WellKnownId_SkipsCustomAppMutationPath()
     {
         SetupFirstPartyServicePrincipalLookup(AuthenticationConstants.WellKnownClientAppId);
         _graphApiService.GetClientAppAccessTokenAsync(
@@ -523,7 +538,7 @@ public class ClientAppValidatorTests
             .Where(call => call.GetMethodInfo().Name is nameof(GraphApiService.GraphPatchAsync) or nameof(GraphApiService.GraphPostAsync))
             .ToList();
         mutationCalls.Should().BeEmpty(
-            because: "the well-known Microsoft application must be protected even when a caller omits the explicit first-party flag");
+            because: "the well-known Microsoft application ID alone must select the non-mutating validation path");
     }
 
     [Fact]
@@ -564,9 +579,9 @@ public class ClientAppValidatorTests
     }
 
     [Fact]
-    public async Task EnsureValidClientAppAsync_CustomApp_DefaultIsFirstPartyFalse_PreservesExistingMutationBehavior()
+    public async Task EnsureValidClientAppAsync_CustomApp_PreservesExistingMutationBehavior()
     {
-        // Regression guard: omitting isFirstParty must preserve the full custom-app validation
+        // Regression guard: a tenant-owned client app ID must keep the full custom-app validation
         // path (existence via /applications, permission/consent self-healing), unchanged.
         SetupAppInfoWithAllPermissions(ValidClientAppId);
         SetupPermissionResolution();
@@ -575,6 +590,100 @@ public class ClientAppValidatorTests
 
         await _graphApiService.Received().GraphGetWithResponseAsync(
             Arg.Any<string>(), Arg.Is<string>(p => p.Contains("displayName")), Arg.Any<bool>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    #region HasWidsClaimOnIssuedAccessTokenAsync Tests
+
+    private static string BuildTokenWithPayload(string payloadJson) =>
+        $"{Base64UrlEncode("""{"alg":"none","typ":"JWT"}""")}.{Base64UrlEncode(payloadJson)}.sig";
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenTokenCarriesWids_ReturnsTrue()
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(
+                BuildTokenWithPayload("""{"wids":["62e90394-69f5-4237-9190-012177145e10"]}""")));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(FirstPartyClientAppId, ValidTenantId);
+
+        result.Should().BeTrue(
+            because: "the claim on a token actually issued to the app is the only evidence available for an app registration the tenant cannot read");
+    }
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenTokenOmitsWids_ReturnsFalse()
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<string?>(BuildTokenWithPayload("""{"scp":"User.Read"}""")));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(FirstPartyClientAppId, ValidTenantId);
+
+        result.Should().BeFalse(
+            because: "a decodable token without the claim proves the claim is absent from issued tokens");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenTokenUnavailableOrUnreadable_ReturnsNull(string? token)
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult(token));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(FirstPartyClientAppId, ValidTenantId);
+
+        result.Should().BeNull(
+            because: "an unavailable or undecodable token is inconclusive and must never be reported as a confirmed absent claim");
+    }
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenTokenAcquisitionThrows_ReturnsNull()
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string?>(new InvalidOperationException("token acquisition failed")));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(FirstPartyClientAppId, ValidTenantId);
+
+        result.Should().BeNull(
+            because: "a token acquisition failure is inconclusive, not proof that the claim is missing");
+    }
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenTokenAcquisitionTimesOut_ReturnsNull()
+    {
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string?>(
+                new TaskCanceledException("token provider timed out")));
+
+        var result = await _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            FirstPartyClientAppId, ValidTenantId);
+
+        result.Should().BeNull(
+            because: "a provider timeout without caller cancellation is inconclusive and must not abort all requirement checks");
+    }
+
+    [Fact]
+    public async Task HasWidsClaimOnIssuedAccessTokenAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _graphApiService.GetClientAppAccessTokenAsync(
+                ValidTenantId, FirstPartyClientAppId, Arg.Any<IEnumerable<string>>(), cts.Token)
+            .Returns(Task.FromException<string?>(new OperationCanceledException(cts.Token)));
+
+        Func<Task> act = async () => await _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            FirstPartyClientAppId, ValidTenantId, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "caller cancellation must abort the command rather than be reported as an inconclusive claim");
     }
 
     #endregion

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/DelegatedConsentServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/DelegatedConsentServiceTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Net;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -91,6 +92,23 @@ public class DelegatedConsentServiceTests
         var result = await svc.EnsureBlueprintPermissionGrantAsync(ValidAppId, ValidTenantId);
 
         result.Should().BeFalse(because: "when Graph token acquisition fails the method must abort without HTTP calls");
+    }
+
+    [Fact]
+    public async Task EnsureBlueprintPermissionGrantAsync_FirstPartyApp_SkipsTenantLocalGrant()
+    {
+        var graphService = Substitute.ForPartsOf<GraphApiService>();
+        using var handler = new TestHttpMessageHandler();
+        var svc = new DelegatedConsentService(NullLogger.Instance, graphService, handler);
+
+        var result = await svc.EnsureBlueprintPermissionGrantAsync(
+            AuthenticationConstants.WellKnownClientAppId,
+            ValidTenantId);
+
+        result.Should().BeTrue(
+            because: "Graph preauthorization is validated from the first-party token and must not require a tenant-local oauth2PermissionGrant");
+        await graphService.DidNotReceive().GetGraphAccessTokenAsync(
+            Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<CancellationToken>());
     }
 
     // ── Scope already on grant ────────────────────────────────────────────────

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GlobalConfigDirectoryCleanupTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GlobalConfigDirectoryCleanupTests.cs
@@ -182,6 +182,13 @@ public class GlobalConfigDirectoryCleanupTests : IDisposable
             Substitute.For<ILogger<GraphApiService>>(),
             executor,
             (Func<Task<string?>>)(() => Task.FromResult<string?>(null)));
+        graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
 
         // Graph resolves the blueprint to the SAME ID as the poisoned global file would
         // carry — so if the pre-fix merge logic at BuildBootstrapConfigForCleanupAsync
@@ -259,6 +266,13 @@ public class GlobalConfigDirectoryCleanupTests : IDisposable
             Substitute.For<ILogger<GraphApiService>>(),
             executor,
             (Func<Task<string?>>)(() => Task.FromResult<string?>(null)));
+        graphApiService.LookupServicePrincipalByAppIdWithResponseAsync(
+                Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new GraphApiService.ServicePrincipalLookupResult
+            {
+                IsSuccess = true,
+                StatusCode = 200
+            });
         // The cleanup duplicate calls FindApplicationByDisplayNameAsync WITHOUT a
         // CancellationToken argument (see CleanupCommand.cs ~line 1356-1357), so the
         // 2-arg overload must be stubbed in addition to the 3-arg one for safety.

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -257,7 +257,10 @@ public class GraphApiServiceTests
             handler,
             tokenProvider,
             loginHintResolver: () => Task.FromResult<string?>(null),
-            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = AuthenticationConstants.WellKnownClientAppId
+        };
 
         var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
             "tenant-123", AuthenticationConstants.WellKnownClientAppId);
@@ -268,11 +271,127 @@ public class GraphApiServiceTests
             because: "the original Graph status must be preserved for authorization and retry diagnostics");
         result.FailureReason.Should().Contain($"HTTP {(int)statusCode}",
             because: "operators need the Graph status to distinguish authorization failures from transient failures");
-        requestedScopes.Should().ContainSingle()
-            .Which.Should().Be(AuthenticationConstants.ApplicationReadAllScope,
-                because: "service-principal lookup requires Application.Read.All and must not rely on an under-scoped cached token");
-        requestedClientAppId.Should().Be(AuthenticationConstants.WellKnownClientAppId,
-            because: "bootstrap must acquire the scoped token directly through the known first-party client instead of invoking Connect-MgGraph with a null client ID");
+        requestedScopes.Should().BeNull(
+            because: "presence discovery must not request a scoped token from the app being probed — that app may not exist, so its token could never be acquired");
+        requestedClientAppId.Should().BeNull(
+            because: "presence discovery must authenticate ambiently, never as the client app whose existence is in question");
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_UsesAmbientAuthEvenWhenProbingTheResolvedClientApp()
+    {
+        // Regression guard: authenticating as the app being probed makes an absent app report
+        // NoAuth instead of a conclusive "not present", blocking the custom-app fallback.
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[]}""")
+        });
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = AuthenticationConstants.WellKnownClientAppId
+        };
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeTrue(
+            because: "the ambient identity can complete the query and report the app as conclusively absent");
+        result.ServicePrincipalId.Should().BeNull();
+        await tokenProvider.DidNotReceiveWithAnyArgs().GetMgGraphAccessTokenAsync(
+            default!, default!, default, default, default, default, default);
+        await authService.ReceivedWithAnyArgs(1).GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenValidatingResolvedApp_UsesItsScopedToken()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[{"id":"first-party-sp-object-id"}]}""")
+        });
+        string[]? requestedScopes = null;
+        string? requestedClientAppId = null;
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Do<IEnumerable<string>>(scopes => requestedScopes = scopes.ToArray()),
+                Arg.Any<bool>(),
+                Arg.Do<string?>(clientAppId => requestedClientAppId = clientAppId),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>())
+            .Returns("first-party-token");
+        var authService = FakeAuth();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            CustomClientAppId = AuthenticationConstants.WellKnownClientAppId
+        };
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123",
+            AuthenticationConstants.WellKnownClientAppId,
+            authenticationMode: GraphAuthenticationMode.ResolvedClientApp);
+
+        result.ServicePrincipalId.Should().Be(
+            "first-party-sp-object-id",
+            because: "validation must still query the resolved first-party service principal");
+        requestedClientAppId.Should().Be(
+            AuthenticationConstants.WellKnownClientAppId,
+            because: "post-resolution validation must not depend on the ambient Graph PowerShell application");
+        requestedScopes.Should().ContainSingle(
+            because: "service-principal validation requires one delegated scope")
+            .Which.Should().Be(
+                AuthenticationConstants.ApplicationReadAllScope,
+                because: "the resolved client token needs Application.Read.All for the service-principal query");
+        await authService.DidNotReceiveWithAnyArgs().GetAccessTokenAsync(
+            default!, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenAmbientTokenUnavailable_ReportsNoAuth()
+    {
+        using var handler = new TestHttpMessageHandler();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuthReturning(null),
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeFalse(
+            because: "without an ambient token the presence query never ran and cannot prove absence");
+        result.StatusCode.Should().Be(
+            0,
+            because: "no HTTP response exists when token acquisition fails before the request");
+        result.FailureReason.Should().Contain(
+            "NoAuth",
+            because: "callers need to distinguish authentication failure from a successful empty lookup");
+        handler.RequestCount.Should().Be(
+            0,
+            because: "Graph must not be called without an access token");
     }
 
     [Fact]
@@ -418,6 +537,53 @@ public class GraphApiServiceTests
             because: "only a successful empty applications response proves that the configured custom app is absent");
         result.ApplicationId.Should().BeNull(
             because: "an empty applications result contains no matching custom application");
+    }
+
+    [Fact]
+    public async Task GraphGetWithResponseAsync_WhenHttpClientTimesOut_ReturnsFailureInsteadOfThrowing()
+    {
+        // HttpClient surfaces its own timeout as TaskCanceledException with no cancellation
+        // requested; treating it as a cancel would abort the command instead of reporting a
+        // recoverable lookup failure.
+        using var handler = new ExceptionThrowingHttpMessageHandler(
+            () => new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout"));
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.GraphGetWithResponseAsync("tenant-123", "/v1.0/servicePrincipals");
+
+        result.IsSuccess.Should().BeFalse(
+            because: "a timed-out lookup is a failure result, not a caller cancellation");
+        result.StatusCode.Should().Be(0,
+            because: "no HTTP response was received, so no status can be reported");
+    }
+
+    [Fact]
+    public async Task GraphGetWithResponseAsync_WhenCallerCancels_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        using var handler = new ExceptionThrowingHttpMessageHandler(() =>
+        {
+            cts.Cancel();
+            return new TaskCanceledException("cancelled by caller", null, cts.Token);
+        });
+        var authService = Substitute.For<IAuthenticationService>();
+        authService.GetAccessTokenAsync(
+                Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(), Arg.Any<string?>(),
+                Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult("fake-token"));
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            authService,
+            handler,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        var act = async () => await service.GraphGetWithResponseAsync(
+            "tenant-123", "/v1.0/servicePrincipals", ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "Ctrl+C must abort the command rather than being converted into a misleading lookup failure");
     }
 
     [Theory]
@@ -1146,15 +1312,29 @@ public class GraphApiServiceTests
     #endregion
 }
 
+// Handler that throws the supplied exception instead of sending a request.
+internal class ExceptionThrowingHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Func<Exception> _exceptionFactory;
+
+    public ExceptionThrowingHttpMessageHandler(Func<Exception> exceptionFactory) => _exceptionFactory = exceptionFactory;
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => throw _exceptionFactory();
+}
+
 // Simple test handler that returns queued responses sequentially
 internal class TestHttpMessageHandler : HttpMessageHandler
 {
     private readonly Queue<HttpResponseMessage> _responses = new();
 
+    public int RequestCount { get; private set; }
+
     public void QueueResponse(HttpResponseMessage resp) => _responses.Enqueue(resp);
 
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        RequestCount++;
         if (_responses.Count == 0)
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") });
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
@@ -29,6 +30,41 @@ public class GraphApiServiceTests
         _mockTokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
     }
 
+
+    [Fact]
+    public async Task GetClientAppAccessTokenAsync_PassesExplicitClientIdAndScopesToTokenProvider()
+    {
+        const string tenantId = "12345678-1234-1234-1234-123456789012";
+        const string clientAppId = "f54280f4-395e-4ea8-9e48-bf2d4952aa14";
+        var expectedScopes = new[] { "User.Read", "Application.Read.All" };
+        string? capturedClientAppId = null;
+        string[]? capturedScopes = null;
+
+        _mockTokenProvider.GetMgGraphAccessTokenAsync(
+                tenantId,
+                Arg.Do<IEnumerable<string>>(scopes => capturedScopes = scopes.ToArray()),
+                useDeviceCode: false,
+                clientAppId: Arg.Do<string?>(id => capturedClientAppId = id),
+                ct: Arg.Any<CancellationToken>(),
+                loginHint: null,
+                forceRefresh: false)
+            .Returns("first-party-token");
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            tokenProvider: _mockTokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null));
+
+        var token = await service.GetClientAppAccessTokenAsync(
+            tenantId, clientAppId, expectedScopes);
+
+        token.Should().Be("first-party-token");
+        capturedClientAppId.Should().Be(clientAppId,
+            because: "the token scp claim is authoritative only when the token was issued to the first-party client being validated");
+        capturedScopes.Should().BeEquivalentTo(expectedScopes,
+            because: "authorization validation must request the exact delegated scopes that will be checked in the token scp claim");
+    }
 
     [Fact]
     public async Task GraphPostWithResponseAsync_Returns_Success_And_ParsesJson()
@@ -162,14 +198,15 @@ public class GraphApiServiceTests
         var service = new GraphApiService(logger, executor, FakeAuth(), handler, loginHintResolver: () => Task.FromResult<string?>(null));
 
         // Queue response for service principal lookup
-        var spResponse = new { value = new[] { new { id = "sp-object-id-123", appId = "blueprint-456" } } };
+        const string appId = "11111111-1111-1111-1111-111111111111";
+        var spResponse = new { value = new[] { new { id = "sp-object-id-123", appId } } };
         handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(JsonSerializer.Serialize(spResponse))
         });
 
         // Act - Call a public method that internally uses LookupServicePrincipalAsync
-        var result = await service.LookupServicePrincipalByAppIdAsync("tenant-123", "blueprint-456");
+        var result = await service.LookupServicePrincipalByAppIdAsync("tenant-123", appId);
 
         // Assert
         result.Should().NotBeNull("service principal lookup should succeed");
@@ -185,6 +222,202 @@ public class GraphApiServiceTests
         capturedRequest.Headers.Contains("ConsistencyLevel").Should().BeFalse(
             "ConsistencyLevel header should NOT be present for simple service principal lookup queries. " +
             "Per Graph docs, appId eq is Default+Advanced and does not require this header.");
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenGraphFails_PreservesOperationalFailure(
+        HttpStatusCode statusCode)
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(
+                """{"error":{"code":"RequestFailed","message":"lookup failed"}}""")
+        });
+
+        string[]? requestedScopes = null;
+        string? requestedClientAppId = null;
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Do<IEnumerable<string>>(scopes => requestedScopes = scopes.ToArray()),
+                Arg.Any<bool>(),
+                Arg.Do<string?>(clientAppId => requestedClientAppId = clientAppId),
+                Arg.Any<CancellationToken>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>())
+            .Returns("fake-token");
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0));
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeFalse(
+            because: "an HTTP failure must not be represented as a successful empty service-principal query");
+        result.StatusCode.Should().Be((int)statusCode,
+            because: "the original Graph status must be preserved for authorization and retry diagnostics");
+        result.FailureReason.Should().Contain($"HTTP {(int)statusCode}",
+            because: "operators need the Graph status to distinguish authorization failures from transient failures");
+        requestedScopes.Should().ContainSingle()
+            .Which.Should().Be(AuthenticationConstants.ApplicationReadAllScope,
+                because: "service-principal lookup requires Application.Read.All and must not rely on an under-scoped cached token");
+        requestedClientAppId.Should().Be(AuthenticationConstants.WellKnownClientAppId,
+            because: "bootstrap must acquire the scoped token directly through the known first-party client instead of invoking Connect-MgGraph with a null client ID");
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenGraphReturnsEmptyArray_ReportsSuccessfulAbsence()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        using var handler = new CapturingHttpMessageHandler(request => capturedRequest = request);
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[]}""")
+        });
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeTrue(
+            because: "only a successful Graph response with an empty value array proves that the service principal is absent");
+        result.ServicePrincipalId.Should().BeNull(
+            because: "an empty successful Graph result proves that no matching service principal exists");
+        result.StatusCode.Should().Be((int)HttpStatusCode.OK,
+            because: "absence is conclusive only when Graph successfully processed the lookup");
+        capturedRequest.Should().NotBeNull(
+            because: "the test must inspect the actual Graph request used for first-party resolution");
+        capturedRequest!.RequestUri!.AbsolutePath.Should().EndWith(
+            "/v1.0/servicePrincipals",
+            because: "customer tenants may contain only the manager-created service principal and no tenant-local application object");
+        capturedRequest.RequestUri.AbsolutePath.Should().NotContain(
+            "/applications",
+            because: "the first-party identity must never be resolved through tenant-local application registrations");
+        Uri.UnescapeDataString(capturedRequest.RequestUri.Query).Should().Be(
+            $"?$filter=appId eq '{AuthenticationConstants.WellKnownClientAppId}'&$select=id",
+            because: "the service-principal query must target the exact well-known application ID and request only its object ID");
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenServicePrincipalExists_ReturnsObjectId()
+    {
+        HttpRequestMessage? capturedRequest = null;
+        using var handler = new CapturingHttpMessageHandler(request => capturedRequest = request);
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[{"id":"first-party-sp-object-id"}]}""")
+        });
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeTrue(
+            because: "a valid Graph response containing the service principal proves the first-party enterprise application is present");
+        result.ServicePrincipalId.Should().Be("first-party-sp-object-id",
+            because: "callers need the tenant service-principal object ID rather than a tenant-local application object");
+        Uri.UnescapeDataString(capturedRequest!.RequestUri!.Query).Should().Be(
+            $"?$filter=appId eq '{AuthenticationConstants.WellKnownClientAppId}'&$select=id",
+            because: "the lookup must query the exact first-party appId through servicePrincipals");
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenResponseIsMalformed_ReportsFailure()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"unexpected":[]}""")
+        });
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", AuthenticationConstants.WellKnownClientAppId);
+
+        result.IsSuccess.Should().BeFalse(
+            because: "an HTTP 200 without a value array cannot prove either service-principal presence or absence");
+        result.FailureReason.Should().Contain("invalid service-principal lookup response",
+            because: "malformed Graph data must remain distinguishable from a successful empty lookup");
+    }
+
+    [Fact]
+    public async Task LookupServicePrincipalByAppIdWithResponseAsync_WhenAppIdIsInvalid_DoesNotSendRequest()
+    {
+        var requestSent = false;
+        using var handler = new CapturingHttpMessageHandler(_ => requestSent = true);
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        var service = new GraphApiService(
+            _mockLogger,
+            _mockExecutor,
+            FakeAuth(),
+            handler,
+            tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null));
+
+        var result = await service.LookupServicePrincipalByAppIdWithResponseAsync(
+            "tenant-123", "not-a-guid");
+
+        result.IsSuccess.Should().BeFalse(
+            because: "user-controlled app IDs must be rejected before OData query construction");
+        requestSent.Should().BeFalse(
+            because: "invalid app IDs must never reach Microsoft Graph");
+        await tokenProvider.DidNotReceiveWithAnyArgs().GetMgGraphAccessTokenAsync(
+            default!, default!, default, default, default, default, default);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.Forbidden)]
+    [InlineData(HttpStatusCode.TooManyRequests)]
+    [InlineData(HttpStatusCode.ServiceUnavailable)]
+    public async Task LookupApplicationByAppIdWithResponseAsync_WhenGraphFails_PreservesOperationalFailure(
+        HttpStatusCode statusCode)
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(
+                """{"error":{"code":"RequestFailed","message":"lookup failed"}}""")
+        });
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.LookupApplicationByAppIdWithResponseAsync(
+            "tenant-123", "11111111-1111-1111-1111-111111111111");
+
+        result.IsSuccess.Should().BeFalse(
+            because: "a failed Graph request cannot prove that a configured custom application is absent");
+        result.StatusCode.Should().Be((int)statusCode,
+            because: "configuration resolution needs the original status to preserve custom IDs on inconclusive lookups");
+        result.FailureReason.Should().Contain($"HTTP {(int)statusCode}",
+            because: "operators need the Graph status to diagnose authorization and transient failures");
+    }
+
+    [Fact]
+    public async Task LookupApplicationByAppIdWithResponseAsync_WhenGraphReturnsEmptyArray_ReportsSuccessfulAbsence()
+    {
+        using var handler = new TestHttpMessageHandler();
+        handler.QueueResponse(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"value":[]}""")
+        });
+        var service = CreateServiceWithTokenProvider(handler);
+
+        var result = await service.LookupApplicationByAppIdWithResponseAsync(
+            "tenant-123", "11111111-1111-1111-1111-111111111111");
+
+        result.IsSuccess.Should().BeTrue(
+            because: "only a successful empty applications response proves that the configured custom app is absent");
+        result.ApplicationId.Should().BeNull(
+            because: "an empty applications result contains no matching custom application");
     }
 
     [Theory]
@@ -683,7 +916,7 @@ public class GraphApiServiceTests
         return mock;
     }
 
-    private static GraphApiService CreateServiceWithTokenProvider(TestHttpMessageHandler handler)
+    private static GraphApiService CreateServiceWithTokenProvider(HttpMessageHandler handler)
     {
         var logger = Substitute.For<ILogger<GraphApiService>>();
         var executor = Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>());
@@ -980,4 +1213,3 @@ internal class CapturingHttpMessageHandler : HttpMessageHandler
         base.Dispose(disposing);
     }
 }
-

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Helpers/JwtHelperTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Helpers/JwtHelperTests.cs
@@ -1,0 +1,172 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services.Helpers;
+
+/// <summary>
+/// Unit tests for JwtHelper, focused on TryDecodeSpaceDelimitedClaim (used to validate a
+/// first-party client app's granted scopes from the token's 'scp' claim).
+/// </summary>
+public class JwtHelperTests
+{
+    private static string BuildJwt(object payload)
+    {
+        var header = Base64UrlEncode("""{"alg":"none","typ":"JWT"}""");
+        var body = Base64UrlEncode(JsonSerializer.Serialize(payload));
+        // Signature segment is irrelevant to claim decoding — only the payload is parsed.
+        return $"{header}.{body}.sig";
+    }
+
+    private static string Base64UrlEncode(string json)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return Convert.ToBase64String(bytes)
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WithMultipleScopes_ReturnsAllValues()
+    {
+        var jwt = BuildJwt(new { scp = "AgentIdentityBlueprint.ReadWrite.All User.Read Application.Read.All" });
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            jwt, "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeTrue(
+            because: "a valid string scp claim must be accepted for delegated authorization validation");
+        failureReason.Should().BeEmpty(
+            because: "a successfully decoded scp claim must not report an authorization parsing failure");
+        scopes.Should().BeEquivalentTo(
+            new[] { "AgentIdentityBlueprint.ReadWrite.All", "User.Read", "Application.Read.All" },
+            because: "each space-separated token in the 'scp' claim must be decoded as a distinct granted scope");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_IsCaseInsensitive()
+    {
+        var jwt = BuildJwt(new { scp = "User.Read" });
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            jwt, "scp", out var scopes, out _);
+
+        succeeded.Should().BeTrue(
+            because: "a valid string scp claim must be decoded before case-insensitive scope comparison");
+        scopes.Contains("user.read").Should().BeTrue(
+            because: "scope comparison must be case-insensitive so validation isn't brittle to casing differences from Graph");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenClaimAbsent_ReturnsExplicitFailure()
+    {
+        var jwt = BuildJwt(new { aud = "00000003-0000-0000-c000-000000000000" });
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            jwt, "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "an absent scp claim cannot prove delegated authorization");
+        scopes.Should().BeEmpty(
+            because: "no delegated scopes can be proven when the token omits scp");
+        failureReason.Should().Contain("does not contain a 'scp' claim",
+            because: "operators must be told that delegated authorization could not be inspected");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenTokenMalformed_ReturnsExplicitFailure()
+    {
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            "not-a-jwt", "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "a malformed token must be distinguishable from a valid token that omits a required scope");
+        scopes.Should().BeEmpty(
+            because: "no delegated scopes can be trusted from a malformed compact token");
+        failureReason.Should().Contain("not a valid compact JWT",
+            because: "malformed token structure must be diagnosed separately from missing permissions");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenTokenNull_ReturnsExplicitFailure()
+    {
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            null, "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "an absent access token cannot prove first-party delegated authorization");
+        scopes.Should().BeEmpty(
+            because: "no scopes exist to validate when token acquisition returns null");
+        failureReason.Should().Contain("empty",
+            because: "token acquisition failure must be reported explicitly");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenClaimEmptyString_SucceedsWithEmptySet()
+    {
+        var jwt = BuildJwt(new { scp = "" });
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            jwt, "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeTrue(
+            because: "an empty string is a readable scp claim whose authorization set is empty");
+        scopes.Should().BeEmpty(because: "an empty 'scp' claim means no scopes were granted");
+        failureReason.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenPayloadIsInvalidBase64Url_ReturnsExplicitFailure()
+    {
+        var header = Base64UrlEncode("""{"alg":"none","typ":"JWT"}""");
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            $"{header}.%%%.sig", "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "an unreadable payload must not be reported as a valid token with missing scopes");
+        scopes.Should().BeEmpty(
+            because: "no scopes can be trusted when the JWT payload cannot be decoded");
+        failureReason.Should().Contain("invalid Base64Url",
+            because: "invalid token encoding must be distinguishable from a valid token missing scopes");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenPayloadIsInvalidJson_ReturnsExplicitFailure()
+    {
+        var header = Base64UrlEncode("""{"alg":"none","typ":"JWT"}""");
+        var payload = Base64UrlEncode("not-json");
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            $"{header}.{payload}.sig", "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "an unreadable payload must not be reported as a valid token with missing scopes");
+        scopes.Should().BeEmpty(
+            because: "no scopes can be trusted when the decoded token payload is not JSON");
+        failureReason.Should().Contain("not valid JSON",
+            because: "invalid token JSON must be distinguishable from missing delegated scopes");
+    }
+
+    [Fact]
+    public void TryDecodeSpaceDelimitedClaim_WhenClaimIsNotAString_ReturnsExplicitFailure()
+    {
+        var jwt = BuildJwt(new { scp = new[] { "User.Read" } });
+
+        var succeeded = JwtHelper.TryDecodeSpaceDelimitedClaim(
+            jwt, "scp", out var scopes, out var failureReason);
+
+        succeeded.Should().BeFalse(
+            because: "the OAuth scp claim must be a space-delimited JSON string");
+        scopes.Should().BeEmpty(
+            because: "OAuth delegated scopes cannot be interpreted from a non-string scp value");
+        failureReason.Should().Contain("'scp' claim is not a string",
+            because: "the OAuth scp contract requires a space-delimited string");
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MsalBrowserCredentialTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MsalBrowserCredentialTests.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Azure.Core;
+using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using NSubstitute;
@@ -161,6 +163,147 @@ public class MsalBrowserCredentialTests
     #region Platform Detection Tests
 
     [Fact]
+    public void SelectAuthenticationMode_FirstPartyAppOnWindows_UsesWam()
+    {
+        var mode = MsalBrowserCredential.SelectAuthenticationMode(
+            AuthenticationConstants.WellKnownClientAppId,
+            useWam: true,
+            isWindows: true);
+
+        Assert.Equal(MsalBrowserCredential.InteractiveAuthenticationMode.Wam, mode);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void SelectAuthenticationMode_FirstPartyAppWithoutWam_UsesDeviceCode(
+        bool useWam,
+        bool isWindows)
+    {
+        var mode = MsalBrowserCredential.SelectAuthenticationMode(
+            AuthenticationConstants.WellKnownClientAppId,
+            useWam,
+            isWindows);
+
+        Assert.Equal(
+            MsalBrowserCredential.InteractiveAuthenticationMode.DeviceCode,
+            mode);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void SelectAuthenticationMode_CustomAppWithoutWam_UsesSystemBrowser(
+        bool useWam,
+        bool isWindows)
+    {
+        var mode = MsalBrowserCredential.SelectAuthenticationMode(
+            ValidClientId,
+            useWam,
+            isWindows);
+
+        Assert.Equal(
+            MsalBrowserCredential.InteractiveAuthenticationMode.SystemBrowser,
+            mode);
+    }
+
+    [Fact]
+    public void SelectAuthenticationMode_CustomAppOnWindowsWithWam_PreservesWam()
+    {
+        var mode = MsalBrowserCredential.SelectAuthenticationMode(
+            ValidClientId,
+            useWam: true,
+            isWindows: true);
+
+        mode.Should().Be(
+            MsalBrowserCredential.InteractiveAuthenticationMode.Wam,
+            because: "tenant-owned custom apps already use WAM on Windows and the FPA fix must not change that behavior");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_FirstPartyWithoutWam_UsesDeviceCodeOnly()
+    {
+        var acquirer = CreateEmptyAcquirer();
+        var expected = CreateAccessToken();
+        acquirer.DeviceCodeResult = expected;
+        var credential = new MsalBrowserCredential(
+            AuthenticationConstants.WellKnownClientAppId,
+            ValidTenantId,
+            MsalBrowserCredential.InteractiveAuthenticationMode.DeviceCode,
+            acquirer);
+
+        var result = await credential.GetTokenAsync(
+            new TokenRequestContext(["https://graph.microsoft.com/Application.Read.All"]),
+            CancellationToken.None);
+
+        result.Token.Should().Be(expected.Token,
+            because: "the FPA has no localhost browser reply URI, so WSL, macOS, and Linux must authenticate with device code");
+        acquirer.DeviceCodeCalls.Should().Be(1,
+            because: "the non-WAM FPA path must invoke device code exactly once");
+        acquirer.SystemBrowserCalls.Should().Be(0,
+            because: "the FPA has no localhost reply URI for browser authentication");
+        acquirer.WamCalls.Should().Be(0,
+            because: "WAM is unavailable in WSL, macOS, and Linux");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_CustomAppWithoutWam_UsesSystemBrowserOnly()
+    {
+        var acquirer = CreateEmptyAcquirer();
+        var expected = CreateAccessToken();
+        acquirer.SystemBrowserResult = expected;
+        var credential = new MsalBrowserCredential(
+            ValidClientId,
+            ValidTenantId,
+            MsalBrowserCredential.InteractiveAuthenticationMode.SystemBrowser,
+            acquirer);
+
+        var result = await credential.GetTokenAsync(
+            new TokenRequestContext(["https://graph.microsoft.com/User.Read"]),
+            CancellationToken.None);
+
+        result.Token.Should().Be(expected.Token,
+            because: "tenant-owned custom apps retain their registered localhost browser callback flow");
+        acquirer.SystemBrowserCalls.Should().Be(1,
+            because: "a custom app without WAM must keep its registered browser callback flow");
+        acquirer.DeviceCodeCalls.Should().Be(0,
+            because: "the FPA-specific fallback must not alter custom-app authentication");
+        acquirer.WamCalls.Should().Be(0,
+            because: "this scenario explicitly represents a platform without WAM");
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_FirstPartyWithWam_UsesWamOnly()
+    {
+        var acquirer = CreateEmptyAcquirer();
+        acquirer.OperatingSystemAccountFailure = new MsalUiRequiredException(
+            "interaction_required",
+            "Interactive WAM sign-in is required.");
+        var expected = CreateAccessToken();
+        acquirer.WamResult = expected;
+        var credential = new MsalBrowserCredential(
+            AuthenticationConstants.WellKnownClientAppId,
+            ValidTenantId,
+            MsalBrowserCredential.InteractiveAuthenticationMode.Wam,
+            acquirer);
+
+        var result = await credential.GetTokenAsync(
+            new TokenRequestContext(["https://graph.microsoft.com/User.Read"]),
+            CancellationToken.None);
+
+        result.Token.Should().Be(expected.Token,
+            because: "Windows should continue using the broker-backed WAM flow for the FPA");
+        acquirer.WamCalls.Should().Be(1,
+            because: "Windows must retain the broker-backed FPA authentication path");
+        acquirer.DeviceCodeCalls.Should().Be(0,
+            because: "device code is only the FPA fallback when WAM is unavailable");
+        acquirer.SystemBrowserCalls.Should().Be(0,
+            because: "the FPA must never use a localhost browser callback");
+    }
+
+    [Fact]
     public void WamShouldOnlyBeEnabledOnWindows()
     {
         // This test documents the expected platform behavior:
@@ -217,6 +360,68 @@ public class MsalBrowserCredentialTests
     }
 
     #endregion
+
+    private static TestMsalTokenAcquirer CreateEmptyAcquirer() => new();
+
+    private static AccessToken CreateAccessToken() =>
+        new("test-token", DateTimeOffset.UtcNow.AddHours(1));
+
+    private sealed class TestMsalTokenAcquirer : MsalBrowserCredential.IMsalTokenAcquirer
+    {
+        public AccessToken DeviceCodeResult { get; set; }
+        public AccessToken SystemBrowserResult { get; set; }
+        public AccessToken WamResult { get; set; }
+        public Exception? OperatingSystemAccountFailure { get; set; }
+        public int DeviceCodeCalls { get; private set; }
+        public int SystemBrowserCalls { get; private set; }
+        public int WamCalls { get; private set; }
+
+        public Task<IReadOnlyList<IAccount>> GetAccountsAsync() =>
+            Task.FromResult<IReadOnlyList<IAccount>>([]);
+
+        public Task<AccessToken> AcquireTokenSilentAsync(
+            string[] scopes,
+            IAccount account,
+            bool forceRefresh,
+            CancellationToken cancellationToken) =>
+            throw new InvalidOperationException("No cached account should be used in these tests.");
+
+        public Task<AccessToken> AcquireOperatingSystemAccountSilentAsync(
+            string[] scopes,
+            bool forceRefresh,
+            CancellationToken cancellationToken) =>
+            OperatingSystemAccountFailure is not null
+                ? Task.FromException<AccessToken>(OperatingSystemAccountFailure)
+                : throw new InvalidOperationException("An operating-system account result was not configured.");
+
+        public Task<AccessToken> AcquireWamAsync(
+            string[] scopes,
+            IAccount? account,
+            string? loginHint,
+            CancellationToken cancellationToken)
+        {
+            WamCalls++;
+            return Task.FromResult(WamResult);
+        }
+
+        public Task<AccessToken> AcquireSystemBrowserAsync(
+            string[] scopes,
+            string? loginHint,
+            CancellationToken cancellationToken)
+        {
+            SystemBrowserCalls++;
+            return Task.FromResult(SystemBrowserResult);
+        }
+
+        public Task<AccessToken> AcquireDeviceCodeAsync(
+            string[] scopes,
+            ILogger? logger,
+            CancellationToken cancellationToken)
+        {
+            DeviceCodeCalls++;
+            return Task.FromResult(DeviceCodeResult);
+        }
+    }
 
     #region Persistent Cache Tests
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MsalBrowserCredentialTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/MsalBrowserCredentialTests.cs
@@ -239,11 +239,11 @@ public class MsalBrowserCredentialTests
             CancellationToken.None);
 
         result.Token.Should().Be(expected.Token,
-            because: "the FPA has no localhost browser reply URI, so WSL, macOS, and Linux must authenticate with device code");
+            because: "the FPA system-browser request is rejected with AADSTS70007 in WSL/non-Windows environments, while device code avoids that response-mode incompatibility");
         acquirer.DeviceCodeCalls.Should().Be(1,
             because: "the non-WAM FPA path must invoke device code exactly once");
         acquirer.SystemBrowserCalls.Should().Be(0,
-            because: "the FPA has no localhost reply URI for browser authentication");
+            because: "the FPA must not repeat the system-browser request that Entra rejects with AADSTS70007");
         acquirer.WamCalls.Should().Be(0,
             because: "WAM is unavailable in WSL, macOS, and Linux");
     }
@@ -300,7 +300,7 @@ public class MsalBrowserCredentialTests
         acquirer.DeviceCodeCalls.Should().Be(0,
             because: "device code is only the FPA fallback when WAM is unavailable");
         acquirer.SystemBrowserCalls.Should().Be(0,
-            because: "the FPA must never use a localhost browser callback");
+            because: "native Windows must retain WAM rather than switching the FPA to system-browser authentication");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/ClientAppRequirementCheckTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/ClientAppRequirementCheckTests.cs
@@ -196,9 +196,10 @@ public class ClientAppRequirementCheckTests
         var check = new ClientAppRequirementCheck(_mockValidator);
 
         // Act & Assert
-        check.Description.Should().Contain("custom client app");
-        check.Description.Should().Contain("Microsoft Graph permissions");
-        check.Description.Should().Contain("admin consent");
+        check.Description.Should().Contain("first-party or custom client app",
+            because: "the requirement check supports both the Microsoft-managed app and tenant-owned custom apps");
+        check.Description.Should().Contain("Microsoft Graph authorization",
+            because: "first-party readiness is established from delegated token authorization rather than tenant-local grant mutation");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/WidsOptionalClaimRequirementCheckTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/WidsOptionalClaimRequirementCheckTests.cs
@@ -82,7 +82,7 @@ public class WidsOptionalClaimRequirementCheckTests
     }
 
     [Fact]
-    public async Task CheckAsync_FirstPartyClientApp_SkipsTenantLocalOptionalClaimsInspection()
+    public async Task CheckAsync_FirstPartyClientApp_WhenIssuedTokenCarriesWids_ReturnsSuccess()
     {
         var check = new WidsOptionalClaimRequirementCheck(_validator);
         var config = new Agent365Config
@@ -90,15 +90,63 @@ public class WidsOptionalClaimRequirementCheckTests
             ClientAppId = AuthenticationConstants.WellKnownClientAppId,
             TenantId = ValidTenantId
         };
+        _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<bool?>(true));
 
         var result = await check.CheckAsync(config, _logger);
 
-        result.Passed.Should().BeTrue(
-            because: "customers cannot inspect or change optional claims on Microsoft's first-party application registration");
-        result.Details.Should().Contain("Microsoft-managed",
-            because: "the requirements output must explain why the tenant-local optional-claim check was skipped");
+        result.Passed.Should().BeTrue();
+        result.IsWarning.Should().BeFalse(
+            because: "the claim was verified from a token actually issued to the app, so PASS is truthful");
+        result.Details.Should().Contain(AuthenticationConstants.WellKnownClientAppId,
+            because: "the success details must identify which app was inspected");
         await _validator.DidNotReceive().HasWidsAccessTokenOptionalClaimAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CheckAsync_FirstPartyClientApp_WhenIssuedTokenOmitsWids_ReturnsWarningNotSuccess()
+    {
+        var check = new WidsOptionalClaimRequirementCheck(_validator);
+        var config = new Agent365Config
+        {
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+            TenantId = ValidTenantId
+        };
+        _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<bool?>(false));
+
+        var result = await check.CheckAsync(config, _logger);
+
+        result.IsWarning.Should().BeTrue(
+            because: "an unverified claim must never be reported as PASS just because the app is Microsoft-managed");
+        result.ErrorMessage.Should().Contain("'wids' is not present",
+            because: "the operator must be told the claim was checked and found absent, not that the check was skipped");
+        result.Details.Should().Contain("cannot be changed in your tenant",
+            because: "remediation must not tell customers to patch Microsoft's application registration");
+    }
+
+    [Fact]
+    public async Task CheckAsync_FirstPartyClientApp_WhenTokenUnavailable_ReturnsWarningNotSuccess()
+    {
+        var check = new WidsOptionalClaimRequirementCheck(_validator);
+        var config = new Agent365Config
+        {
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+            TenantId = ValidTenantId
+        };
+        _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+            AuthenticationConstants.WellKnownClientAppId, ValidTenantId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<bool?>(null));
+
+        var result = await check.CheckAsync(config, _logger);
+
+        result.IsWarning.Should().BeTrue(
+            because: "an inconclusive verification is a diagnostic result, not a pass and not a hard failure the tenant could fix");
+        result.ErrorMessage.Should().Contain("Could not verify",
+            because: "the operator must be able to distinguish an unverifiable claim from a confirmed missing claim");
     }
 
     [Fact]
@@ -137,6 +185,26 @@ public class WidsOptionalClaimRequirementCheckTests
             () => check.CheckAsync(config, _logger, new System.Threading.CancellationToken(canceled: true)));
         // Contract: cancellation must propagate so the calling pipeline can abort the entire setup
         // — swallowing it into a Failure result would make Ctrl+C unresponsive.
+    }
+
+    [Fact]
+    public async Task CheckAsync_FirstPartyClientApp_WhenValidatorThrowsCancellation_PropagatesCancellation()
+    {
+        var check = new WidsOptionalClaimRequirementCheck(_validator);
+        var config = new Agent365Config
+        {
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+            TenantId = ValidTenantId
+        };
+        var cancellationToken = new CancellationToken(canceled: true);
+        _validator.HasWidsClaimOnIssuedAccessTokenAsync(
+                config.ClientAppId, config.TenantId, cancellationToken)
+            .Throws(new OperationCanceledException(cancellationToken));
+
+        Func<Task> act = async () => await check.CheckAsync(config, _logger, cancellationToken);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "caller cancellation must propagate through the first-party token inspection path");
     }
 
     [Fact]

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/WidsOptionalClaimRequirementCheckTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Requirements/WidsOptionalClaimRequirementCheckTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
 using Microsoft.Agents.A365.DevTools.Cli.Models;
 using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Agents.A365.DevTools.Cli.Services.Requirements.RequirementChecks;
@@ -78,6 +79,26 @@ public class WidsOptionalClaimRequirementCheckTests
             because: "wids is on the access token so role detection will work — the check has nothing to do");
         result.Details.Should().Contain(ValidClientAppId,
             because: "the success details must identify which app was inspected so the operator can correlate with their app registration");
+    }
+
+    [Fact]
+    public async Task CheckAsync_FirstPartyClientApp_SkipsTenantLocalOptionalClaimsInspection()
+    {
+        var check = new WidsOptionalClaimRequirementCheck(_validator);
+        var config = new Agent365Config
+        {
+            ClientAppId = AuthenticationConstants.WellKnownClientAppId,
+            TenantId = ValidTenantId
+        };
+
+        var result = await check.CheckAsync(config, _logger);
+
+        result.Passed.Should().BeTrue(
+            because: "customers cannot inspect or change optional claims on Microsoft's first-party application registration");
+        result.Details.Should().Contain("Microsoft-managed",
+            because: "the requirements output must explain why the tenant-local optional-claim check was skipped");
+        await _validator.DidNotReceive().HasWidsAccessTokenOptionalClaimAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- default setup and bootstrap to the Microsoft-managed Agent 365 CLI client ID
- resolve the first-party identity through tenant service principals and preserve the tenant-owned custom-app fallback
- validate first-party authorization from acquired token `scp` claims without modifying Microsoft’s application registration or requiring a tenant-local CLI consent grant
- use WAM on native Windows and device code in WSL, macOS, and Linux, avoiding unsupported localhost browser-response flows for the first-party app
- preserve configured custom apps when Graph lookup failures are inconclusive
- add regression coverage for bootstrap, token validation, mutation guards, cross-platform authentication routing, and custom-app compatibility

## Validation
- `dotnet test src\tests.proj --configuration Release --no-restore -p:NuGetAudit=false` — 1,994 passed, 12 skipped
- authentication regression suite — 105 passed
- manual first-party requirements validation succeeded in two tenants with zero tenant-local CLI `oauth2PermissionGrant` records
- manual OBO setup completed with 4 of 4 resources reporting effective inheritance