### PR TITLE
Add VNet enable command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 **Option B — CLI** (`a365 setup admin`) has been removed in this release. Use Option A above, or copy the PowerShell instructions printed in the `a365 setup all` summary output.
 
 ### Added
+- `a365 develop-mcp enable-vnet` enables virtual network support for external MCP servers.
 - Log separator written at the start of each CLI invocation now redacts values for secret-bearing options (e.g. `--idp-client-secret`) so they are not written to the log file in plain text.
 - Authentication context (tenant and user) is now logged at the `Information` level whenever the resolved sign-in identity changes, giving operators a clear audit trail in the log file of who the CLI is acting as, without exposing credentials.
 - `a365 develop-mcp evaluate` command for evaluating MCP server tool schema quality — runs deterministic and semantic checks (via GitHub Copilot or Claude Code CLIs), computes maturity scoring, and generates an interactive HTML report

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -27,6 +27,7 @@ There is reference documentation for each command.
 | [develop-mcp list-servers](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/develop-mcp#develop-mcp-list-servers) | List MCP servers in a specific Dataverse environment. |
 | [develop-mcp publish](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/develop-mcp#develop-mcp-publish) | Publish an MCP server to a Dataverse environment. |
 | [develop-mcp unpublish](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/develop-mcp#develop-mcp-unpublish) | Unpublish an MCP server from a Dataverse environment. |
+| [develop-mcp enable-vnet](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/develop-mcp#develop-mcp-enable-vnet) | Enable virtual network support for external MCP servers. |
 | [publish](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/publish) | Update manifest.json ID values and publish the package. Configure federated identity and app role assignments. |
 | [query-entra](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/query-entra) | Query Microsoft Entra ID for agent information including scopes, permissions, and consent status. |
 | [query-entra blueprint-scopes](https://learn.microsoft.com/microsoft-agent-365/developer/reference/cli/query-entra#query-entra-blueprint-scopes) | List configured scopes and consent status for the agent blueprint. |

--- a/src/DEVELOPER.md
+++ b/src/DEVELOPER.md
@@ -88,6 +88,7 @@ The CLI provides a `develop-mcp` command for managing Model Context Protocol (MC
 - `a365 develop-mcp list-servers -e <environment-id>` — List MCP servers in a specific Dataverse environment
 - `a365 develop-mcp publish -e <environment-id> -s <server-name>` — Publish an MCP server to a Dataverse environment
 - `a365 develop-mcp unpublish -e <environment-id> -s <server-name>` — Unpublish an MCP server from a Dataverse environment
+- `a365 develop-mcp enable-vnet` — Enable virtual network support for external MCP servers
 
 **Key Features:**
 - **Azure CLI Style Parameters:** Uses named options (`--environment-id/-e`, `--server-name/-s`) for better UX
@@ -121,6 +122,9 @@ a365 develop-mcp publish \
 
 # Quick unpublish with short aliases
 a365 develop-mcp unpublish -e "Default-12345678-1234-1234-1234-123456789abc" -s "msdyn_MyMcpServer"
+
+# Enable virtual network support for external MCP servers
+a365 develop-mcp enable-vnet
 
 # Test commands safely with dry-run
 a365 develop-mcp publish -e "myenv" -s "myserver" --dry-run
@@ -978,5 +982,3 @@ Logging is implemented using Serilog with dual sinks:
 Command name detection is automatic - the CLI analyzes command-line arguments to determine which command is running.
 
 ---
-
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Commands/DevelopMcpCommand.cs
@@ -39,6 +39,7 @@ public static class DevelopMcpCommand
         developMcpCommand.AddCommand(CreatePublishSubcommand(logger, toolingService, graphApiService));
         developMcpCommand.AddCommand(CreateUnpublishSubcommand(logger, toolingService));
         developMcpCommand.AddCommand(CreateRegisterExternalMcpServerSubcommand(logger, toolingService, graphApiService));
+        developMcpCommand.AddCommand(CreateEnableVnetSubcommand(logger, toolingService));
 
         if (evaluationPipelineService is not null)
         {
@@ -528,6 +529,50 @@ public static class DevelopMcpCommand
             logger.LogInformation("Successfully unpublished MCP server {ServerName} from environment {EnvId}", serverName, envId);
 
         }, envIdOption, serverNameOption, dryRunOption, verboseOption);
+
+        return command;
+    }
+
+    /// <summary>
+    /// Creates the enable-vnet subcommand.
+    /// </summary>
+    private static Command CreateEnableVnetSubcommand(
+        ILogger logger,
+        IAgent365ToolingService toolingService)
+    {
+        var command = new Command(
+            "enable-vnet",
+            "Enable virtual network support for external MCP servers");
+
+        var dryRunOption = new Option<bool>(
+            "--dry-run",
+            description: "Show what would be done without executing");
+        command.AddOption(dryRunOption);
+
+        command.AddOption(new Option<bool>(
+            ["--verbose", "-v"],
+            description: "Enable verbose logging"));
+
+        command.SetHandler(async (context) =>
+        {
+            var dryRun = context.ParseResult.GetValueForOption(dryRunOption);
+            if (dryRun)
+            {
+                logger.LogInformation("[DRY RUN] Would enable virtual network support for external MCP servers");
+                return;
+            }
+
+            logger.LogInformation("Enabling virtual network support for external MCP servers...");
+            var success = await toolingService.EnableVnetAsync(context.GetCancellationToken());
+            if (!success)
+            {
+                logger.LogError("Failed to enable virtual network support for external MCP servers.");
+                context.ExitCode = 1;
+                return;
+            }
+
+            logger.LogInformation("Virtual network support for external MCP servers enabled successfully.");
+        });
 
         return command;
     }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Agent365ToolingService.cs
@@ -17,9 +17,11 @@ namespace Microsoft.Agents.A365.DevTools.Cli.Services;
 public class Agent365ToolingService : IAgent365ToolingService
 {
     private readonly IConfigService _configService;
-    private readonly AuthenticationService _authService;
+    private readonly IAuthenticationService _authService;
     private readonly ILogger<Agent365ToolingService> _logger;
     private readonly string _environment;
+    private readonly HttpMessageHandler? _httpMessageHandler;
+    private readonly Func<Task<string?>> _loginHintResolver;
 
     /// <inheritdoc />
     public string Environment => _environment;
@@ -29,11 +31,25 @@ public class Agent365ToolingService : IAgent365ToolingService
         AuthenticationService authService,
         ILogger<Agent365ToolingService> logger,
         string environment = "prod")
+        : this(configService, authService, logger, environment, null, null)
+    {
+    }
+
+
+    internal Agent365ToolingService(
+        IConfigService configService,
+        IAuthenticationService authService,
+        ILogger<Agent365ToolingService> logger,
+        string environment,
+        HttpMessageHandler? httpMessageHandler,
+        Func<Task<string?>>? loginHintResolver)
     {
         _configService = configService ?? throw new ArgumentNullException(nameof(configService));
         _authService = authService ?? throw new ArgumentNullException(nameof(authService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _environment = environment ?? "prod";
+        _httpMessageHandler = httpMessageHandler;
+        _loginHintResolver = loginHintResolver ?? AzCliHelper.ResolveLoginHintAsync;
     }
 
     /// <summary>
@@ -297,6 +313,12 @@ public class Agent365ToolingService : IAgent365ToolingService
     {
         var baseUrl = BuildAgent365ToolsBaseUrl(environment);
         return $"{baseUrl}/agents/externalMcpServers/logEvaluate";
+    }
+
+    private string BuildEnableVnetUrl(string environment)
+    {
+        var baseUrl = BuildAgent365ToolsBaseUrl(environment);
+        return $"{baseUrl}/agents/vnet/enable";
     }
 
     /// <summary>
@@ -697,6 +719,58 @@ public class Agent365ToolingService : IAgent365ToolingService
         }
     }
 
+    /// <inheritdoc />
+    public async Task<bool> EnableVnetAsync(CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var endpointUrl = BuildEnableVnetUrl(_environment);
+            var correlationId = Internal.HttpClientFactory.GenerateCorrelationId();
+            var audience = ConfigConstants.GetAgent365ToolsResourceAppId(_environment);
+
+            _logger.LogDebug("Enabling virtual network support (CorrelationId: {CorrelationId})", correlationId);
+            _logger.LogDebug("Environment: {Env}", _environment);
+            _logger.LogDebug("Endpoint URL: {Url}", endpointUrl);
+            _logger.LogDebug("Acquiring access token for audience: {Audience}", audience);
+
+            var loginHint = await _loginHintResolver().WaitAsync(cancellationToken);
+            var authToken = await _authService.GetAccessTokenAsync(
+                audience,
+                userId: loginHint,
+                ct: cancellationToken);
+            if (string.IsNullOrWhiteSpace(authToken))
+            {
+                _logger.LogError("Failed to acquire authentication token");
+                return false;
+            }
+
+            using var httpClient = Internal.HttpClientFactory.CreateAuthenticatedClient(
+                authToken,
+                correlationId: correlationId,
+                handler: _httpMessageHandler,
+                disposeHandler: _httpMessageHandler is null);
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpointUrl);
+
+            LogRequest("POST", endpointUrl);
+
+            using var response = await httpClient.SendAsync(request, cancellationToken);
+            var (isSuccess, _) = await ValidateResponseAsync(
+                response,
+                "enable virtual network support",
+                cancellationToken);
+            return isSuccess;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to enable virtual network support");
+            return false;
+        }
+    }
+
     public async Task<AddMcpServerResponse?> AddMcpServerAsync(
         AddMcpServerRequest request,
         string? environmentId = null,
@@ -905,4 +979,3 @@ public class Agent365ToolingService : IAgent365ToolingService
         }
     }
 }
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/IAgent365ToolingService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/IAgent365ToolingService.cs
@@ -76,6 +76,13 @@ public interface IAgent365ToolingService
     Task LogEvaluateUsageAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Enables virtual network support for external MCP servers.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True when virtual network support was enabled successfully; otherwise false</returns>
+    Task<bool> EnableVnetAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Adds a BYO (Bring Your Own) MCP server
     /// </summary>
     /// <param name="request">Add MCP server request</param>
@@ -108,4 +115,3 @@ public interface IAgent365ToolingService
         bool force = false,
         CancellationToken cancellationToken = default);
 }
-

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/HttpClientFactory.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Internal/HttpClientFactory.cs
@@ -20,15 +20,20 @@ public static class HttpClientFactory
     /// Optional correlation ID for request tracing. If null, empty, or whitespace,
     /// a new GUID will be generated automatically.
     /// </param>
+    /// <param name="handler">Optional HTTP message handler.</param>
+    /// <param name="disposeHandler">
+    /// Whether disposing the returned client also disposes <paramref name="handler"/>.
+    /// </param>
     /// <returns>A configured HttpClient instance with the correlation ID applied.</returns>
     public static HttpClient CreateAuthenticatedClient(
         string? authToken = null,
         string userAgentPrefix = DefaultUserAgentPrefix,
         string? correlationId = null,
-        HttpMessageHandler? handler = null)
+        HttpMessageHandler? handler = null,
+        bool disposeHandler = true)
     {
         var client = handler != null
-            ? new HttpClient(handler) { Timeout = TimeSpan.FromMinutes(2) }
+            ? new HttpClient(handler, disposeHandler) { Timeout = TimeSpan.FromMinutes(2) }
             : new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
 
         if (!string.IsNullOrWhiteSpace(authToken))

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/DevelopMcpCommandTests.cs
@@ -42,17 +42,22 @@ public class DevelopMcpCommandTests
         var command = DevelopMcpCommand.CreateCommand(_mockLogger, _mockToolingService);
 
         // Assert
-        command.Subcommands.Should().HaveCount(5);
+        command.Subcommands.Should().HaveCount(
+            6,
+            because: "enable-vnet must be registered in the develop-mcp command group");
 
         var subcommandNames = command.Subcommands.Select(sc => sc.Name).ToList();
-        subcommandNames.Should().Contain(new[]
-        {
-            "list-environments",
-            "list-servers",
-            "publish",
-            "unpublish",
-            "register-external-mcp-server"
-        });
+        subcommandNames.Should().Contain(
+            new[]
+            {
+                "list-environments",
+                "list-servers",
+                "publish",
+                "unpublish",
+                "register-external-mcp-server",
+                "enable-vnet"
+            },
+            because: "all supported develop-mcp commands must remain registered");
     }
 
     [Fact]
@@ -246,6 +251,27 @@ public class DevelopMcpCommandTests
 
         var verboseOption = options.First(o => o.Name == "verbose");
         verboseOption.Aliases.Should().Contain("-v");
+    }
+
+    [Fact]
+    public void EnableVnetSubcommand_HasExpectedShape()
+    {
+        // Act
+        var command = DevelopMcpCommand.CreateCommand(_mockLogger, _mockToolingService);
+        var subcommand = command.Subcommands.First(sc => sc.Name == "enable-vnet");
+
+        // Assert
+        subcommand.Description.Should().Be(
+            "Enable virtual network support for external MCP servers",
+            because: "the enable-vnet help text is user-facing");
+        subcommand.Arguments.Should().BeEmpty(
+            because: "the MCP Platform endpoint accepts no route parameters");
+        subcommand.Options.Select(o => o.Name).Should().BeEquivalentTo(
+            ["dry-run", "verbose"],
+            because: "the endpoint accepts no payload fields or command-specific inputs");
+        subcommand.Options.First(o => o.Name == "verbose").Aliases.Should().Contain(
+            "-v",
+            because: "enable-vnet should follow the neighboring command's verbose alias convention");
     }
 
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/EnableVnetCommandTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Commands/EnableVnetCommandTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Commands;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.CommandLine;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Commands;
+
+public class EnableVnetCommandTests
+{
+    private readonly CapturingLogger _logger = new();
+    private readonly IAgent365ToolingService _toolingService =
+        Substitute.For<IAgent365ToolingService>();
+
+    [Fact]
+    public async Task EnableVnet_ServiceSucceeds_ExitsZeroAndWritesSuccessOutput()
+    {
+        _toolingService.EnableVnetAsync(Arg.Any<CancellationToken>()).Returns(true);
+        var command = DevelopMcpCommand.CreateCommand(_logger, _toolingService);
+
+        var exitCode = await command.InvokeAsync("enable-vnet");
+
+        exitCode.Should().Be(
+            0,
+            because: "a successful enable-vnet operation must exit successfully");
+        _logger.Messages.Should().Contain(
+            "Virtual network support for external MCP servers enabled successfully.",
+            because: "users must receive confirmation after the platform enables VNet support");
+        await _toolingService.Received(1).EnableVnetAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnableVnet_ServiceFails_ExitsOneAndWritesErrorOutput()
+    {
+        _toolingService.EnableVnetAsync(Arg.Any<CancellationToken>()).Returns(false);
+        var command = DevelopMcpCommand.CreateCommand(_logger, _toolingService);
+
+        var exitCode = await command.InvokeAsync("enable-vnet");
+
+        exitCode.Should().Be(
+            1,
+            because: "a failed platform operation must produce a nonzero exit code");
+        _logger.Messages.Should().Contain(
+            "Failed to enable virtual network support for external MCP servers.",
+            because: "users must receive an actionable failure message");
+        await _toolingService.Received(1).EnableVnetAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task EnableVnet_DryRun_ExitsZeroWithoutCallingService()
+    {
+        var command = DevelopMcpCommand.CreateCommand(_logger, _toolingService);
+
+        var exitCode = await command.InvokeAsync("enable-vnet --dry-run");
+
+        exitCode.Should().Be(
+            0,
+            because: "dry-run validation should complete successfully");
+        _logger.Messages.Should().Contain(
+            "[DRY RUN] Would enable virtual network support for external MCP servers",
+            because: "dry-run output must describe the operation without executing it");
+        await _toolingService.DidNotReceive().EnableVnetAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("enable-vnet unexpected-argument")]
+    [InlineData("enable-vnet --unsupported-option")]
+    public async Task EnableVnet_UnsupportedInput_ExitsWithErrorWithoutCallingService(string input)
+    {
+        var command = DevelopMcpCommand.CreateCommand(_logger, _toolingService);
+
+        var exitCode = await command.InvokeAsync(input);
+
+        exitCode.Should().Be(
+            1,
+            because: "unsupported input must return the standard CLI failure exit code");
+        await _toolingService.DidNotReceive().EnableVnetAsync(Arg.Any<CancellationToken>());
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ToolingServiceEnableVnetTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Agent365ToolingServiceEnableVnetTests.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
+
+public class Agent365ToolingServiceEnableVnetTests
+{
+    [Fact]
+    public async Task EnableVnetAsync_Success_SendsExpectedRequest()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        var (service, authService) = CreateService(handler, "access-token");
+
+        var result = await service.EnableVnetAsync();
+
+        result.Should().BeTrue(
+            because: "a successful MCP Platform response must be reported as enabled");
+        handler.Method.Should().Be(
+            HttpMethod.Post,
+            because: "the MCP Platform VNet enable contract is a POST operation");
+        handler.RequestUri.Should().Be(
+            "https://agent365.svc.cloud.microsoft/agents/vnet/enable",
+            because: "the command must target the MCP Platform VNet enable route without route parameters");
+        handler.Body.Should().BeNull(
+            because: "the VNet enable endpoint does not define a request payload");
+        handler.Authorization.Should().Be(
+            new AuthenticationHeaderValue("Bearer", "access-token"),
+            because: "MCP Platform management calls require the acquired bearer token");
+        await authService.Received(1).GetAccessTokenAsync(
+            Arg.Any<string>(),
+            null,
+            false,
+            null,
+            null,
+            true,
+            "developer@contoso.com",
+            Arg.Any<CancellationToken>());
+        authService.ReceivedCalls()
+            .Single()
+            .GetArguments()[0]
+            .Should().Be(
+                McpConstants.WorkIQToolsProdAppId,
+                because: "MCP Platform management calls require the Agent365 tooling OAuth audience");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_AuthorizationError_ReturnsFalse()
+    {
+        using var handler = new RecordingHandler(
+            HttpStatusCode.Forbidden,
+            """{"error":{"message":"Insufficient privileges"}}""");
+        var (service, _) = CreateService(handler, "access-token");
+
+        var result = await service.EnableVnetAsync();
+
+        result.Should().BeFalse(
+            because: "authorization failures from MCP Platform must produce a failed CLI operation");
+        handler.SendCount.Should().Be(
+            1,
+            because: "the configured authorization error response must be exercised");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_ServiceError_ReturnsFalse()
+    {
+        using var handler = new RecordingHandler(
+            HttpStatusCode.InternalServerError,
+            """{"error":{"message":"Service unavailable"}}""");
+        var (service, _) = CreateService(handler, "access-token");
+
+        var result = await service.EnableVnetAsync();
+
+        result.Should().BeFalse(
+            because: "non-success service responses must not be reported as an enabled VNet");
+        handler.SendCount.Should().Be(
+            1,
+            because: "the configured service error response must be exercised");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_AuthenticationFails_DoesNotSendRequest()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        var (service, _) = CreateService(handler, string.Empty);
+
+        var result = await service.EnableVnetAsync();
+
+        result.Should().BeFalse(
+            because: "authentication failure must prevent the operation from succeeding");
+        handler.SendCount.Should().Be(
+            0,
+            because: "the MCP Platform request must not be sent without an access token");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_ReusedInjectedHandler_RemainsUsable()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        var (service, _) = CreateService(handler, "access-token");
+
+        var firstResult = await service.EnableVnetAsync();
+        var secondResult = await service.EnableVnetAsync();
+
+        firstResult.Should().BeTrue(
+            because: "the initial request should succeed before handler reuse is verified");
+        secondResult.Should().BeTrue(
+            because: "the service must not dispose a caller-owned HTTP message handler");
+        handler.SendCount.Should().Be(
+            2,
+            because: "the injected handler should remain available for subsequent operations");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_LoginHintResolutionStalls_PropagatesCancellation()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        using var cancellationSource = new CancellationTokenSource();
+        var loginHintCompletion = new TaskCompletionSource<string?>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var (service, _) = CreateService(
+            handler,
+            "access-token",
+            () => loginHintCompletion.Task);
+
+        var enableVnetTask = service.EnableVnetAsync(cancellationSource.Token);
+        await cancellationSource.CancelAsync();
+        var action = () => enableVnetTask;
+
+        await action.Should().ThrowAsync<OperationCanceledException>(
+            because: "caller cancellation must interrupt stalled login-hint resolution");
+        handler.SendCount.Should().Be(
+            0,
+            because: "a canceled operation must not send the MCP Platform request");
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_HttpRequestIsCanceled_ForwardsTokenAndPropagatesCancellation()
+    {
+        using var handler = new BlockingHandler();
+        using var cancellationSource = new CancellationTokenSource();
+        var (service, authService) = CreateService(handler, "access-token");
+
+        var enableVnetTask = service.EnableVnetAsync(cancellationSource.Token);
+        await handler.RequestStarted.Task;
+        await cancellationSource.CancelAsync();
+        var action = () => enableVnetTask;
+
+        await action.Should().ThrowAsync<OperationCanceledException>(
+            because: "caller cancellation during HTTP transmission must not be converted to a service failure");
+        handler.CancellationToken.CanBeCanceled.Should().BeTrue(
+            because: "the HTTP request must remain cancelable by its caller");
+        handler.CancellationToken.IsCancellationRequested.Should().BeTrue(
+            because: "canceling the caller token must cancel the in-flight HTTP request");
+        await authService.Received(1).GetAccessTokenAsync(
+            Arg.Any<string>(),
+            Arg.Any<string?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<bool>(),
+            Arg.Any<string?>(),
+            cancellationSource.Token);
+    }
+
+    [Fact]
+    public async Task EnableVnetAsync_AuthenticationThrows_ReturnsFalseWithoutSendingRequest()
+    {
+        using var handler = new RecordingHandler(HttpStatusCode.OK);
+        var authService = Substitute.For<IAuthenticationService>();
+        var logger = Substitute.For<ILogger<Agent365ToolingService>>();
+        authService.GetAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<string>(
+                new InvalidOperationException("Authentication unavailable")));
+        var service = new Agent365ToolingService(
+            Substitute.For<IConfigService>(),
+            authService,
+            logger,
+            "vnet-wire-test",
+            handler,
+            () => Task.FromResult<string?>("developer@contoso.com"));
+
+        var result = await service.EnableVnetAsync();
+
+        result.Should().BeFalse(
+            because: "authentication exceptions must produce a failed CLI operation");
+        handler.SendCount.Should().Be(
+            0,
+            because: "the MCP Platform request must not be sent when authentication throws");
+        logger.Received(1).Log(
+            LogLevel.Error,
+            Arg.Any<EventId>(),
+            Arg.Is<object>(state =>
+                state != null &&
+                state.ToString()!.Contains("Failed to enable virtual network support")),
+            Arg.Is<Exception?>(exception => exception is InvalidOperationException),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    private static (Agent365ToolingService Service, IAuthenticationService AuthService) CreateService(
+        HttpMessageHandler handler,
+        string authToken,
+        Func<Task<string?>>? loginHintResolver = null)
+    {
+        var authService = Substitute.For<IAuthenticationService>();
+        authService.GetAccessTokenAsync(
+                Arg.Any<string>(),
+                Arg.Any<string?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<IEnumerable<string>?>(),
+                Arg.Any<bool>(),
+                Arg.Any<string?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(authToken);
+
+        var service = new Agent365ToolingService(
+            Substitute.For<IConfigService>(),
+            authService,
+            Substitute.For<ILogger<Agent365ToolingService>>(),
+            "vnet-wire-test",
+            handler,
+            loginHintResolver ?? (() => Task.FromResult<string?>("developer@contoso.com")));
+
+        return (service, authService);
+    }
+
+    private sealed class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _responseBody;
+        private bool _disposed;
+
+        public RecordingHandler(HttpStatusCode statusCode, string responseBody = "")
+        {
+            _statusCode = statusCode;
+            _responseBody = responseBody;
+        }
+
+        public HttpMethod? Method { get; private set; }
+
+        public string? RequestUri { get; private set; }
+
+        public string? Body { get; private set; }
+
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        public int SendCount { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+
+            SendCount++;
+            Method = request.Method;
+            RequestUri = request.RequestUri?.ToString();
+            Body = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            Authorization = request.Headers.Authorization;
+
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_responseBody),
+            };
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _disposed = disposing;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        public TaskCompletionSource RequestStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public CancellationToken CancellationToken { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            CancellationToken = cancellationToken;
+            RequestStarted.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Internal/HttpClientFactoryTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/Internal/HttpClientFactoryTests.cs
@@ -243,4 +243,48 @@ public class HttpClientFactoryTests
 
         correlationId.Should().Be(clientRequestId, "Both headers should have the same auto-generated correlation ID");
     }
+
+    [Fact]
+    public void CreateAuthenticatedClient_DisposeHandlerTrue_DisposesInjectedHandler()
+    {
+        using var handler = new DisposalTrackingHandler();
+        var client = HttpClientFactory.CreateAuthenticatedClient(
+            handler: handler,
+            disposeHandler: true);
+
+        client.Dispose();
+
+        handler.IsDisposed.Should().BeTrue(
+            because: "the default ownership contract disposes the injected handler with its client");
+    }
+
+    [Fact]
+    public void CreateAuthenticatedClient_DisposeHandlerFalse_PreservesInjectedHandler()
+    {
+        using var handler = new DisposalTrackingHandler();
+        using (var client = HttpClientFactory.CreateAuthenticatedClient(
+            handler: handler,
+            disposeHandler: false))
+        {
+        }
+
+        handler.IsDisposed.Should().BeFalse(
+            because: "callers can retain ownership of a reusable injected handler");
+    }
+
+    private sealed class DisposalTrackingHandler : HttpMessageHandler
+    {
+        public bool IsDisposed { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new HttpResponseMessage());
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = disposing;
+            base.Dispose(disposing);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add `a365 develop-mcp enable-vnet` beside the existing external MCP server registration command
- call the authenticated MCP Platform `POST /agents/vnet/enable` endpoint with no route parameters or request body
- preserve cancellation and failure behavior, and support reusable injected HTTP handlers for request-level tests
- document the command in the changelog, command inventory, and developer guide
- cover command shape, output and exit codes, dry-run and invalid input, request URI/method/body/auth, service and authorization failures, authentication failures, cancellation, and handler ownership

## Validation
- `dotnet test src\Tests\Microsoft.Agents.A365.DevTools.Cli.Tests\Microsoft.Agents.A365.DevTools.Cli.Tests.csproj --configuration Release --no-restore --filter "FullyQualifiedName~EnableVnetCommandTests|FullyQualifiedName~Agent365ToolingServiceEnableVnetTests|FullyQualifiedName~DevelopMcpCommandTests|FullyQualifiedName~HttpClientFactoryTests"` (53 passed)
- `dotnet build src\dirs.proj --no-restore --configuration Release`
- `dotnet build src\tests.proj --no-restore --configuration Release`
- `dotnet test src\tests.proj --no-build --configuration Release --verbosity minimal --blame-hang --blame-hang-timeout 5min` (1,937 passed, 12 skipped)
- `dotnet pack src\dirs.proj --configuration Release --output NuGetPackages --no-restore -p:NuGetAudit=false`
