### PR TITLE
Run client app validation as the ambient operator identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Agents provisioned before this release need `Agent365.Observability.OtelWrite` g
 - `a365 develop get-token --device-code` — forces device code auth for Microsoft Graph scopes the Windows WAM broker rejects (e.g. Exchange `MailboxSettings.ReadWrite`, `ExchangeMessageTrace.Read.All`).
 
 ### Fixed
+- `setup requirements` no longer fails against a correctly configured custom client app, and no longer reports the app as missing when Microsoft Graph cannot complete the lookup (#489).
 - Setup no longer fails to detect the Agent 365 CLI application in tenants where it is not yet provisioned, and reports lookup errors instead of silently switching your configured client app (#489).
 - The first-party Agent 365 CLI app now uses device code authentication when Windows Account Manager is unavailable, avoiding unsupported browser-response errors in WSL, macOS, and Linux (#489).
 - `setup all --authmode s2s` no longer prints spurious "Action Required" PowerShell steps when the agent identity already inherits its app roles from the blueprint, and now retries the grant automatically before falling back to manual steps (#460).

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Exceptions/ClientAppValidationException.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using System.Globalization;
 
 namespace Microsoft.Agents.A365.DevTools.Cli.Exceptions;
 
@@ -48,6 +49,45 @@ public sealed class ClientAppValidationException : Agent365Exception
             {
                 ["clientAppId"] = clientAppId,
                 ["tenantId"] = tenantId
+            });
+    }
+
+    /// <summary>
+    /// Creates an exception when the client app lookup could not complete. Distinct from
+    /// <see cref="AppNotFound"/>: absence is only proven by a successful Graph response with no
+    /// matching application, never by an authorization, HTTP, or network failure.
+    /// </summary>
+    public static ClientAppValidationException ApplicationLookupFailed(
+        string clientAppId,
+        string tenantId,
+        string reason,
+        int statusCode = 0)
+    {
+        var mitigationSteps = new List<string>();
+        if (statusCode == 403)
+        {
+            mitigationSteps.Add($"Ask a tenant administrator to grant your account the '{AuthenticationConstants.ApplicationReadAllScope}' Microsoft Graph permission, or run the command as a Global Administrator or Application Administrator.");
+        }
+
+        mitigationSteps.Add("Confirm you are signed in to the intended tenant with 'az login --tenant <tenantId>'.");
+        mitigationSteps.Add("Confirm network connectivity to Microsoft Graph and retry — the failure may be transient.");
+        mitigationSteps.Add("Do not change 'clientAppId' in a365.config.json based on this error; the app was never confirmed absent.");
+        mitigationSteps.Add($"See setup guide: {ConfigConstants.Agent365CliDocumentationUrl}");
+
+        return new ClientAppValidationException(
+            issueDescription: "Unable to verify the client app registration in the tenant",
+            errorDetails: new List<string>
+            {
+                reason,
+                $"Application lookup for client app '{clientAppId}' failed in tenant '{tenantId}'.",
+                "The lookup did not complete, so the app's presence or absence is unknown."
+            },
+            mitigationSteps: mitigationSteps,
+            context: new Dictionary<string, string>
+            {
+                ["clientAppId"] = clientAppId,
+                ["tenantId"] = tenantId,
+                ["statusCode"] = statusCode.ToString(CultureInfo.InvariantCulture)
             });
     }
 

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/ClientAppValidator.cs
@@ -267,7 +267,9 @@ public sealed class ClientAppValidator : IClientAppValidator
 
                 if (provisioned)
                 {
-                    // Re-fetch fresh app info and re-validate to confirm provisioning succeeded
+                    // Re-fetch fresh app info and re-validate to confirm provisioning succeeded.
+                    // A null result now means only that the app was deleted between the two reads;
+                    // a failed re-read throws rather than silently keeping the stale verdict.
                     var freshAppInfo = await GetClientAppInfoAsync(clientAppId, tenantId, ct);
                     if (freshAppInfo != null)
                     {
@@ -464,7 +466,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         {
             _logger.LogDebug("Checking redirect URIs for client app {ClientAppId}", clientAppId);
 
-            using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var appDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient", ct);
 
             if (appDoc == null)
@@ -519,7 +521,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             foreach (var uri in allUris)
                 urisArray.Add(JsonValue.Create(uri));
 
-            var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+            var patchSuccess = await DirectoryPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 new JsonObject { ["publicClient"] = new JsonObject { ["redirectUris"] = urisArray } },
                 ct);
@@ -611,7 +613,7 @@ public sealed class ClientAppValidator : IClientAppValidator
                 "(required so the CLI can detect Global Administrator role and apply tenant-wide consent grants).");
             _logger.LogInformation("Re-run 'a365 setup requirements' at any time to re-verify this setting.");
 
-            var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+            var patchSuccess = await DirectoryPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 patchPayload,
                 ct);
@@ -648,8 +650,8 @@ public sealed class ClientAppValidator : IClientAppValidator
     /// Attempts to add the 'wids' optional claim and reports admin authority based on the result.
     /// Used only when <see cref="GraphApiService.IsCurrentUserAdminAsync"/> returns Unknown — i.e.
     /// the token can't tell us the role because wids isn't configured yet. A successful PATCH
-    /// implies admin (Application.ReadWrite-scope-on-app via directory role); a 403 with
-    /// <c>Authorization_RequestDenied</c> implies non-admin; anything else is inconclusive.
+    /// implies write authority over the app registration (a directory role, or app ownership);
+    /// a 403 with <c>Authorization_RequestDenied</c> implies non-admin; anything else is inconclusive.
     /// </summary>
     private async Task<ProbeResult> TryProbeAdminViaWidsPatchAsync(
         string clientAppId,
@@ -697,7 +699,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         {
             _logger.LogDebug("Checking 'Allow public client flows' for client app {ClientAppId}", clientAppId);
 
-            using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var appDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient", ct);
 
             if (appDoc == null)
@@ -737,7 +739,7 @@ public sealed class ClientAppValidator : IClientAppValidator
                 "headless environments, and as a Conditional Access Policy fallback on Windows).");
             _logger.LogInformation("Run 'a365 setup requirements' at any time to re-verify and auto-fix this setting.");
 
-            var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+            var patchSuccess = await DirectoryPatchAsync(tenantId,
                 $"/v1.0/applications/{objectId}",
                 new { isFallbackPublicClient = true },
                 ct);
@@ -858,7 +860,7 @@ public sealed class ClientAppValidator : IClientAppValidator
                 });
             }
 
-            var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+            var patchSuccess = await DirectoryPatchAsync(tenantId,
                 $"/v1.0/applications/{appInfo.ObjectId}",
                 new JsonObject { ["requiredResourceAccess"] = updatedResourceAccess },
                 ct);
@@ -898,7 +900,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             // Look up the service principal for the client app
-            using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var spDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
 
             if (spDoc == null) return;
@@ -908,7 +910,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             if (string.IsNullOrWhiteSpace(spObjectId)) return;
 
             // Find the oauth2PermissionGrant that targets Microsoft Graph
-            using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var grantsDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
 
             if (grantsDoc == null) return;
@@ -919,7 +921,7 @@ public sealed class ClientAppValidator : IClientAppValidator
 
             // Look up the Microsoft Graph service principal ID to match against resourceId
             string? graphSpObjectId = null;
-            using var graphSpDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var graphSpDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{AuthenticationConstants.MicrosoftGraphResourceAppId}'&$select=id", ct);
 
             if (graphSpDoc != null)
@@ -953,7 +955,7 @@ public sealed class ClientAppValidator : IClientAppValidator
 
                 var updatedScope = string.Join(' ', existingScopes.Concat(scopesToAdd));
 
-                var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+                var patchSuccess = await DirectoryPatchAsync(tenantId,
                     $"/v1.0/oauth2PermissionGrants/{grantId}",
                     new JsonObject
                     {
@@ -1071,7 +1073,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         try
         {
-            using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var appDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,publicClient", ct);
 
             if (appDoc == null) return new List<string>();
@@ -1111,7 +1113,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         try
         {
-            using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var appDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,isFallbackPublicClient", ct);
 
             if (appDoc == null) return false;
@@ -1148,7 +1150,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         try
         {
-            using var appDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var appDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/applications?$filter=appId eq '{clientAppId}'&$select=id,optionalClaims", ct);
 
             if (appDoc == null) return (false, null, null);
@@ -1203,7 +1205,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         try
         {
-            using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var spDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
             if (spDoc == null) return false;
 
@@ -1211,7 +1213,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             var spObjectId = spJson?["value"]?.AsArray().FirstOrDefault()?.AsObject()["id"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(spObjectId)) return false;
 
-            using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var grantsDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
             if (grantsDoc == null) return false;
 
@@ -1258,7 +1260,7 @@ public sealed class ClientAppValidator : IClientAppValidator
     {
         try
         {
-            using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var spDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
             if (spDoc == null) return;
 
@@ -1266,7 +1268,7 @@ public sealed class ClientAppValidator : IClientAppValidator
             var spObjectId = spJson?["value"]?.AsArray().FirstOrDefault()?.AsObject()["id"]?.GetValue<string>();
             if (string.IsNullOrWhiteSpace(spObjectId)) return;
 
-            using var grantsDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var grantsDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
             if (grantsDoc == null) return;
 
@@ -1294,7 +1296,7 @@ public sealed class ClientAppValidator : IClientAppValidator
 
                 _logger.LogInformation("Upgrading consent grant from per-user to tenant-wide (AllPrincipals)...");
 
-                var patchSuccess = await _graphApiService.GraphPatchAsync(tenantId,
+                var patchSuccess = await DirectoryPatchAsync(tenantId,
                     $"/v1.0/oauth2PermissionGrants/{grantId}",
                     new JsonObject
                     {
@@ -1318,45 +1320,111 @@ public sealed class ClientAppValidator : IClientAppValidator
 
     #region Private Helper Methods
 
+    // Tenant-directory reads and repairs must run as the ambient operator identity. A token
+    // issued for the app under validation carries only User.Read, so Graph rejects every
+    // application and servicePrincipal query with 403 Authorization_RequestDenied (issue #489).
+    private Task<JsonDocument?> DirectoryGetAsync(string tenantId, string relativePath, CancellationToken ct) =>
+        _graphApiService.GraphGetAsync(tenantId, relativePath, ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+
+    private Task<bool> DirectoryPatchAsync(string tenantId, string relativePath, object payload, CancellationToken ct) =>
+        _graphApiService.GraphPatchAsync(tenantId, relativePath, payload, ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+
+    private Task<GraphApiService.GraphResponse> DirectoryGetWithResponseAsync(string tenantId, string relativePath, CancellationToken ct) =>
+        _graphApiService.GraphGetWithResponseAsync(tenantId, relativePath, ct: ct,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+
     private async Task<ClientAppInfo?> GetClientAppInfoAsync(string clientAppId, string tenantId, CancellationToken ct)
     {
         _logger.LogDebug("Checking if client app exists in tenant...");
 
         const string path = "/v1.0/applications?$filter=appId eq '{0}'&$select=id,appId,displayName,requiredResourceAccess";
-        var graphResponse = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-            string.Format(path, clientAppId), ct: ct);
 
-        if (graphResponse == null || !graphResponse.IsSuccess)
+        // Probe with the ambient bootstrap identity: a token issued for the app under validation
+        // cannot prove that app's own absence, and it is not consented for Application.Read.All (issue #489).
+        GraphApiService.GraphResponse graphResponse;
+        try
         {
-            // Only retry on 401 — a stale token due to CAE revocation. Transient errors (503,
-            // network failure) surface the real error to the caller rather than masking it as
-            // "token revoked". StatusCode 0 means token acquisition itself failed.
-            if (graphResponse?.StatusCode != 401)
-            {
-                _logger.LogDebug("Graph app query failed with {StatusCode} — not retrying", graphResponse?.StatusCode);
-                return null;
-            }
-
-            _logger.LogDebug("Graph app query returned 401 — retrying with fresh token (possible CAE revocation)");
             graphResponse = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-                string.Format(path, clientAppId), forceRefresh: true, ct: ct);
+                string.Format(path, clientAppId), ct: ct,
+                authenticationMode: GraphAuthenticationMode.Ambient);
 
-            if (!graphResponse.IsSuccess)
-                throw ClientAppValidationException.TokenRevoked(clientAppId);
+            if (graphResponse is { IsSuccess: false, StatusCode: 401 })
+            {
+                _logger.LogDebug("Graph app query returned 401 — retrying with fresh token (possible CAE revocation)");
+                graphResponse.Json?.Dispose();
+                graphResponse = await _graphApiService.GraphGetWithResponseAsync(tenantId,
+                    string.Format(path, clientAppId), forceRefresh: true, ct: ct,
+                    authenticationMode: GraphAuthenticationMode.Ambient);
+
+                // Only a second 401 proves revocation. Any other failure falls through so the
+                // block below reports it with its real status instead of misdiagnosing it.
+                if (graphResponse is { IsSuccess: false, StatusCode: 401 })
+                    throw ClientAppValidationException.TokenRevoked(clientAppId);
+            }
+        }
+        catch (Exception ex) when (ex is not ClientAppValidationException
+            && !(ex is OperationCanceledException && ct.IsCancellationRequested))
+        {
+            // An HttpClient timeout arrives as TaskCanceledException with no cancellation
+            // requested; that is a lookup failure, not a caller cancel.
+            throw ClientAppValidationException.ApplicationLookupFailed(clientAppId, tenantId, ex.Message);
+        }
+
+        if (graphResponse is null || !graphResponse.IsSuccess)
+        {
+            // 403, 429, 5xx, network failure and token-acquisition failure all leave the app's
+            // existence unknown. Reporting them as "not found" sends users to re-create an app
+            // that is already there.
+            var status = graphResponse is null
+                ? "Microsoft Graph application lookup returned no result."
+                : graphResponse.StatusCode > 0
+                    ? $"Microsoft Graph application lookup failed: HTTP {graphResponse.StatusCode} {graphResponse.ReasonPhrase}".TrimEnd()
+                    : $"Microsoft Graph application lookup failed before a response was received: {graphResponse.ReasonPhrase}".TrimEnd();
+
+            _logger.LogDebug("Graph app query failed with {StatusCode} — reporting lookup failure", graphResponse?.StatusCode ?? 0);
+            throw ClientAppValidationException.ApplicationLookupFailed(
+                clientAppId, tenantId, status, graphResponse?.StatusCode ?? 0);
         }
 
         using var doc = graphResponse.Json;
-        if (doc == null) return null;
+        var apps = doc is null ? null : JsonNode.Parse(doc.RootElement.GetRawText()) as JsonObject;
+        if (apps?["value"] is not JsonArray values)
+        {
+            throw ClientAppValidationException.ApplicationLookupFailed(
+                clientAppId,
+                tenantId,
+                "Microsoft Graph returned an invalid application lookup response.",
+                graphResponse.StatusCode);
+        }
 
-        var response = JsonNode.Parse(doc.RootElement.GetRawText());
-        var apps = response?["value"]?.AsArray();
-        if (apps == null || apps.Count == 0) return null;
+        // Only a successful response with no match proves the app is absent.
+        if (values.Count == 0) return null;
 
-        var app = apps[0]!.AsObject();
-        return new ClientAppInfo(
-            app["id"]?.GetValue<string>() ?? string.Empty,
-            app["displayName"]?.GetValue<string>() ?? string.Empty,
-            app["requiredResourceAccess"]?.AsArray());
+        if (values[0] is not JsonObject app)
+        {
+            throw ClientAppValidationException.ApplicationLookupFailed(
+                clientAppId,
+                tenantId,
+                "Microsoft Graph returned an application result that is not an object.",
+                graphResponse.StatusCode);
+        }
+
+        if (app["id"] is not JsonValue idValue || !idValue.TryGetValue<string>(out var objectId) || string.IsNullOrWhiteSpace(objectId))
+        {
+            throw ClientAppValidationException.ApplicationLookupFailed(
+                clientAppId,
+                tenantId,
+                "Microsoft Graph returned an application result without a valid object ID.",
+                graphResponse.StatusCode);
+        }
+
+        var displayName = app["displayName"] is JsonValue nameValue && nameValue.TryGetValue<string>(out var name)
+            ? name
+            : string.Empty;
+
+        return new ClientAppInfo(objectId, displayName, app["requiredResourceAccess"] as JsonArray);
     }
 
     private async Task<List<string>> ValidatePermissionsConfiguredAsync(
@@ -1438,7 +1506,7 @@ public sealed class ClientAppValidator : IClientAppValidator
 
         try
         {
-            using var doc = await _graphApiService.GraphGetAsync(tenantId,
+            using var doc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{AuthenticationConstants.MicrosoftGraphResourceAppId}'&$select=id,oauth2PermissionScopes",
                 ct);
 
@@ -1498,7 +1566,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         try
         {
             // Get service principal for the app
-            using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
+            using var spDoc = await DirectoryGetAsync(tenantId,
                 $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id", ct);
 
             if (spDoc == null)
@@ -1529,8 +1597,8 @@ public sealed class ClientAppValidator : IClientAppValidator
             // are consented rather than reporting an empty set (which would trigger a false
             // "permissions not consented" prompt for non-admin developers who can never read
             // the grants table by design).
-            var grantsResp = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct: ct);
+            var grantsResp = await DirectoryGetWithResponseAsync(tenantId,
+                $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
             using var grantsDoc = grantsResp.Json;
 
             if (grantsResp.StatusCode == 403)
@@ -1586,7 +1654,7 @@ public sealed class ClientAppValidator : IClientAppValidator
         _logger.LogDebug("Checking admin consent status for {ClientAppId}", clientAppId);
 
         // Get service principal for the app
-        using var spDoc = await _graphApiService.GraphGetAsync(tenantId,
+        using var spDoc = await DirectoryGetAsync(tenantId,
             $"/v1.0/servicePrincipals?$filter=appId eq '{clientAppId}'&$select=id,appId", ct);
 
         if (spDoc == null)
@@ -1617,8 +1685,8 @@ public sealed class ClientAppValidator : IClientAppValidator
         // "caller lacks DelegatedPermissionGrant.Read.All" (403) from other failure modes
         // (token acquisition, network, 5xx) — the user-facing message differs and lumping them
         // together would either misattribute the cause or hide real failures.
-        var grantsResp = await _graphApiService.GraphGetWithResponseAsync(tenantId,
-            $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct: ct);
+        var grantsResp = await DirectoryGetWithResponseAsync(tenantId,
+            $"/v1.0/oauth2PermissionGrants?$filter=clientId eq '{spObjectId}'", ct);
         using var grantsDoc = grantsResp.Json;
 
         if (grantsResp.StatusCode == 403)

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphApiService.cs
@@ -363,9 +363,9 @@ public class GraphApiService
     /// Executes a GET request to Microsoft Graph API.
     /// Virtual to allow mocking in unit tests using Moq.
     /// </summary>
-    public virtual async Task<JsonDocument?> GraphGetAsync(string tenantId, string relativePath, CancellationToken ct = default, IEnumerable<string>? scopes = null)
+    public virtual async Task<JsonDocument?> GraphGetAsync(string tenantId, string relativePath, CancellationToken ct = default, IEnumerable<string>? scopes = null, GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.ResolvedClientApp)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct)) return null;
+        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct, authenticationMode: authenticationMode)) return null;
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
         try
         {
@@ -553,9 +553,9 @@ public class GraphApiService
     /// Executes a PATCH request to Microsoft Graph API.
     /// Virtual to allow mocking in unit tests using Moq.
     /// </summary>
-    public virtual async Task<bool> GraphPatchAsync(string tenantId, string relativePath, object payload, CancellationToken ct = default, IEnumerable<string>? scopes = null)
+    public virtual async Task<bool> GraphPatchAsync(string tenantId, string relativePath, object payload, CancellationToken ct = default, IEnumerable<string>? scopes = null, GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.ResolvedClientApp)
     {
-        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct)) return false;
+        if (!await EnsureGraphHeadersAsync(tenantId, scopes: scopes, ct: ct, authenticationMode: authenticationMode)) return false;
         var url = GraphApiConstants.BuildUrl(_graphBaseUrl, relativePath);
         var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
         try

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/GraphAuthenticationMode.cs
@@ -16,8 +16,10 @@ public enum GraphAuthenticationMode
 
     /// <summary>
     /// Force the ambient bootstrap identity, ignoring the resolved client app and any requested
-    /// scopes. Required when probing whether a client app exists: authenticating as the app being
-    /// probed makes its own absence unverifiable.
+    /// scopes. Required whenever the operation reads or repairs tenant directory objects for the
+    /// client app: a token issued for that app carries only its own default scope, so Graph
+    /// refuses application and servicePrincipal queries. Note that requested scopes are silently
+    /// discarded on this path, so callers needing a specific scope must not use it.
     /// </summary>
     Ambient = 1
 }

--- a/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
+++ b/src/Microsoft.Agents.A365.DevTools.Cli/Services/Requirements/RequirementChecks/ClientAppRequirementCheck.cs
@@ -82,7 +82,7 @@ public class ClientAppRequirementCheck : RequirementCheck
             return RequirementCheckResult.Failure(
                 errorMessage: string.Join("\n", errorLines),
                 resolutionGuidance: string.Join("\n", ex.MitigationSteps),
-                details: $"Client app validation failed for {config.ClientAppId}. Please ensure the app exists and has the required configuration."
+                details: $"Client app validation failed for {config.ClientAppId}."
             );
         }
         catch (OperationCanceledException)

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/AgentBlueprintServiceTests.cs
@@ -798,7 +798,8 @@ public class AgentBlueprintServiceTests
             string relativePath,
             object payload,
             CancellationToken ct = default,
-            IEnumerable<string>? scopes = null)
+            IEnumerable<string>? scopes = null,
+            GraphAuthenticationMode authenticationMode = GraphAuthenticationMode.ResolvedClientApp)
             => Task.FromException<bool>(new HttpRequestException("Network error during PATCH"));
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorAmbientIdentityTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorAmbientIdentityTests.cs
@@ -1,0 +1,149 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using FluentAssertions;
+using Microsoft.Agents.A365.DevTools.Cli.Constants;
+using Microsoft.Agents.A365.DevTools.Cli.Services;
+using Microsoft.Agents.A365.DevTools.Cli.Services.Helpers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using System.Net;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Agents.A365.DevTools.Cli.Tests.Services;
+
+/// <summary>
+/// End-to-end guard for issue #489: once the bootstrap resolves a tenant-owned client app,
+/// every directory read and repair in client app validation must run as the ambient operator
+/// identity. A token issued for the app under validation carries only User.Read, so Microsoft
+/// Graph answers 403 Authorization_RequestDenied to application and servicePrincipal queries.
+/// </summary>
+public class ClientAppValidatorAmbientIdentityTests
+{
+    private const string CustomAppId = "11111111-2222-3333-4444-555555555555";
+    private const string TenantId = "12345678-1234-1234-1234-123456789012";
+    private const string AmbientToken = "ambient-identity-token";
+    private const string CustomAppToken = "custom-app-user-read-token";
+
+    /// <summary>
+    /// Ambient identity can read the directory, while a token minted for the custom client app
+    /// is refused by Graph.
+    /// </summary>
+    private sealed class DualIdentityGraphHandler : HttpMessageHandler
+    {
+        public List<string> RequestsAsCustomApp { get; } = new();
+        public List<string> RequestsAsAmbient { get; } = new();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var url = request.RequestUri!.ToString();
+            var descriptor = $"{request.Method} {request.RequestUri!.AbsolutePath}";
+
+            if (request.Headers.Authorization?.Parameter == CustomAppToken)
+            {
+                RequestsAsCustomApp.Add(descriptor);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.Forbidden)
+                {
+                    Content = new StringContent(
+                        """{"error":{"code":"Authorization_RequestDenied","message":"Insufficient privileges to complete the operation."}}""",
+                        Encoding.UTF8, "application/json")
+                });
+            }
+
+            RequestsAsAmbient.Add(descriptor);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(BuildBody(url), Encoding.UTF8, "application/json")
+            });
+        }
+
+        private static string BuildBody(string url)
+        {
+            if (url.Contains("oauth2PermissionScopes", StringComparison.OrdinalIgnoreCase))
+            {
+                var scopes = string.Join(",", AuthenticationConstants.RequiredClientAppPermissions
+                    .Select((p, i) => $$"""{"id":"{{PermissionId(i)}}","value":"{{p}}"}"""));
+                return $$"""{"value":[{"id":"graph-sp","oauth2PermissionScopes":[{{scopes}}]}]}""";
+            }
+
+            if (url.Contains("/applications", StringComparison.OrdinalIgnoreCase))
+            {
+                var resourceAccess = string.Join(",", AuthenticationConstants.RequiredClientAppPermissions
+                    .Select((_, i) => $$"""{"id":"{{PermissionId(i)}}","type":"Scope"}"""));
+                var redirectUris = string.Join(",", AuthenticationConstants
+                    .GetRequiredRedirectUris(CustomAppId).Select(u => $"\"{u}\""));
+                return $$"""
+                {"value":[{
+                  "id":"app-object-id",
+                  "appId":"{{CustomAppId}}",
+                  "displayName":"Agent 365 CLI",
+                  "isFallbackPublicClient":true,
+                  "publicClient":{"redirectUris":[{{redirectUris}}]},
+                  "optionalClaims":{"accessToken":[{"name":"wids"}]},
+                  "requiredResourceAccess":[{"resourceAppId":"{{AuthenticationConstants.MicrosoftGraphResourceAppId}}","resourceAccess":[{{resourceAccess}}]}]
+                }]}
+                """;
+            }
+
+            return """{"value":[]}""";
+        }
+
+        private static string PermissionId(int index) => $"aaaa{index:0000}-0000-0000-0000-000000000000";
+    }
+
+    private static GraphApiService CreateGraphService(DualIdentityGraphHandler handler)
+    {
+        var authService = Substitute.For<IAuthenticationService>();
+        authService.GetAccessTokenAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<bool>(),
+                Arg.Any<string?>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>(), Arg.Any<string?>())
+            .Returns(Task.FromResult(AmbientToken));
+
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(Task.FromResult<string?>(CustomAppToken));
+
+        return new GraphApiService(
+            NullLogger<GraphApiService>.Instance,
+            Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>()),
+            authService, handler, tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null),
+            retryHelper: new RetryHelper(NullLogger.Instance, maxRetries: 1, baseDelaySeconds: 0))
+        {
+            // Exactly what RequirementsSubcommand does once the bootstrap resolves the app.
+            CustomClientAppId = CustomAppId
+        };
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenCustomAppTokenIsRefusedByGraph_StillCompletesValidation()
+    {
+        using var handler = new DualIdentityGraphHandler();
+        var validator = new ClientAppValidator(NullLogger<ClientAppValidator>.Instance, CreateGraphService(handler));
+
+        var act = async () => await validator.EnsureValidClientAppAsync(
+            CustomAppId, TenantId, skipConfirmation: true);
+
+        await act.Should().NotThrowAsync(
+            because: "the app exists and is fully configured, so a 403 on the custom-app token must not fail setup");
+        handler.RequestsAsCustomApp.Should().BeEmpty(
+            because: "no directory read or repair may authenticate as the app under validation — that token only carries User.Read");
+        handler.RequestsAsAmbient.Should().NotBeEmpty(
+            because: "the validation flow must reach Graph using the operator's ambient identity");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenAppIsFullyConfigured_MakesNoRepairWrites()
+    {
+        using var handler = new DualIdentityGraphHandler();
+        var validator = new ClientAppValidator(NullLogger<ClientAppValidator>.Instance, CreateGraphService(handler));
+
+        await validator.EnsureValidClientAppAsync(CustomAppId, TenantId, skipConfirmation: true);
+
+        handler.RequestsAsAmbient.Should().NotContain(r => r.StartsWith("PATCH", StringComparison.Ordinal),
+            because: "an app that already carries every required permission, redirect URI, the public-client flag and the wids claim needs no repair write");
+    }
+}

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/ClientAppValidatorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Agents.A365.DevTools.Cli.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using System.Globalization;
 using System.Text.Json;
 using Xunit;
 
@@ -45,6 +46,13 @@ public class ClientAppValidatorTests
     // Separate SP object ID used only by the consent-grant path (GetConsentedPermissionsAsync)
     // so it does not conflict with SetupAdminConsentSp / SetupAdminConsentGrantsEmpty.
     private const string ConsentSpObjId = "consent-check-sp-id-999";
+
+    // Pinning the exact issue descriptions keeps "inconclusive lookup" and "confirmed absent"
+    // distinguishable: asserting only the absence of "not found" is satisfied by every other
+    // failure factory in ClientAppValidationException.
+    private const string AppNotFoundIssue = "Client app not found in tenant";
+    private const string LookupFailedIssue = "Unable to verify the client app registration in the tenant";
+    private const string TokenRevokedIssue = "Azure authentication token revoked — re-authentication required";
 
     public ClientAppValidatorTests()
     {
@@ -122,8 +130,11 @@ public class ClientAppValidatorTests
     {
         SetupAppInfoGetEmpty();
 
-        await Assert.ThrowsAsync<ClientAppValidationException>(async () =>
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(async () =>
             await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(AppNotFoundIssue,
+            because: "a successful Graph response with an empty result set is the only proof that the app is absent");
     }
 
     [Fact]
@@ -131,26 +142,300 @@ public class ClientAppValidatorTests
     {
         // Simulate a 401 on both the first attempt and the retry after cache invalidation.
         // TokenRevoked is only thrown when the failure is specifically a 401 (auth error),
-        // not for transient failures like 503 — which would produce AppNotFound instead.
-        _graphApiService.GraphGetWithResponseAsync(
-            Arg.Any<string>(),
-            Arg.Is<string>(p => p.Contains("displayName")),
-            Arg.Any<bool>(),
-            Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
-            {
-                IsSuccess = false,
-                StatusCode = 401,
-                ReasonPhrase = "Unauthorized"
-            }));
+        // not for transient failures like 503 — which report an inconclusive lookup instead.
+        SetupAppInfoGetFailure(401, "Unauthorized");
 
         var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
             () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
 
         exception.ErrorCode.Should().Be(ErrorCodes.ClientAppValidationFailed);
-        exception.IssueDescription.Should().Contain("revoked",
+        exception.IssueDescription.Should().Be(TokenRevokedIssue,
             because: "a persistent 401 from Graph indicates a CAE token revocation, not a transient error");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupIsForbidden_DoesNotReportAppNotFound()
+    {
+        // Regression (#489): reading application metadata requires Application.Read.All. A 403
+        // leaves the app's existence unknown; reporting "not found" sends operators to re-create
+        // an app registration that is already present in the tenant.
+        SetupAppInfoGetFailure(403, "Forbidden");
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "HTTP 403 is an authorization failure and must be reported as an inconclusive lookup, never as proof the app is absent");
+        exception.ErrorDetails.Should().Contain(d => d.Contains("403", StringComparison.Ordinal),
+            because: "the HTTP status must be preserved so operators can identify the authorization failure");
+        exception.MitigationSteps.Should().Contain(s => s.Contains(AuthenticationConstants.ApplicationReadAllScope, StringComparison.Ordinal),
+            because: "reading application metadata requires the Application.Read.All Microsoft Graph permission");
+        exception.MitigationSteps.Should().NotContain(s => s.Contains("from scratch", StringComparison.OrdinalIgnoreCase),
+            because: "the app-not-found remediation re-creates the app registration and must never be offered on an unproven absence");
+        exception.Context.Should().Contain(new KeyValuePair<string, string>("statusCode", "403"),
+            because: "the status must be machine-readable in the exception context, not only embedded in prose");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenForbiddenAfter401Retry_DoesNotReportTokenRevoked()
+    {
+        // Regression (#489): a stale ambient token yields 401, and the refreshed retry then hits
+        // the real 403. Reporting revocation sends operators to 'az login', which cannot fix a
+        // missing Application.Read.All grant.
+        var attempts = 0;
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns(_ => Task.FromResult(Interlocked.Increment(ref attempts) == 1
+                ? new GraphApiService.GraphResponse { IsSuccess = false, StatusCode = 401, ReasonPhrase = "Unauthorized" }
+                : new GraphApiService.GraphResponse { IsSuccess = false, StatusCode = 403, ReasonPhrase = "Forbidden" }));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "only a second 401 proves token revocation; the retry's own status must be reported instead");
+        exception.ErrorDetails.Should().Contain(d => d.Contains("403", StringComparison.Ordinal),
+            because: "the status returned by the refreshed attempt is the actionable one and must survive into the error");
+    }
+
+    [Theory]
+    [InlineData(429, "Too Many Requests")]
+    [InlineData(500, "Internal Server Error")]
+    [InlineData(503, "Service Unavailable")]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupCannotComplete_PreservesStatusAndDoesNotReportAppNotFound(
+        int statusCode, string reasonPhrase)
+    {
+        SetupAppInfoGetFailure(statusCode, reasonPhrase);
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "throttling and server errors leave the app's existence unknown");
+        exception.ErrorDetails.Should().Contain(d => d.Contains(statusCode.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal),
+            because: "the HTTP status must survive into the error so operators can distinguish throttling from a server fault");
+        exception.MitigationSteps.Should().NotContain(s => s.Contains(AuthenticationConstants.ApplicationReadAllScope, StringComparison.Ordinal),
+            because: "only HTTP 403 indicates a permission gap; suggesting an admin grant for a transient failure misdirects the operator");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenTokenAcquisitionFailsBeforeResponse_SurfacesTheUnderlyingReason()
+    {
+        // The shape GraphGetWithResponseAsync returns when no HTTP response was ever received.
+        SetupAppInfoGetFailure(0, "NoAuth");
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "a failure before any response leaves the app's existence unknown");
+        exception.ErrorDetails.Should().Contain(d => d.Contains("NoAuth", StringComparison.Ordinal),
+            because: "with no HTTP status available the reason phrase is the only diagnostic, so it must be preserved");
+    }
+
+    [Theory]
+    [InlineData("""{"unexpected": true}""", "a response without a 'value' array does not prove the application is absent")]
+    [InlineData("""{"value": {}}""", "a non-array 'value' is a malformed response, not a confirmed absence")]
+    [InlineData("""{"value": ["app"]}""", "a non-object array element is a malformed response, not a confirmed absence")]
+    [InlineData("""{"value": [{"displayName": "Test App"}]}""", "an application result without an object ID is unusable, not a confirmed absence")]
+    [InlineData("""{"value": [{"id": 42}]}""", "a non-string object ID is a malformed response, not a confirmed absence")]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupResponseIsMalformed_DoesNotReportAppNotFound(
+        string body, string reason)
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDocument.Parse(body)
+            }));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue, because: reason);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenCustomClientAppIdIsResolved_LooksUpApplicationAmbiently()
+    {
+        // Regression (#489): after the bootstrap resolves a tenant-owned client app,
+        // GraphApiService.CustomClientAppId is set. Authenticating the existence probe as that
+        // app yields a User.Read token that Graph rejects with 403 on /applications.
+        _graphApiService.CustomClientAppId = ValidClientAppId;
+        SetupAppInfoWithAllPermissions(ValidClientAppId);
+        SetupPermissionResolution();
+
+        await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId);
+
+        await _graphApiService.Received().GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("/v1.0/applications")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupReturns401_RetriesAmbientlyWithFreshToken()
+    {
+        _graphApiService.CustomClientAppId = ValidClientAppId;
+        SetupAppInfoGetFailure(401, "Unauthorized");
+
+        await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        await _graphApiService.Received(1).GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("/v1.0/applications")),
+            true,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupSucceedsAfter401Retry_CompletesValidation()
+    {
+        SetupAppInfoWithAllPermissions(ValidClientAppId);
+        SetupPermissionResolution();
+
+        var appJson = BuildAppInfoJson(ValidClientAppId, BuildAllPermissionsResourceAccess());
+        var attempts = 0;
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns(_ => Task.FromResult(Interlocked.Increment(ref attempts) == 1
+                ? new GraphApiService.GraphResponse { IsSuccess = false, StatusCode = 401, ReasonPhrase = "Unauthorized" }
+                : new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = JsonDocument.Parse(appJson) }));
+
+        await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId);
+
+        await _graphApiService.Received(1).GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("/v1.0/applications")),
+            true,
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            GraphAuthenticationMode.Ambient);
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupThrows_ReportsLookupFailureNotAppNotFound()
+    {
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns<GraphApiService.GraphResponse>(_ => throw new HttpRequestException("connection reset"));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "a network failure leaves the app's existence unknown");
+        exception.ErrorDetails.Should().Contain(d => d.Contains("connection reset", StringComparison.Ordinal),
+            because: "the underlying transport failure must be surfaced so the operator can act on it");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenApplicationLookupTimesOut_ReportsLookupFailureNotCancellation()
+    {
+        // HttpClient surfaces its own timeout as TaskCanceledException with no cancellation
+        // requested; treating it as a cancel would abort the command instead of reporting a
+        // recoverable lookup failure.
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns<GraphApiService.GraphResponse>(_ =>
+                throw new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout"));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "a transport timeout is a lookup failure, not a caller cancellation or a confirmed absence");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenPostProvisioningRefetchFails_ReportsLookupFailureNotMissingPermissions()
+    {
+        // The confirming re-read after permission provisioning uses the same lookup. A throttled
+        // re-read must not be reported as a permission gap the operator has to fix by hand.
+        SetupAppInfoGet(ValidClientAppId, requiredResourceAccess: "[]");
+        SetupPermissionResolution();
+
+        var appJson = BuildAppInfoJson(ValidClientAppId, "[]");
+        var attempts = 0;
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns(_ => Task.FromResult(Interlocked.Increment(ref attempts) == 1
+                ? new GraphApiService.GraphResponse { IsSuccess = true, StatusCode = 200, Json = JsonDocument.Parse(appJson) }
+                : new GraphApiService.GraphResponse { IsSuccess = false, StatusCode = 429, ReasonPhrase = "Too Many Requests" }));
+
+        // Permission provisioning succeeds so the flow reaches the confirming re-read.
+        _graphApiService.GraphPatchAsync(
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
+            .Returns(Task.FromResult(true));
+
+        var exception = await Assert.ThrowsAsync<ClientAppValidationException>(
+            () => _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId, skipConfirmation: true));
+
+        exception.IssueDescription.Should().Be(LookupFailedIssue,
+            because: "a throttled confirmation read leaves the provisioning outcome unknown and must not be reported as missing permissions");
+    }
+
+    [Fact]
+    public async Task EnsureValidClientAppAsync_WhenCallerCancelsDuringApplicationLookup_PropagatesCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns<GraphApiService.GraphResponse>(_ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        Func<Task> act = async () => await _validator.EnsureValidClientAppAsync(
+            ValidClientAppId, ValidTenantId, ct: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            because: "Ctrl+C must abort the command rather than being reported as a client app validation failure");
     }
 
     #endregion
@@ -389,12 +674,12 @@ public class ClientAppValidatorTests
 
         // No app-registration mutation of any kind must be attempted on a first-party application.
         await _graphApiService.DidNotReceive().GraphPatchAsync(
-            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
         await _graphApiService.DidNotReceive().GraphPostAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<bool>());
         // A tenant-local oauth2PermissionGrant must not be required when the token itself proves authorization.
         await _graphApiService.DidNotReceive().GraphGetAsync(
-            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("oauth2PermissionGrants")), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("oauth2PermissionGrants")), Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -589,7 +874,7 @@ public class ClientAppValidatorTests
         await _validator.EnsureValidClientAppAsync(ValidClientAppId, ValidTenantId);
 
         await _graphApiService.Received().GraphGetWithResponseAsync(
-            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("displayName")), Arg.Any<bool>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Is<string>(p => p.Contains("displayName")), Arg.Any<bool>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<CancellationToken>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     #endregion
@@ -750,7 +1035,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Any<object>(),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>());
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -761,7 +1046,7 @@ public class ClientAppValidatorTests
         SetupPublicClientFlowsGet(enabled: false);
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
         // Redirect URIs GET returns null (unmatched) → no separate PATCH
 
@@ -773,7 +1058,7 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains(AppObjId)),
             Arg.Any<object>(),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>());
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -830,7 +1115,8 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains("displayName")),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
                 IsSuccess = true,
@@ -856,7 +1142,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("oauth2PermissionScopes")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(permJson)));
 
         return new ClientAppValidator(_logger, graphApiService, confirmationProvider);
@@ -890,7 +1176,8 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains("displayName")),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
                 IsSuccess = true, StatusCode = 200, Json = JsonDocument.Parse(appJson)
@@ -911,7 +1198,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("oauth2PermissionScopes")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(permJson)));
 
         graphApiService.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -928,7 +1215,7 @@ public class ClientAppValidatorTests
         // Confirm no Graph mutations were attempted after the decline
         await graphApiService.DidNotReceive().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -957,7 +1244,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("publicClient") && !p.Contains("displayName")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(redirectUriJson)));
 
         // Build a fresh validator wired to _graphApiService so the redirect URI mock is reachable
@@ -975,7 +1262,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.DidNotReceive().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1000,7 +1287,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.DidNotReceive().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1026,7 +1313,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("publicClient") && !p.Contains("displayName")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(redirectUriJson)));
 
         _graphApiService.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -1054,7 +1341,7 @@ public class ClientAppValidatorTests
         SetupPublicClientFlowsGet(enabled: false);
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
         _graphApiService.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult(Cli.Models.RoleCheckResult.HasRole));
@@ -1069,7 +1356,7 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains(AppObjId)),
             Arg.Any<object>(),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>());
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     // ── Unknown-role probe tests ────────────────────────────────────────────────
@@ -1099,7 +1386,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("optionalClaims")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(
                 _ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(noWidsJson)),    // pre-flight read
                 _ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(noWidsJson)),    // inside EnsureWids read
@@ -1107,7 +1394,7 @@ public class ClientAppValidatorTests
 
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
 
         // First call returns Unknown to exercise the probe path; subsequent calls (if any)
@@ -1133,7 +1420,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.Received().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
 
         // Cache must be invalidated after the successful wids PATCH (per D1) so subsequent
         // token acquisitions pick up the new claim.
@@ -1154,12 +1441,12 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("optionalClaims")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(noWidsJson)));
 
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(false));  // PATCH returns false — wids does not land
 
         _graphApiService.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -1252,7 +1539,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("optionalClaims")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(noWidsJson)));
 
         // PATCH succeeds (so the probe's success-path LogInformation is reached and our injected
@@ -1261,7 +1548,7 @@ public class ClientAppValidatorTests
         // is what forces Inconclusive, not the PATCH outcome.
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
 
         _graphApiService.IsCurrentUserAdminAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
@@ -1308,7 +1595,7 @@ public class ClientAppValidatorTests
         SetupPublicClientFlowsGet(enabled: false);
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
 
         var confirmationProvider = Substitute.For<IConfirmationProvider>();
@@ -1322,7 +1609,7 @@ public class ClientAppValidatorTests
         // But fix must still be applied
         await _graphApiService.Received(1).GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     #endregion
@@ -1349,7 +1636,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.DidNotReceive().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1368,7 +1655,7 @@ public class ClientAppValidatorTests
         SetupRedirectUrisGet(appResponseJson);
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
 
         await _validator.EnsureRedirectUrisAsync(ValidClientAppId, ValidTenantId);
@@ -1378,7 +1665,7 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains(AppObjId)),
             Arg.Any<object>(),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>());
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1397,14 +1684,14 @@ public class ClientAppValidatorTests
         SetupRedirectUrisGet(appResponseJson);
         _graphApiService.GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>())
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(Task.FromResult(true));
 
         await _validator.EnsureRedirectUrisAsync(ValidClientAppId, ValidTenantId);
 
         await _graphApiService.Received(1).GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1416,7 +1703,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.DidNotReceive().GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     [Fact]
@@ -1439,7 +1726,7 @@ public class ClientAppValidatorTests
 
         await _graphApiService.Received(1).GraphPatchAsync(
             Arg.Any<string>(), Arg.Any<string>(), Arg.Any<object>(),
-            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>());
+            Arg.Any<CancellationToken>(), Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>());
     }
 
     #endregion
@@ -1452,7 +1739,26 @@ public class ClientAppValidatorTests
     /// </summary>
     private void SetupAppInfoGet(string appId, string requiredResourceAccess = "[]")
     {
-        var json = $$"""
+        var json = BuildAppInfoJson(appId, requiredResourceAccess);
+
+        // GetClientAppInfoAsync now calls GraphGetWithResponseAsync; GraphGetAsync is used by
+        // subsequent steps (permission resolution, consent checks, redirect URIs, etc.).
+        _graphApiService.GraphGetWithResponseAsync(
+            Arg.Any<string>(),
+            Arg.Is<string>(p => p.Contains("displayName")),
+            Arg.Any<bool>(),
+            Arg.Any<IEnumerable<string>?>(),
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
+            .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
+            {
+                IsSuccess = true,
+                StatusCode = 200,
+                Json = JsonDocument.Parse(json)
+            }));
+    }
+
+    private static string BuildAppInfoJson(string appId, string requiredResourceAccess) => $$"""
         {
             "value": [
                 {
@@ -1465,19 +1771,24 @@ public class ClientAppValidatorTests
         }
         """;
 
-        // GetClientAppInfoAsync now calls GraphGetWithResponseAsync; GraphGetAsync is used by
-        // subsequent steps (permission resolution, consent checks, redirect URIs, etc.).
+    /// <summary>
+    /// Sets up the app info GET to fail with the given HTTP status. Status 0 models a
+    /// token-acquisition or network failure where no response was received.
+    /// </summary>
+    private void SetupAppInfoGetFailure(int statusCode, string reasonPhrase)
+    {
         _graphApiService.GraphGetWithResponseAsync(
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("displayName")),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
-                IsSuccess = true,
-                StatusCode = 200,
-                Json = JsonDocument.Parse(json)
+                IsSuccess = false,
+                StatusCode = statusCode,
+                ReasonPhrase = reasonPhrase
             }));
     }
 
@@ -1491,7 +1802,8 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains("displayName")),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
                 IsSuccess = true,
@@ -1500,14 +1812,7 @@ public class ClientAppValidatorTests
             }));
     }
 
-    /// <summary>
-    /// Sets up the app info GET with all required permissions. The 5 GUID-resolvable permissions
-    /// match those returned by SetupPermissionResolution; AgentIdentity.Read.All and
-    /// AgentIdentity.DeleteRestore.All are resolved via the GetConsentedPermissionsAsync fallback.
-    /// </summary>
-    private void SetupAppInfoWithAllPermissions(string appId)
-    {
-        var requiredResourceAccess = $$"""
+    private static string BuildAllPermissionsResourceAccess() => $$"""
         [
             {
                 "resourceAppId": "{{AuthenticationConstants.MicrosoftGraphResourceAppId}}",
@@ -1522,7 +1827,14 @@ public class ClientAppValidatorTests
         ]
         """;
 
-        SetupAppInfoGet(appId, requiredResourceAccess: requiredResourceAccess);
+    /// <summary>
+    /// Sets up the app info GET with all required permissions. The 5 GUID-resolvable permissions
+    /// match those returned by SetupPermissionResolution; AgentIdentity.Read.All and
+    /// AgentIdentity.DeleteRestore.All are resolved via the GetConsentedPermissionsAsync fallback.
+    /// </summary>
+    private void SetupAppInfoWithAllPermissions(string appId)
+    {
+        SetupAppInfoGet(appId, requiredResourceAccess: BuildAllPermissionsResourceAccess());
         SetupConsentGrantForAgentIdentityCreate();
     }
 
@@ -1553,7 +1865,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("oauth2PermissionScopes")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(json)));
     }
 
@@ -1572,7 +1884,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("servicePrincipals") && p.EndsWith("&$select=id")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(spJson)));
 
         // Grants for ConsentSpObjId — contains all four no-GUID scopes so they are removed from missingPermissions.
@@ -1581,7 +1893,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("oauth2PermissionGrants") && p.Contains(ConsentSpObjId)),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(grantsJson)));
         // Also mock GraphGetWithResponseAsync for the same grants endpoint — production code now
         // uses this method to detect 403 (caller lacks DelegatedPermissionGrant.Read.All) without
@@ -1592,7 +1904,8 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains("oauth2PermissionGrants") && p.Contains(ConsentSpObjId)),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
                 IsSuccess = true,
@@ -1621,7 +1934,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("servicePrincipals") && p.Contains("id,appId")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(json)));
     }
 
@@ -1634,7 +1947,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("oauth2PermissionGrants") && p.Contains(spObjectId)),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse("""{"value": []}""")));
         // Mirror for GraphGetWithResponseAsync (used by GetConsentedPermissionsAsync to detect 403).
         _graphApiService.GraphGetWithResponseAsync(
@@ -1642,7 +1955,8 @@ public class ClientAppValidatorTests
             Arg.Is<string>(p => p.Contains("oauth2PermissionGrants") && p.Contains(spObjectId)),
             Arg.Any<bool>(),
             Arg.Any<IEnumerable<string>?>(),
-            Arg.Any<CancellationToken>())
+            Arg.Any<CancellationToken>(),
+            Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult(new GraphApiService.GraphResponse
             {
                 IsSuccess = true,
@@ -1660,7 +1974,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("publicClient") && !p.Contains("displayName")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(appResponseJson)));
     }
 
@@ -1682,7 +1996,7 @@ public class ClientAppValidatorTests
             Arg.Any<string>(),
             Arg.Is<string>(p => p.Contains("isFallbackPublicClient")),
             Arg.Any<CancellationToken>(),
-            Arg.Any<IEnumerable<string>?>())
+            Arg.Any<IEnumerable<string>?>(), Arg.Any<GraphAuthenticationMode>())
             .Returns(_ => Task.FromResult<JsonDocument?>(JsonDocument.Parse(json)));
     }
 

--- a/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
+++ b/src/Tests/Microsoft.Agents.A365.DevTools.Cli.Tests/Services/GraphApiServiceTests.cs
@@ -540,6 +540,63 @@ public class GraphApiServiceTests
     }
 
     [Fact]
+    public async Task GraphGetWithResponseAsync_AmbientMode_DoesNotRequestATokenForTheResolvedClientApp()
+    {
+        // Issue #489: a token issued for the app being probed cannot prove that app's own
+        // absence, and it carries only User.Read — Graph rejects /applications with 403.
+        using var handler = new TestHttpMessageHandler();
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(Task.FromResult<string?>("custom-app-token"));
+        var service = new GraphApiService(
+            Substitute.For<ILogger<GraphApiService>>(),
+            Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>()),
+            FakeAuth(), handler, tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null))
+        {
+            CustomClientAppId = "11111111-1111-1111-1111-111111111111"
+        };
+
+        await service.GraphGetWithResponseAsync(
+            "tenant-123", "/v1.0/applications", ct: default,
+            authenticationMode: GraphAuthenticationMode.Ambient);
+
+        await tokenProvider.DidNotReceive().GetMgGraphAccessTokenAsync(
+            Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(),
+            Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<string?>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task GraphGetWithResponseAsync_ResolvedClientAppMode_RequestsATokenForTheResolvedClientApp()
+    {
+        // Counter-test to the ambient case: without it, a regression that stops using the token
+        // provider entirely would still satisfy the DidNotReceive assertion above.
+        const string customAppId = "11111111-1111-1111-1111-111111111111";
+        using var handler = new TestHttpMessageHandler();
+        var tokenProvider = Substitute.For<IMicrosoftGraphTokenProvider>();
+        tokenProvider.GetMgGraphAccessTokenAsync(
+                Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(),
+                Arg.Any<string?>(), Arg.Any<CancellationToken>(), Arg.Any<string?>(), Arg.Any<bool>())
+            .Returns(Task.FromResult<string?>("custom-app-token"));
+        var service = new GraphApiService(
+            Substitute.For<ILogger<GraphApiService>>(),
+            Substitute.For<CommandExecutor>(Substitute.For<ILogger<CommandExecutor>>()),
+            FakeAuth(), handler, tokenProvider,
+            loginHintResolver: () => Task.FromResult<string?>(null))
+        {
+            CustomClientAppId = customAppId
+        };
+
+        await service.GraphGetWithResponseAsync("tenant-123", "/v1.0/applications");
+
+        await tokenProvider.Received().GetMgGraphAccessTokenAsync(
+            Arg.Any<string>(), Arg.Any<IEnumerable<string>>(), Arg.Any<bool>(),
+            customAppId, Arg.Any<CancellationToken>(), Arg.Any<string?>(), Arg.Any<bool>());
+    }
+
+    [Fact]
     public async Task GraphGetWithResponseAsync_WhenHttpClientTimesOut_ReturnsFailureInsteadOfThrowing()
     {
         // HttpClient surfaces its own timeout as TaskCanceledException with no cancellation


### PR DESCRIPTION
## Problem

When `setup requirements` falls back to a tenant-owned custom client app, the resolved app ID is set on `GraphApiService.CustomClientAppId`. From that point on, **every** Microsoft Graph call in client app validation authenticated *as the app being validated*, and `EnsureGraphHeadersAsync` defaults that token request to `User.Read`.

Reading application and servicePrincipal metadata requires `Application.Read.All`, so Graph answered `403 Authorization_RequestDenied` to all of them. Two distinct failures followed:

1. **The existence probe** returned `null` on the 403, and the caller translated that into `AppNotFound` — telling operators their client app did not exist and directing them to re-create an app registration that was already present.
2. **Every subsequent read** also returned 403. Permission resolution produced an empty map, so all seven required permissions were reported missing, the read-only pre-flight checks failed closed, and a repair `PATCH` was attempted and refused.

This reproduces in any tenant where the Agent 365 CLI application is not provisioned, so setup falls back to a tenant-owned app. The app is demonstrably present in that situation — the ambient bootstrap lookup already found it by display name on the same `/v1.0/applications` endpoint, and MSAL had acquired a token as that client.

## Fix

**Existence probe** (`GetClientAppInfoAsync`):

- The probe and its 401 force-refresh retry use `GraphAuthenticationMode.Ambient`. A token issued for the app under validation cannot prove that app's own absence, and requesting `Application.Read.All` from it would be circular when the app is missing or has not consented that scope.
- `null` is reserved exclusively for a **successful** response with an empty `value` array — the only outcome that proves absence.
- 403, 429, 5xx, status 0 / `NoAuth`, transport failures and malformed responses throw `ClientAppValidationException.ApplicationLookupFailed`, preserving the HTTP status and reason. A 403 can never be reported as `AppNotFound`.
- `TokenRevoked` is raised only when the **refreshed** attempt is itself a 401.
- Caller cancellation propagates; an `HttpClient` timeout is a lookup failure, not a Ctrl+C.

**The rest of the validation flow:** the 23 remaining tenant-directory reads and repairs (15 GETs, 6 PATCHes, 2 status-bearing GETs) now route through three small ambient helpers, so the whole flow runs as the ambient operator identity — the same identity that already resolves the app by display name. `GraphGetAsync` and `GraphPatchAsync` gained an `authenticationMode` parameter defaulting to the existing `ResolvedClientApp`, so no other caller changes behavior.

The `wids` / `scp` token-inspection paths deliberately keep using the custom-app token, since they exist to read claims that only that app's registration carries.

`ClientAppRequirementCheck` no longer appends "ensure the app exists" to every validation failure, which contradicted the new guidance.

## Not changed

Untouched: `LookupServicePrincipalByAppIdWithResponseAsync`, `EnsureValidFirstPartyClientAppAsync`, `GraphAuthenticationMode` defaults, first-party token scope validation, service-principal creation, fallback SP propagation, and `RequirementsSubcommand` (which still sets the resolved client app ID for later operations).

## Testing

Full CLI test project: **2034 passed, 12 skipped, 0 failed** (2046 total, up from 2035). Release build: 0 warnings, 0 errors.

`ClientAppValidatorAmbientIdentityTests` exercises the failing scenario end to end with a dual-identity HTTP handler: the ambient token receives 200, a custom-app token receives 403 `Authorization_RequestDenied`. Against the pre-fix code the flow issued 1 ambient call and 8 forbidden ones and failed with "missing required API permissions"; it now issues 9 ambient calls, 0 forbidden, and validation succeeds. Both tests were verified to fail against the unfixed code with a clean rebuild.

Unit coverage added for the probe: ambient lookup when `CustomClientAppId` is set; 403 reported as an authorization failure with the status preserved and never as `AppNotFound`; 401 then 403 on retry reported as a lookup failure rather than revocation; 200-with-empty-result as the only path to `AppNotFound`; 429 and 5xx preserving status without offering the `Application.Read.All` step; status 0 preserving the reason phrase; five malformed-response shapes; ambient 401 force-refresh retry; transport failure and timeout; caller cancellation. Plus `GraphApiService` tests pinning that `Ambient` does not request a token for `CustomClientAppId`, paired with a `ResolvedClientApp` counter-test that it does.
